### PR TITLE
Fix typos in JSDoc and docs for Mqtt#abandon and Mqtt#reject

### DIFF
--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -98,7 +98,7 @@ The `complete` method is there for compatibility purposes with other transports 
 **SRS_NODE_DEVICE_MQTT_16_005: [** The `complete` method shall call the `done` callback given as argument immediately since all messages are automatically completed. **]** 
 
 ### reject(message, done)
-The `reject` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support abandonning messages.
+The `reject` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support rejecting messages.
 
 **SRS_NODE_DEVICE_MQTT_16_006: [** The `reject` method shall throw because MQTT doesn’t support rejecting messages. **]** 
 

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -88,7 +88,7 @@ The `getReceiver` method creates a receiver object and returns it, or returns th
 **SRS_NODE_DEVICE_MQTT_16_003: [** If a receiver for this endpoint doesn’t exist, the `getReceiver` method should create a new `MqttReceiver` object and then call the `done` callback with the object that was just created as an argument. **]** 
 
 ### abandon(message, done)
-The `abandon` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support abandonning messages.
+The `abandon` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support abandoning messages.
 
 **SRS_NODE_DEVICE_MQTT_16_004: [** The `abandon` method shall throw because MQTT doesn’t support abandoning messages. **]** 
 

--- a/device/transport/mqtt/lib/mqtt.js
+++ b/device/transport/mqtt/lib/mqtt.js
@@ -133,7 +133,7 @@ Mqtt.prototype.reject = function () {
  * @method              module:azure-iot-device-mqtt.Mqtt#abandon
  * @description         Settles the message as abandoned and calls the done callback with the result.
  *
- * @throws {Error}      The MQTT transport does not support rejecting messages.
+ * @throws {Error}      The MQTT transport does not support abandoning messages.
  */
 /*Codes_SRS_NODE_DEVICE_MQTT_16_004: [The ‘abandon’ method shall throw because MQTT doesn’t support abandoning messages.] */
 Mqtt.prototype.abandon = function () {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request contains code (and maybe docs): it is submitted against the `develop` branch. 
  - [x] This pull-request contains only docs: it is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Fixes a couple of types in the docs and JSDoc comments for Mqtt#abandon and Mqtt#reject

# Description of the solution
Fixed the typos