### PR TITLE
Update Registry service TypeScript sample with Async/Await

### DIFF
--- a/service/samples/typescript_sample/package.json
+++ b/service/samples/typescript_sample/package.json
@@ -1,12 +1,18 @@
 {
   "name": "registry_sample",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "main": "registry_sample.js",
   "author": "Microsoft Corp.",
   "license": "MIT",
   "dependencies": {
-    "azure-iothub": "1.1.9"
+    "azure-iothub": "^1.1.10"
+  },
+  "devDependencies": {
+    "@types/node": "^7.0.18",
+    "tslint": "^5.2.0",
+    "typescript": "^2.3.2",
+    "typings": "^2.1.1"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/service/samples/typescript_sample/tsconfig.json
+++ b/service/samples/typescript_sample/tsconfig.json
@@ -2,9 +2,13 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
+    "lib": [ "es2017" ], 
+    "strict": true,
+    "strictNullChecks": false,
     "moduleResolution": "node",
-    "removeComments": false,
-    "noImplicitAny": true,
-    "suppressImplicitAnyIndexErrors": true
+    "typeRoots": [
+      "typings"
+    ],
+    "types": [ "@types/node" ]
   }
 }

--- a/service/samples/typescript_sample/typings.json
+++ b/service/samples/typescript_sample/typings.json
@@ -1,11 +1,5 @@
 {
-  "name": "registry_sample",
   "dependencies": {
-    "amqp10": "registry:npm/amqp10#3.1.4+20160601175358",
-    "bluebird": "registry:npm/bluebird#3.4.1+20160811213708"
-  },
-  "globalDependencies": {
-    "es2015-promise": "registry:env/es2015-promise#1.0.0+20160526151700",
-    "node": "registry:dt/node#6.0.0+20160807145350"
+    "amqp10": "registry:npm/amqp10#3.3.1+20170124180914"
   }
 }


### PR DESCRIPTION
This commit updates TypeScript service example code to use new
features from TypeScript 2.* including Async/Await support to
simplify flow of asynchronous operation. Updating TS support
allows also to simplify tooling setup with use of NPM @types.

The results and output of the changed source code is the same
as before update.

Instead of using hardcoded connection string the TS version uses
Node environment variable as widely used way of providing sensitive
information on the process start.


# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).

# Description of the problem
The JavaScript Node engine is based on asynchronous event loop. For this reason using complex flow, like here in registry, can results in extensive use of nested callbacks, which makes using SDK code harder for new users

# Description of the solution
The TypeScript 2 allows to use ES2015/ES2017 Async/Await (asynchronous) functions together with Promise based functions using IoT SDK.

Compare callback based version, with clearly visible nested callbacks and unclear execution flow where there is no guaranted execution order for `registry.list` and `registry.create`:
```JavaScript
// List devices
console.log('**listing devices..');
registry.list((err, deviceList) => {
    deviceList.forEach((device) => {
        let key = device.authentication ? device.authentication.symmetricKey.primaryKey : '<no primary key>';
        console.log(device.deviceId + ': ' + key);
    });
});

// Create a new device
let device = new Device();
device.deviceId = 'sample-device-' + Date.now();
console.log('\n**creating device \'' + device.deviceId + '\'');
registry.create(device, printAndContinue('create', () => {
    // Get the newly-create device
    console.log('\n**getting device \'' + device.deviceId + '\'');
    registry.get(device.deviceId, printAndContinue('get', () => {
        // Delete the new device
        console.log('\n**deleting device \'' + device.deviceId + '\'');
        registry.delete(device.deviceId, printAndContinue('delete'));
    }));
}));
```

with this version:
```TypeScript
// listing devices
console.log('**listing devices ...');
try {
    const deviceList: Device[] = await listDevices(registry);
    deviceList.forEach((device: Device) => {
        let key = (device.authentication) ?
            device.authentication.symmetricKey.primaryKey :
            '<no primary key>';
        console.log(`${device.deviceId}:${key}`);
    });
} catch (error) {
    console.log(error);
}
// Create a new device
let device = new Device();
device.deviceId = `sample-device-${Date.now()}`;
console.log(`**creating device ${device.deviceId}`);
try {
    device = await createDevice(registry, device);
    device = await getDevice(registry, device.deviceId);
} catch (error) {
    console.log(error);
}
```

The output from updated version:
```shell
node registry_sample.js 
**listing devices ...
sample-device-1494020150060:M7GZ2n0BeEo0eJd1UI4Bge4kQx5GuJgyXOe0lSkUNS4=
sample-device-1494020275582:YRAsMXPTCICq6joF48wmzQFokBy8svKmW+bnxndjI+I=
myraspberrypi:BeVjKyM+Dhgj2hGo76V4qjB4HWBnZ0s9XIEmAydadSg=
**creating device sample-device-1494022155595
create status: 200 OK
create device info: {"deviceId":"sample-device-1494022155595","generationId":"636296189567763392","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GpqHJnPPsV+hrDWxnuIzRyd1vlZC9kb6PcDnHa7+Wdc=","secondaryKey":"ZbhcSSBrWqE/ZPA9mGHom4pkwiENlN37ZsbsRDRKGpQ="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null},"SymmetricKey":{"primaryKey":"GpqHJnPPsV+hrDWxnuIzRyd1vlZC9kb6PcDnHa7+Wdc=","secondaryKey":"ZbhcSSBrWqE/ZPA9mGHom4pkwiENlN37ZsbsRDRKGpQ="}}}
get status: 200 OK
get device info: {"deviceId":"sample-device-1494022155595","generationId":"636296189567763392","etag":"MA==","connectionState":"Disconnected","status":"enabled","statusReason":null,"connectionStateUpdatedTime":"0001-01-01T00:00:00","statusUpdatedTime":"0001-01-01T00:00:00","lastActivityTime":"0001-01-01T00:00:00","cloudToDeviceMessageCount":0,"authentication":{"symmetricKey":{"primaryKey":"GpqHJnPPsV+hrDWxnuIzRyd1vlZC9kb6PcDnHa7+Wdc=","secondaryKey":"ZbhcSSBrWqE/ZPA9mGHom4pkwiENlN37ZsbsRDRKGpQ="},"x509Thumbprint":{"primaryThumbprint":null,"secondaryThumbprint":null},"SymmetricKey":{"primaryKey":"GpqHJnPPsV+hrDWxnuIzRyd1vlZC9kb6PcDnHa7+Wdc=","secondaryKey":"ZbhcSSBrWqE/ZPA9mGHom4pkwiENlN37ZsbsRDRKGpQ="}}}
```

Thanks!