### PR TITLE
Fix member variable name typo in Result interface

### DIFF
--- a/common/core/src/results.ts
+++ b/common/core/src/results.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 export interface Result {
-    tranportObj?: any;
+    transportObj?: any;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
The d.ts files included with this library fail to build on TypeScript 2.4 due to the new weak types (https://github.com/Microsoft/TypeScript/wiki/What's-new-in-TypeScript). This change to TypeScript is a good one because it actually catches a bug with the current code. The base Result interface has a typo with its transportObj field. Derived classes don't have the typo. Older TypeScript compilers treated it as a second field declaration and built fine. But in 2.4 you need overlap with a weak type and so now it will fail to build given the typo.

# Description of the solution
Fixes the typo.
