### PR TITLE
HTTP Content-Length calculating for UTF8

### DIFF
--- a/service/src/rest_api_client.ts
+++ b/service/src/rest_api_client.ts
@@ -102,7 +102,8 @@ export class RestApiClient {
       }
 
       /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_036: [The `executeApiCall` shall set the `Content-Length` header to the length of the serialized value of `requestBody` if it is truthy.]*/
-      headers['Content-Length'] = requestBodyString.length;
+      const requestBodyStringSizeInBytes = Buffer.byteLength(requestBodyString, 'utf8');
+      headers['Content-Length'] = requestBodyStringSizeInBytes;
     }
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_008: [The `executeApiCall` method shall build the HTTP request using the arguments passed by the caller.]*/


### PR DESCRIPTION
# Description of the problem
When tried to update DeviceTwin with UTF-8 2-bytes encoding signs server return error with message: 

> Provided json is not a valid 'twin' object.

For example for calling update on Twin with object contains Polish special characters:
`{ 
"żółw": "gęś"
}` server return error as above. When I call Twin update directly url from Postman everything went ok.
[Twin.update](https://docs.microsoft.com/en-us/rest/api/iothub/devicetwinapi/updatedevicetwin)
I found in source code that Content-Length for HTTP header is calculating incorrectly, should include UTF8 encoding.

#Solution
I used Buffer.byteLenght() function to calculate correctly sizeof http body.



