### PR TITLE
Add common retry logic objects: RetryPolicy, RetryOperation, and default policies

### DIFF
--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -11,6 +11,8 @@ export { anHourFromNow, encodeUriComponentStrict } from './lib/authorization';
 export { ConnectionString } from './lib/connection_string';
 export { Message }
 export { SharedAccessSignature } from './lib/shared_access_signature';
+export { RetryOperation } from './lib/retry_operation';
+export { RetryPolicy, NoRetry, ExponentialBackOffWithJitter } from './lib/retry_policy';
 
 // Typescript only, used by other modules in azure-iot-sdk
 export interface X509 {

--- a/common/core/common.js
+++ b/common/core/common.js
@@ -5,7 +5,7 @@
 
 /**
  * The `azure-iot-common` module contains code common to the Azure IoT Hub Device and Service SDKs.
- * 
+ *
  * @module azure-iot-common
  */
 
@@ -17,5 +17,9 @@ module.exports = {
   errors: require('./lib/errors.js'),
   results: require('./lib/results.js'),
   Message: require('./lib/message.js').Message,
-  SharedAccessSignature: require('./lib/shared_access_signature.js').SharedAccessSignature
+  SharedAccessSignature: require('./lib/shared_access_signature.js').SharedAccessSignature,
+  RetryOperation: require('./lib/retry_operation.js').RetryOperation,
+  RetryPolicy: require('./lib/retry_policy.js').RetryPolicy,
+  NoRetry: require('./lib/retry_policy.js').NoRetry,
+  ExponentialBackOffWithJitter: require('./lib/retry_policy.js').ExponentialBackOffWithJitter,
 };

--- a/common/core/devdoc/retry_operation_requirements.md
+++ b/common/core/devdoc/retry_operation_requirements.md
@@ -1,0 +1,36 @@
+# azure-iot-common.RetryOperation Requirements
+
+## Overview
+
+the `RetryOperation` class implements the necessary logic to retry operations such as connecting, receiving C2D messages, sending telemetry, twin updates, etc.
+
+## Usage example
+
+```js
+var op = new RetryOperation(new ExponentialBackoffWithJitter(), 120000);
+op.retry(function (retryCallback) {
+  callSomethingAsync(someParam, retryCallback);
+}, function (err, result) {
+  if (err) {
+    console.log('error after retrying: ' + err.toString());
+  } else {
+    console.log('successful operation result: ' + result.toString());
+  }
+});
+```
+
+## Public API
+
+### retry(operation, finalCallback)
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_001: [** The `operation` function should be called at every retry. **]**
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_002: [** If the `operation` is successful the `finalCallback` function should be called with a `null` error parameter and the result of the operation.**]**
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_003: [** If the `operation` fails with an error the `retry` method should determine whether to retry or not using the `shouldRetry` method of the policy passed to the constructor.**]**
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_004: [** If the `operation` fails and should not be retried, the `finalCallback` should be called with the last error as the only parameter. **]**
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_005: [** If the `operation` fails and should be retried, the time at which to try again the `operation` should be computed using the `nextRetryTimeout` method of the policy passed to the constructor. **]**
+
+**SRS_NODE_COMMON_RETRY_OPERATION_16_006: [** The `operation` should not be retried past the `maxTimeout` parameter passed to the constructor.**]**

--- a/common/core/devdoc/retry_policy_requirements.md
+++ b/common/core/devdoc/retry_policy_requirements.md
@@ -1,0 +1,76 @@
+# azure-iot-common.RetryPolicy Requirements
+
+## Overview
+
+The `RetryPolicy` interface and classes implement the necessary logic to compute retry intervals using different algorithms and parameters when an operation (such as sending a D2C message) fails.
+
+## Example
+
+```js
+var policy = new ExponentialBackoffWithJitter(new DefaultErrorFilter());
+var firstTimeout = policy.nextRetryTimeout(1, false);
+var secondTimeout = policy.nextRetryTimeout(2, false);
+
+// the second parameter indicates whether the algorithm should use normal parameters (false)
+// or parameters adapted to situations where the Azure IoT hub is throttling
+var timeoutWhenThrottled = policy.nextRetryTimeout(1, true);
+// timeoutWhenThrottled will be longer than firstTimeout.
+
+var errorFilter: {
+  TimeoutError: false
+};
+
+var policy = new ExponentialBackoffWithJitter(errorFilter);
+var shouldBeFalse = policy.shouldRetry(new errors.TimeoutError());
+```
+
+## Public API:
+
+### RetryPolicy interface
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_001: [** Any implementation of the `RetryPolicy` interface shall have a `shouldRetry` method used to evaluate if an error is "retryable" or not. **]**
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_002: [** Any implementation of the `RetryPolicy` interface shall have a `getNextTimeout` method used to return the timeout value corresponding to the current retry count. **]**
+
+### NoRetry
+
+#### shouldRetry(error)
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_03: [** The `shouldRetry` method shall always return `false`. **]**
+
+#### getNextTimeout(currentRetryCount, isThrottled)
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_004: [** The `getNextTimeout` method shall always return `-1`. **]**
+
+### ExponentialBackoffWithJitter
+
+#### shouldRetry(error)
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_006: [** The `shouldRetry` method of the new instance shall use the error filter passed to the constructor when the object was instantiated. **]**
+
+#### getNextTimeout(currentRetryCount, isThrottled)
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_007: [** The `getNextTimeout` method shall implement the following math formula to determine the next timeout value: `F(x) = min(Cmin+ (2^(x-1)-1) * rand(C * (1 – Jd), C*(1-Ju)), Cmax` **]**
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_008: [** The `getNextTimeout` method shall return `0` instead of the result of the math formula if the following 3 conditions are met:
+- the `constructor` was called with the `immediateFirstTimeout` boolean set to `true`
+- the `isThrottled` boolean is `false`.
+- the `currentRetryCount` is `0` (meaning it's the first retry). **]**
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_009: [** The default constants to use with the Math formula for the normal conditions retry are:
+```
+c = 100
+cMin = 100
+cMax = 10000
+ju = 0.25
+jd = 0.5
+``` **]**
+
+**SRS_NODE_COMMON_RETRY_POLICY_16_010: [** The default constants to use with the Math formula for the throttled conditions retry are:
+```
+c = 5000
+cMin = 10000
+cMax = 60000
+ju = 0.5
+jd = 0.25
+``` **]**

--- a/common/core/src/retry_error_filter.ts
+++ b/common/core/src/retry_error_filter.ts
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+export interface ErrorFilter {
+  ArgumentError: boolean;
+  ArgumentOutOfRangeError: boolean;
+  DeviceMaximumQueueDepthExceededError: boolean; // ??
+  DeviceNotFoundError: boolean;
+  FormatError: boolean;
+  UnauthorizedError: boolean;
+  NotImplementedError: boolean;
+  NotConnectedError: boolean;
+  IotHubQuotaExceededError: boolean;
+  MessageTooLargeError: boolean;
+  InternalServerError: boolean;
+  ServiceUnavailableError: boolean;
+  IotHubNotFoundError: boolean;
+  IoTHubSuspendedError: boolean; // ??
+  JobNotFoundError: boolean;
+  TooManyDevicesError: boolean;
+  ThrottlingError: boolean;
+  DeviceAlreadyExistsError: boolean;
+  DeviceMessageLockLostError: boolean;
+  InvalidEtagError: boolean;
+  InvalidOperationError: boolean;
+  PreconditionFailedError: boolean; // ??
+  TimeoutError: boolean;
+  BadDeviceResponseError: boolean;
+  GatewayTimeoutError: boolean; // ??
+  DeviceTimeoutError: boolean;// ??
+}
+
+/* tslint:disable:variable-name */
+export class DefaultErrorFilter implements ErrorFilter {
+  ArgumentError: boolean = false;
+  ArgumentOutOfRangeError: boolean = false;
+  DeviceMaximumQueueDepthExceededError: boolean = false; // ??
+  DeviceNotFoundError: boolean = false;
+  FormatError: boolean = false;
+  UnauthorizedError: boolean = false;
+  NotImplementedError: boolean = false;
+  NotConnectedError: boolean = true;
+  IotHubQuotaExceededError: boolean = false;
+  MessageTooLargeError: boolean = false;
+  InternalServerError: boolean = false;
+  ServiceUnavailableError: boolean = true;
+  IotHubNotFoundError: boolean = false;
+  IoTHubSuspendedError: boolean = false; // ??
+  JobNotFoundError: boolean = false;
+  TooManyDevicesError: boolean = false;
+  ThrottlingError: boolean = true;
+  DeviceAlreadyExistsError: boolean = false;
+  DeviceMessageLockLostError: boolean = false;
+  InvalidEtagError: boolean = false;
+  InvalidOperationError: boolean = false;
+  PreconditionFailedError: boolean = false; // ??
+  TimeoutError: boolean = true;
+  BadDeviceResponseError: boolean = false;
+  GatewayTimeoutError: boolean = false; // ??
+  DeviceTimeoutError: boolean = false;// ??
+}
+/* tslint:enable:variable-name */

--- a/common/core/src/retry_operation.ts
+++ b/common/core/src/retry_operation.ts
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import * as errors from './errors';
+import { RetryPolicy } from './retry_policy';
+
+/**
+ * Implements the necessary logic to retry operations such as connecting, receiving C2D messages, sending telemetry, twin updates, etc.
+ */
+export class RetryOperation {
+  private _policy: RetryPolicy;
+  private _retryCount: number = 0;
+  private _currentTimeout: any;
+  private _totalRetryTime: number = 0;
+  private _maxTimeout: number;
+
+  /**
+   * Creates an instance of {@link azure-iot-common.RetryOperation.}
+   * @param {RetryPolicy} policy The retry policy to be used for this operation, which determines what error is "retryable" or not and how fast to retry.
+   * @param {number} maxTimeout  The maximum timeout for this operation, after which no retry will be attempted.
+   */
+  constructor (policy: RetryPolicy, maxTimeout: number) {
+    this._policy = policy;
+    this._maxTimeout = maxTimeout;
+  }
+
+  /**
+   * Executes an operation and retries if it fails and the retry policy allows it.
+   *
+   * @param {(opCallback: (err?: Error, result?: any) => void) => void} operation The operation to execute.
+   * @param {(err?: Error, result?: any) => void} finalCallback                   The callback to call with the final error or result, after retries if necessary.
+   */
+  retry(operation: (opCallback: (err?: Error, result?: any) => void) => void, finalCallback: (err?: Error, result?: any) => void): void {
+    const retryOperation = () => {
+      this._retryCount++;
+      /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_001: [The `operation` function should be called at every retry.]*/
+      operation((err, result) => {
+        if (err) {
+          /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_003: [If the `operation` fails with an error the `retry` method should determine whether to retry or not using the `shouldRetry` method of the policy passed to the constructor.]*/
+          if (this._policy.shouldRetry(err)) {
+            /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_005: [If the `operation` fails and should be retried, the time at which to try again the `operation` should be computed using the `nextRetryTimeout` method of the policy passed to the constructor. ]*/
+            let nextRetryTimeout = this._policy.nextRetryTimeout(this._retryCount, (err instanceof errors.ThrottlingError));
+            this._totalRetryTime += nextRetryTimeout;
+            /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_006: [The `operation` should not be retried past the `maxTimeout` parameter passed to the constructor.]*/
+            if (this._totalRetryTime > this._maxTimeout || nextRetryTimeout < 0) {
+              finalCallback(err);
+            } else {
+              this._currentTimeout = setTimeout(retryOperation, nextRetryTimeout);
+            }
+          } else {
+            /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_004: [If the `operation` fails and should not be retried, the `finalCallback` should be called with the last error as the only parameter. ]*/
+            finalCallback(err);
+          }
+        } else {
+          /*Codes_SRS_NODE_COMMON_RETRY_OPERATION_16_002: [If the `operation` is successful the `finalCallback` function should be called with a `null` error parameter and the result of the operation.]*/
+          finalCallback(null, result);
+        }
+      });
+    };
+    retryOperation();
+  }
+
+  // A cancel() API would be nice and easy to implement but doesn't exist in other SDKs yet. To be specified first.
+}

--- a/common/core/src/retry_policy.ts
+++ b/common/core/src/retry_policy.ts
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import { ErrorFilter, DefaultErrorFilter } from './retry_error_filter';
+
+/**
+ * Interface describing a retry policy object.
+ * Retry policies are composed of 2 things
+ * - An algorithm that computes the next time to retry based on the current number or retries.
+ * - An error filter that decides, based on the type of error received, whether a retry should happen or not.
+ *
+ * Those 2 components hide behind 2 method calls described in this interface.
+ */
+export interface RetryPolicy {
+  /**
+   * Computes the interval to wait before retrying at each new retry tentative.
+   *
+   * @param {number} retryCount    Current retry tentative.
+   * @param {boolean} isThrottled  Boolean indicating whether the Azure IoT hub is throttling operations.
+   * @returns {number}             The time to wait before attempting a retry in milliseconds.
+   */
+  /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_002: [Any implementation of the `RetryPolicy` interface shall have a `getNextTimeout` method used to return the timeout value corresponding to the current retry count.]*/
+  nextRetryTimeout: (retryCount: number, isThrottled: boolean) => number;
+
+  /**
+   * Based on the error passed as argument, determines if an error is transient and if the operation should be retried or not.
+   *
+   * @param {Error} error The error encountered by the operation.
+   * @returns {boolean}   Whether the operation should be retried or not.
+   */
+  /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_001: [Any implementation of the `RetryPolicy` interface shall have a `shouldRetry` method used to evaluate if an error is "retryable" or not.]*/
+  shouldRetry: (error: Error) => boolean;
+}
+
+/**
+ * Parameters used with the {@link azure-iot-common.ExponentialBackOffWithJitter} policy to compute retry intervals.
+ */
+/*SRS_NODE_COMMON_RETRY_POLICY_16_009: [The default constants to use with the Math formula for the normal conditions retry are:
+```
+c = 100
+cMin = 100
+cMax = 10000
+ju = 0.25
+jd = 0.5
+```]*/
+export class ExponentialBackoffWithJitterParameters {
+  /**
+   * Initial retry interval: 100 ms by default.
+   */
+  c: number = 100;
+  /**
+   * Minimal interval between each retry. 100 milliseconds by default
+   */
+  cMin: number = 100;
+  /**
+   * Maximum interval between each retry. 10 seconds by default
+   */
+  cMax: number = 10000;
+  /**
+   * Jitter up factor. 0.25 by default.
+   */
+  ju: number = 0.25;
+  /**
+   * Jitter down factor. 0.5 by default
+   */
+  jd: number = 0.5;
+}
+
+/**
+ * Implements an Exponential Backoff with Jitter retry strategy.
+ * The function to calculate the next interval is the following (x is the xth retry):
+ * F(x) = min(Cmin+ (2^(x-1)-1) * rand(C * (1 – Jd), C*(1-Ju)), Cmax)
+ * @implements {RetryStrategy}
+ */
+/*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_005: [The `ExponentialBackoffWithJitter` class shall implement the `RetryPolicy` interface.]*/
+export class ExponentialBackOffWithJitter implements RetryPolicy {
+  /**
+   * Retry parameters used to calculate the delay between each retry in normal situations (ie. not throttled).
+   */
+  normalParameters: ExponentialBackoffWithJitterParameters;
+  /**
+   * Retry parameters used to calculate the delay between each retry in throttled situations.
+   */
+  throttledParameters: ExponentialBackoffWithJitterParameters;
+  /**
+   * Boolean indicating whether the first retry should be immediate (if set to true) or after the normalParameters.c delay (if set to false).
+   */
+  immediateFirstRetry: boolean;
+
+  private _errorFilter: ErrorFilter;
+
+  /**
+   * Initializes a new instance of the {@link azure-iot-common.ExponentialBackOffWithJitter} class.
+   * @param maxTimeout            maximum allowed timeout in milliseconds.
+   * @param immediateFirstRetry   boolean indicating whether the first retry should be immediate (default) or wait the first interval (c value).
+   */
+  constructor(immediateFirstRetry?: boolean, errorFilter?: ErrorFilter, ) {
+    this._errorFilter = errorFilter ? errorFilter : new DefaultErrorFilter();
+    this.immediateFirstRetry = immediateFirstRetry !== false ? true : false;    // should default to true if not specified.
+    this.normalParameters = new ExponentialBackoffWithJitterParameters();
+    this.throttledParameters = new ExponentialBackoffWithJitterParameters();
+    /*SRS_NODE_COMMON_RETRY_POLICY_16_010: [The default constants to use with the Math formula for the throttled conditions retry are:
+    ```
+    c = 5000
+    cMin = 10000
+    cMax = 60000
+    ju = 0.5
+    jd = 0.25
+    ```]*/
+    this.throttledParameters.c = 5000;
+    this.throttledParameters.cMin = 10000;
+    this.throttledParameters.cMax = 60000;
+  }
+
+  /**
+   * Computes the interval to wait before retrying at each new retry tentative.
+   *
+   * @param {number} retryCount    Current retry tentative.
+   * @param {boolean} isThrottled  Boolean indicating whether the Azure IoT hub is throttling operations.
+   * @returns {number}             The time to wait before attempting a retry in milliseconds.
+   */
+  nextRetryTimeout(retryCount: number, isThrottled: boolean): number {
+    /*SRS_NODE_COMMON_RETRY_POLICY_16_008: [The `getNextTimeout` method shall return `0` instead of the result of the math formula if the following 3 conditions are met:
+    - the `constructor` was called with the `immediateFirstTimeout` boolean set to `true`
+    - the `isThrottled` boolean is `false`.
+    - the `currentRetryCount` is `0` (meaning it's the first retry).]*/
+    if (this.immediateFirstRetry && retryCount === 0 && !isThrottled) {
+      return 0;
+    } else {
+      /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_007: [The `getNextTimeout` method shall implement the following math formula to determine the next timeout value: `F(x) = min(Cmin+ (2^(x-1)-1) * rand(C * (1 – Jd), C*(1-Ju)), Cmax)`]*/
+      let constants = isThrottled ? this.throttledParameters : this.normalParameters;
+      let minRandomFactor = constants.c * (1 - constants.jd);
+      let maxRandomFactor = constants.c * (1 - constants.ju);
+      let randomJitter = Math.random() * (maxRandomFactor - minRandomFactor);
+      return Math.min(constants.cMin + (Math.pow(retryCount - 1, 2) - 1) * randomJitter, constants.cMax);
+    }
+  }
+
+  /**
+   * Based on the error passed as argument, determines if an error is transient and if the operation should be retried or not.
+   *
+   * @param {Error} error The error encountered by the operation.
+   * @returns {boolean}   Whether the operation should be retried or not.
+   */
+  shouldRetry(error: Error): boolean {
+    /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_006: [The `shouldRetry` method of the new instance shall use the error filter passed to the constructor when the object was instantiated.]*/
+    return this._errorFilter[error.name];
+  }
+}
+
+/**
+ * Stub policy that blocks any retry tentative. Operations are not retried.
+ *
+ * @implements {RetryPolicy}
+ */
+export class NoRetry implements RetryPolicy {
+  /**
+   * This will always return -1 as no retry is desired.
+   *
+   * @param {number} retryCount This parameter is ignored.
+   */
+  /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_004: [The `getNextTimeout` method shall always return `-1`.]*/
+  nextRetryTimeout(retryCount: number): number {
+    return -1;
+  }
+
+  /**
+   * This will always return false as no retry is desired.
+   *
+   * @param {Error} err This parameter is ignored.
+   * @returns {boolean} Will always be false: retry should not be attempted no matter what the error is.
+   */
+  /*Codes_SRS_NODE_COMMON_RETRY_POLICY_16_03: [The `shouldRetry` method shall always return `false`.]*/
+  shouldRetry(err: Error): boolean {
+    return false;
+  }
+}

--- a/common/core/test/_retry_operation_test.js
+++ b/common/core/test/_retry_operation_test.js
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+var errors = require('../lib/errors.js');
+var RetryOperation = require('../lib/retry_operation.js').RetryOperation;
+
+describe('RetryOperation', function () {
+  describe('retry', function () {
+    it('uses the RetryPolicy passed to the constructor', function (testCallback) {
+      // This policy should be able to try twice (t = 0; t = 1).
+      var testPolicy = {
+        nextRetryTimeout: sinon.stub().returns(1),
+        shouldRetry: sinon.stub().returns(true)
+      };
+      var testError = new Error('fake timeout that shall be retried');
+      var actualOperation = sinon.stub().callsArgWith(0, testError);
+
+      var testOperation = new RetryOperation(testPolicy, 1);
+      testOperation.retry(function (callback) {
+        actualOperation(callback);
+      }, function (finalErr) {
+        assert(actualOperation.calledTwice);
+        assert(testPolicy.nextRetryTimeout.calledTwice);
+        assert(testPolicy.shouldRetry.calledTwice);
+        assert.strictEqual(finalErr, testError);
+        testCallback();
+      });
+    });
+
+    it('does not retry if the error is unrecoverable', function (testCallback) {
+      // This policy should be able to try only once (t = 0) but not retry
+      var testPolicy = {
+        nextRetryTimeout: sinon.stub().returns(1),
+        shouldRetry: sinon.stub().returns(false)
+      };
+      var testError = new Error('unrecoverable');
+      var actualOperation = sinon.stub().callsArgWith(0, testError);
+
+      var testOperation = new RetryOperation(testPolicy, 1);
+      testOperation.retry(function (callback) {
+        actualOperation(callback);
+      }, function () {
+        assert(actualOperation.calledOnce);
+        assert(testPolicy.nextRetryTimeout.notCalled);
+        testCallback();
+      });
+    });
+
+    it('does not retry past the maximum timeout', function (testCallback) {
+      // This policy should be able to try only 3 times (t = 0; t = 2; t = 4)
+      var testPolicy = {
+        nextRetryTimeout: sinon.stub().returns(2),
+        shouldRetry: sinon.stub().returns(true)
+      };
+      var testError = new Error('fake timeout that shall be retried');
+      var actualOperation = sinon.stub().callsArgWith(0, testError);
+
+      var testOperation = new RetryOperation(testPolicy, 5);
+      testOperation.retry(function (callback) {
+        actualOperation(callback);
+      }, function (finalErr) {
+        assert(actualOperation.calledThrice);
+        assert(testPolicy.nextRetryTimeout.calledThrice);
+        assert.strictEqual(finalErr, testError);
+        testCallback();
+      });
+    });
+
+    it('calls the callback with a null error object and the result of the operation if it is successful', function (testCallback) {
+      // This policy should be able to try twice (t = 0; t = 1).
+      var testPolicy = {
+        nextRetryTimeout: sinon.stub().returns(1),
+        shouldRetry: sinon.stub().returns(true)
+      };
+      var testResult = { success: true };
+      var actualOperation = sinon.stub().callsArgWith(0, null, testResult);
+
+      var testOperation = new RetryOperation(testPolicy, 1);
+      testOperation.retry(function (callback) {
+        actualOperation(callback);
+      }, function (finalErr, finalResult) {
+        assert.isNotOk(finalErr);
+        assert.strictEqual(finalResult, testResult);
+        testCallback();
+      });
+    });
+  });
+});

--- a/common/core/test/_retry_policy_test.js
+++ b/common/core/test/_retry_policy_test.js
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+var errors = require('../lib/errors.js');
+var RetryPolicy = require('../lib/retry_policy.js').RetryPolicy;
+var ExponentialBackOffWithJitter = require('../lib/retry_policy.js').ExponentialBackOffWithJitter;
+var NoRetry = require('../lib/retry_policy.js').NoRetry;
+
+describe('RetryPolicy', function () {
+  describe('ExponentialBackOffWithJitter', function () {
+    describe('shouldRetry', function () {
+      /*SRS_NODE_COMMON_RETRY_POLICY_16_006: [** The `shouldRetry` method of the new instance shall use the error filter passed to the constructor when the object was instantiated.]*/
+      it('uses the ErrorFilter passed in the constructor', function () {
+        var testFilter = {
+          TimeoutError: false,
+          UnauthorizedError: true
+        };
+        var testPolicy = new ExponentialBackOffWithJitter(testPolicy, testFilter);
+        assert.isFalse(testPolicy.shouldRetry(new errors.TimeoutError('fake timeout that shall not be retried because of the filter')));
+        assert.isTrue(testPolicy.shouldRetry(new errors.UnauthorizedError('fake UnauthorizedError that shall be retried because of the filter')));
+      });
+    });
+
+    describe('nextRetryTimeout', function () {
+      /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_008: [The `getNextTimeout` method shall return `0` instead of the result of the math formula if the following 3 conditions are met:
+      - the `constructor` was called with the `immediateFirstTimeout` boolean set to `true`
+      - the `isThrottled` boolean is `false`.
+      - the `currentRetryCount` is `0` (meaning it's the first retry).]*/
+      it('returns 0 for the first immediate retry if the first retry is set to be immediate', function () {
+        sinon.stub(Math, 'random').returns(0.42);
+        var policy = new ExponentialBackOffWithJitter(true);
+        assert.strictEqual(policy.nextRetryTimeout(0, false), 0);
+        Math.random.restore();
+      });
+
+      it('returns \'C\' for the first retry if the first retry is not set to be immediate', function () {
+        sinon.stub(Math, 'random').returns(0.42);
+        var policy = new ExponentialBackOffWithJitter(false);
+        assert.strictEqual(policy.nextRetryTimeout(0, false), 100);
+        Math.random.restore();
+      });
+
+      /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_007: [The `getNextTimeout` method shall implement the following math formula to determine the next timeout value: `F(x) = min(Cmin+ (2^(x-1)-1) * rand(C * (1 – Jd), C*(1-Ju)), Cmax`]*/
+      it('returns the proper value based on the retry count', function() {
+        sinon.stub(Math, 'random').returns(0.42);
+        var policy = new ExponentialBackOffWithJitter();
+        /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_009: [The default constants to use with the Math formula for the normal conditions retry are:
+        ```
+        c = 100
+        cMin = 100
+        cMax = 10000
+        ju = 0.25
+        jd = 0.5
+        ```]*/
+        [
+          { retryCount: 0, expected: 0 },
+          { retryCount: 1, expected: 89.5 },
+          { retryCount: 2, expected: 100 },
+          { retryCount: 3, expected: 131.5 },
+          { retryCount: 10, expected: 940 },
+          { retryCount: 42, expected: 10000 }
+        ].forEach(function (testConfig) {
+          assert.strictEqual(policy.nextRetryTimeout(testConfig.retryCount, false), testConfig.expected);
+        });
+
+        /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_010: [The default constants to use with the Math formula for the throttled conditions retry are:
+        ```
+        c = 5000
+        cMin = 10000
+        cMax = 60000
+        ju = 0.5
+        jd = 0.25
+        ```]*/
+        [
+          { retryCount: 0, expected: 10000 },
+          { retryCount: 1, expected: 9475 },
+          { retryCount: 2, expected: 10000 },
+          { retryCount: 3, expected: 11575 },
+          { retryCount: 10, expected: 52000 },
+          { retryCount: 42, expected: 60000 }
+        ].forEach(function (testConfig) {
+          assert.strictEqual(policy.nextRetryTimeout(testConfig.retryCount, true), testConfig.expected);
+        });
+        Math.random.restore();
+      });
+    });
+  });
+
+  describe('NoRetry', function () {
+    describe('shouldRetry', function () {
+      /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_03: [The `shouldRetry` method shall always return `false`.]*/
+      it('returns false', function() {
+        var policy = new NoRetry();
+        assert.strictEqual(false, policy.shouldRetry(new Error()));
+      });
+    });
+
+    describe('nextRetryTimeout', function () {
+      /*Tests_SRS_NODE_COMMON_RETRY_POLICY_16_004: [The `getNextTimeout` method shall always return `-1`.]*/
+      it('always returns -1', function () {
+        var policy = new NoRetry();
+        [0, 1, 42, -1, 9999].forEach(function(retryCount) {
+          assert.strictEqual(-1, policy.nextRetryTimeout(retryCount));
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description of the problem
Currently the SDK does not implement any sort of retry logic for operations that can fail because of transient errors such as network issues. This is the beginning of a series of commits aimed at solving that problem

# Description of the solution
Right now this only contains the objects that will be used by the high level clients to retry operations. Next up are the new versions of the transport packages.
