### PR TITLE
fix(types): Align callback interfaces for compatibility with non-nullable types

### DIFF
--- a/device/core/src/client.ts
+++ b/device/core/src/client.ts
@@ -806,13 +806,13 @@ export namespace Client {
 
   export interface Transport extends EventEmitter {
     setOptions?(options: any, done: (err?: Error, result?: results.TransportConfigured) => void): void;
-    updateSharedAccessSignature(sharedAccessSignature: string, done: (err: Error, result?: results.SharedAccessSignatureUpdated) => void): void;
-    getReceiver(func: (err: Error, receiver?: Receiver) => void): void;
-    sendEvent(message: Message, done: (err: Error, result?: results.MessageEnqueued) => void): void;
-    sendEventBatch?(messages: Message[], done: (err: Error, result?: results.MessageEnqueued) => void): void;
-    complete(message: Message, done: (err: Error, result?: results.MessageCompleted) => void): void;
-    reject(message: Message, done: (err: Error, results?: results.MessageRejected) => void): void;
-    abandon(message: Message, done: (err: Error, results?: results.MessageAbandoned) => void): void;
+    updateSharedAccessSignature(sharedAccessSignature: string, done: (err?: Error, result?: results.SharedAccessSignatureUpdated) => void): void;
+    getReceiver(func: (err?: Error, receiver?: Receiver) => void): void;
+    sendEvent(message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+    sendEventBatch?(messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+    complete(message: Message, done: (err?: Error, result?: results.MessageCompleted) => void): void;
+    reject(message: Message, done: (err?: Error, results?: results.MessageRejected) => void): void;
+    abandon(message: Message, done: (err?: Error, results?: results.MessageAbandoned) => void): void;
   }
 
   export interface BlobUpload {

--- a/device/core/src/interfaces.ts
+++ b/device/core/src/interfaces.ts
@@ -13,7 +13,7 @@ import { Client } from './client';
  * Describes the specific methods that a transport should implement to support device-to-cloud message batching.
  */
 export interface BatchingTransport extends Client.Transport {
-  sendEventBatch(messages: Message[], done: (err: Error, result?: results.MessageEnqueued) => void): void;
+  sendEventBatch(messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void;
 }
 
 /**

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -138,7 +138,7 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
   /* Codes_SRS_NODE_DEVICE_AMQP_16_002: [The sendEvent method shall construct an AMQP request using the message passed in argument as the body of the message.] */
   /* Codes_SRS_NODE_DEVICE_AMQP_16_003: [The sendEvent method shall call the done() callback with a null error object and a MessageEnqueued result object when the message has been successfully sent.] */
   /* Codes_SRS_NODE_DEVICE_AMQP_16_004: [If sendEvent encounters an error before it can send the request, it shall invoke the done callback function and pass the standard JavaScript Error object with a text description of the error (err.message). ] */
-  sendEvent(message: Message, done: (err: Error, result?: results.MessageEnqueued) => void): void {
+  sendEvent(message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void {
     const eventEndpoint = endpoint.eventPath(this._config.deviceId);
     this._amqp.send(message, eventEndpoint, eventEndpoint, handleResult('AMQP Transport: Could not send', done));
   }
@@ -151,7 +151,7 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
    */
   /* Codes_SRS_NODE_DEVICE_AMQP_16_006: [If a receiver for this endpoint has already been created, the getReceiver method should call the done() method with the existing instance as an argument.]*/
   /* Codes_SRS_NODE_DEVICE_AMQP_16_007: [If a receiver for this endpoint doesn’t exist, the getReceiver method should create a new AmqpReceiver object and then call the done() method with the object that was just created as an argument.]*/
-  getReceiver(done: (err: Error, receiver?: AmqpReceiver) => void): void {
+  getReceiver(done: (err?: Error, receiver?: AmqpReceiver) => void): void {
     done(null, this._receiver);
   }
 


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] ~I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).~
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Description of the problem
When importing `azure-iot-device` and associated packages into a project using TypeScript with `strictNullChecks` set to true, the project won't compile due to type mismatches within the SDK.

Specifically, trying to do a build will yield the following errors:

```
node_modules/azure-iot-device-http/lib/http.d.ts(12,22): error TS2420: Class 'Http' incorrectly implements interface 'BatchingTransport'.
  Types of property 'sendEventBatch' are incompatible.
    Type '(messages: Message[], done: (err?: Error | undefined, result?: MessageEnqueued | undefined) => vo...' is not assignable to type '(messages: Message[], done: (err: Error, result?: MessageEnqueued | undefined) => void) => void'.
      Types of parameters 'done' and 'done' are incompatible.
        Types of parameters 'err' and 'err' are incompatible.
          Type 'Error | undefined' is not assignable to type 'Error'.
            Type 'undefined' is not assignable to type 'Error'.
node_modules/azure-iot-device-http/lib/http.d.ts(12,22): error TS2420: Class 'Http' incorrectly implements interface 'Transport'.
  Types of property 'updateSharedAccessSignature' are incompatible.
    Type '(sharedAccessSignature: string, done: (err?: Error | undefined, result?: SharedAccessSignatureUpd...' is not assignable to type '(sharedAccessSignature: string, done: (err: Error, result?: SharedAccessSignatureUpdated | undefi...'.
      Types of parameters 'done' and 'done' are incompatible.
        Types of parameters 'err' and 'err' are incompatible.
          Type 'Error | undefined' is not assignable to type 'Error'.
            Type 'undefined' is not assignable to type 'Error'.
```

Both of these errors (as well as a couple others that come from using the `Http` transport from `azure-iot-device-http` and passing it into the client from `azure-iot-device`) come from the fact that in the `azure-iot-device-http` package, the callback defines the `err` parameter as optional, but it's required in several parts of `azure-iot-device`.

# Description of the solution

I aligned the contract for the transport in `azure-iot-device` and the transports themselves to all use the form with an optional `err` parameter so that TypeScript projects with `strictNullChecks` set to true will be able to compile.

I found other places with a required `err` parameter in the callback but decided to leave them as is for now since they don't seem to cause any issues for external consumers.