### PR TITLE
New state machine for MqttBase

### DIFF
--- a/device/transport/mqtt/devdoc/mqtt_base_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_base_requirements.md
@@ -33,6 +33,7 @@ base.receive(function (topic, msg) {
 The `Mqtt` constructor receives the configuration parameters to configure the MQTT.JS library to connect to an IoT hub.
 
 **SRS_NODE_COMMON_MQTT_BASE_16_004: [** The `Mqtt` constructor shall instanciate the default MQTT.JS library if no argument is passed to it. **]**
+
 **SRS_NODE_COMMON_MQTT_BASE_16_005: [** The `Mqtt` constructor shall use the object passed as argument instead of the default MQTT.JS library if it's not falsy. **]**
 
 ### MqttBase.connect(config, done)
@@ -45,40 +46,61 @@ The `connect` method establishes a connection with the server using the config o
 
 **SRS_NODE_COMMON_MQTT_BASE_16_003: [** The `connect` method shall call the `done` callback with a standard javascript `Error` object if the connection failed. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_007: [** The `connect` method shall not throw if the `done` argument has not been passed. **]**
-
 **SRS_NODE_COMMON_MQTT_BASE_16_016: [** The `connect` method shall configure the `keepalive` ping interval to 3 minutes by default since the Azure Load Balancer TCP Idle timeout default is 4 minutes. (https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-tcp-idle-timeout) **]**
 
 ### MqttBase.disconnect(done)
 The `disconnect` method closes the connection to the server.
 
-**SRS_NODE_COMMON_MQTT_BASE_16_001: [** The `disconnect` method shall call the done callback when the connection to the server has been closed. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_001: [** The `disconnect` method shall call the `done` callback when the connection to the server has been closed. **]**
 
-### Mqtt.publish(message)
-The `publish` method publishes the message passed as argument.
+### Mqtt.publish(topic, payload, options, callback)
 
-**SRS_NODE_COMMON_MQTT_BASE_12_006: [** The `publish` method shall throw `ReferenceError` “Invalid message” if the message is falsy. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_017: [** The `publish` method publishes a `payload` on a `topic` using `options`. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_12_007: [** The `publish` method shall call `publish`  on MQTT.JS  library with the given message. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_018: [** The `publish` method shall throw a `ReferenceError` if the topic is falsy. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_008: [** The `publish` method shall use a topic formatted using the following convention: `devices/<deviceId>/messages/events/`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_019: [** The `publish` method shall throw a `ReferenceError` if the payload is falsy. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_009: [** If the message has properties, the property keys and values shall be uri-encoded, then serialized and appended at the end of the topic with the following convention: `<key>=<value>&<key2>=<value2>&<key3>=<value3>(...)`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_020: [** The `publish` method shall call the callback with a `NotConnectedError` if the connection hasn't been established prior to calling `publish`. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_010: [** The `publish` method shall use QoS level of 1. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_021: [** The  `publish` method shall call `publish` on the mqtt client object and call the `callback` argument with `null` and the `puback` object if it succeeds. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_011: [** The `publish` method shall serialize the `messageId` property of the message as a key-value pair on the topic with the key `$.mid`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_022: [** The `publish` method shall call the `callback` argument with an Error if the operation fails. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_012: [** The `publish` method shall serialize the `correlationId` property of the message as a key-value pair on the topic with the key `$.cid`. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_013: [** The `publish` method shall serialize the `userId` property of the message as a key-value pair on the topic with the key `$.uid`. **]**
+### MqttBase.subscribe(topic, options, callback)
 
-**SRS_NODE_COMMON_MQTT_BASE_16_014: [** The `publish` method shall serialize the `to` property of the message as a key-value pair on the topic with the key `$.to`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_12_008: [** The `subscribe` method shall call `subscribe`  on MQTT.JS  library and pass it the `topic` and `options` arguments. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_015: [** The `publish` method shall serialize the `expiryTimeUtc` property of the message as a key-value pair on the topic with the key `$.exp`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_023: [** The `subscribe` method shall throw a `ReferenceError` if the topic is falsy. **]**
 
-### MqttBase.subscribe()
-**SRS_NODE_COMMON_MQTT_BASE_12_008: [** The `subscribe` method shall call `subscribe`  on MQTT.JS  library with the given message and with the hardcoded topic path. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_024: [** The `subscribe` method shall call the callback with `null` and the `suback` object if the mqtt library successfully subscribes to the `topic`. **]**
 
-### MqttBase.receive()
-**SRS_NODE_COMMON_MQTT_BASE_12_010: [** The `receive` method shall implement the MQTT.JS library callback event and calls back to the caller with the given callback. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_025: [** The `subscribe` method shall call the callback with an `Error` if the mqtt library fails to subscribe to the `topic`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_026: [** The `subscribe` method shall call the callback with a `NotConnectedError` if the connection hasn't been established prior to calling `publish`. **]**
+
+### MqttBase.unsubscribe(topic, callback)
+
+**SRS_NODE_COMMON_MQTT_BASE_16_031: [** The `unsubscribe` method shall throw a `ReferenceError` if the `topic` argument is falsy. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_027: [** The `unsubscribe` method shall call the callback with a `NotConnectedError` if the connection hasn't been established prior to calling `publish`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_028: [** The `unsubscribe` method shall call `unsubscribe` on the mqtt library and pass it the `topic`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_029: [** The `unsubscribe` method shall call the `callback` argument with no arguments if the operation succeeds. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_030: [** The `unsubscribe` method shall call the `callback` argument with an `Error` if the operation fails. **]**
+
+
+### MqttBase.updateSharedAccessSignature(sharedAccessSignature, callback)
+
+**SRS_NODE_COMMON_MQTT_BASE_16_032: [** The `updateSharedAccessSignature` method shall throw a `ReferenceError` if the `sharedAccessSignature` argument is falsy. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_033: [** The `updateSharedAccessSignature` method shall disconnect and reconnect the mqtt client with the new `sharedAccessSignature`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_034: [** The `updateSharedAccessSignature` method shall not trigger any network activity if the mqtt client is not connected. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_035: [** The `updateSharedAccessSignature` method shall call the `callback` argument with no parameters if the operation succeeds. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_036: [** The `updateSharedAccessSignature` method shall call the `callback` argument with an `Error` if the operation fails. **]**

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -1,7 +1,7 @@
 # azure-iot-device-mqtt.Mqtt/MqttWs Requirements
 
 ## Overview
-`Mqtt` and `MqttWs` provide a standard transport interface between the generic device Client and the specific MQTT transport implementation. 
+`Mqtt` and `MqttWs` provide a standard transport interface between the generic device Client and the specific MQTT transport implementation.
 `MqttWs` will connect over secure websockets whereas `Mqtt` connects over secure TCP sockets.
 
 ## Example usage
@@ -35,7 +35,7 @@ client.connect(function (err) {
     });
 
     mqtt.getReceiver(function (err, receiver) {
-      receiver.on('message', function(msg) { 
+      receiver.on('message', function(msg) {
         console.log('received: ' + msg.getData());
       });
 
@@ -61,7 +61,7 @@ The `Mqtt` and `MqttWs` constructors initialize a new instance of the MQTT trans
 
 **SRS_NODE_DEVICE_MQTT_16_017: [** The `MqttWs` constructor shall initialize the `uri` property of the `config` object to `wss://<host>:443/$iothub/websocket`. **]**
 
-**SRS_NODE_DEVICE_MQTT_18_025: [** If the `Mqtt` constructor receives a second parameter, it shall be used as a provider in place of mqtt.js **]**  
+**SRS_NODE_DEVICE_MQTT_18_025: [** If the `Mqtt` constructor receives a second parameter, it shall be used as a provider in place of mqtt.js **]**
 
 ### connect(done)
 The `connect` method initializes a connection to an IoT hub.
@@ -80,37 +80,53 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_DEVICE_MQTT_12_005: [** The `sendEvent` method shall call the publish method on `MqttTransport`. **]**
 
+**SRS_NODE_COMMON_MQTT_BASE_16_008: [** The `sendEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/messages/events/`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_009: [** If the message has properties, the property keys and values shall be uri-encoded, then serialized and appended at the end of the topic with the following convention: `<key>=<value>&<key2>=<value2>&<key3>=<value3>(...)`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_010: [** The `sendEvent` method shall use QoS level of 1. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_011: [** The `sendEvent` method shall serialize the `messageId` property of the message as a key-value pair on the topic with the key `$.mid`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_012: [** The `sendEvent` method shall serialize the `correlationId` property of the message as a key-value pair on the topic with the key `$.cid`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_013: [** The `sendEvent` method shall serialize the `userId` property of the message as a key-value pair on the topic with the key `$.uid`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_014: [** The `sendEvent` method shall serialize the `to` property of the message as a key-value pair on the topic with the key `$.to`. **]**
+
+**SRS_NODE_COMMON_MQTT_BASE_16_015: [** The `sendEvent` method shall serialize the `expiryTimeUtc` property of the message as a key-value pair on the topic with the key `$.exp`. **]**
+
 ### getReceiver(done)
 The `getReceiver` method creates a receiver object and returns it, or returns the existing instance.
 
-**SRS_NODE_DEVICE_MQTT_16_002: [** If a receiver for this endpoint has already been created, the `getReceiver` method should call the `done` callback with the existing instance as an argument. **]** 
+**SRS_NODE_DEVICE_MQTT_16_002: [** If a receiver for this endpoint has already been created, the `getReceiver` method should call the `done` callback with the existing instance as an argument. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_003: [** If a receiver for this endpoint doesn’t exist, the `getReceiver` method should create a new `MqttReceiver` object and then call the `done` callback with the object that was just created as an argument. **]** 
+**SRS_NODE_DEVICE_MQTT_16_003: [** If a receiver for this endpoint doesn’t exist, the `getReceiver` method should create a new `MqttReceiver` object and then call the `done` callback with the object that was just created as an argument. **]**
 
 ### abandon(message, done)
 The `abandon` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support abandoning messages.
 
-**SRS_NODE_DEVICE_MQTT_16_004: [** The `abandon` method shall throw because MQTT doesn’t support abandoning messages. **]** 
+**SRS_NODE_DEVICE_MQTT_16_004: [** The `abandon` method shall throw because MQTT doesn’t support abandoning messages. **]**
 
 ### complete(message, done)
 The `complete` method is there for compatibility purposes with other transports but doesn't do anything because messages are automatically acknowledged.
 
-**SRS_NODE_DEVICE_MQTT_16_005: [** The `complete` method shall call the `done` callback given as argument immediately since all messages are automatically completed. **]** 
+**SRS_NODE_DEVICE_MQTT_16_005: [** The `complete` method shall call the `done` callback given as argument immediately since all messages are automatically completed. **]**
 
 ### reject(message, done)
 The `reject` method is there for compatibility purposes with other transports but will throw because the MQTT protocol doesn't support rejecting messages.
 
-**SRS_NODE_DEVICE_MQTT_16_006: [** The `reject` method shall throw because MQTT doesn’t support rejecting messages. **]** 
+**SRS_NODE_DEVICE_MQTT_16_006: [** The `reject` method shall throw because MQTT doesn’t support rejecting messages. **]**
 
 ### updateSharedAccessSignature(sharedAccessSignature, done)
 
-**SRS_NODE_DEVICE_MQTT_16_007: [** The `updateSharedAccessSignature` method shall save the new shared access signature given as a parameter to its configuration. **]** 
+**SRS_NODE_DEVICE_MQTT_16_007: [** The `updateSharedAccessSignature` method shall save the new shared access signature given as a parameter to its configuration. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_008: [** The `updateSharedAccessSignature` method shall disconnect the current connection operating with the deprecated token, and re-initialize the transport object with the new connection parameters. **]** 
+**SRS_NODE_DEVICE_MQTT_16_008: [** The `updateSharedAccessSignature` method shall disconnect the current connection operating with the deprecated token, and re-initialize the transport object with the new connection parameters. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_009: [** The `updateSharedAccessSignature` method shall call the `done` method with an `Error` object if updating the configuration or re-initializing the transport object. **]** 
+**SRS_NODE_DEVICE_MQTT_16_009: [** The `updateSharedAccessSignature` method shall call the `done` method with an `Error` object if updating the configuration or re-initializing the transport object. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_010: [** The `updateSharedAccessSignature` method shall call the `done` callback with a `null` error object and a `SharedAccessSignatureUpdated` object as a result, indicating that the client needs to reestablish the transport connection when ready. **]** 
+**SRS_NODE_DEVICE_MQTT_16_010: [** The `updateSharedAccessSignature` method shall call the `done` callback with a `null` error object and a `SharedAccessSignatureUpdated` object as a result, indicating that the client needs to reestablish the transport connection when ready. **]**
 
 ### setOptions(options, done)
 
@@ -178,9 +194,9 @@ The `sendTwinRequest` method sends the given body to the given endpoint on an Io
 
 **SRS_NODE_DEVICE_MQTT_18_013: [** The `sendTwinRequest` method shall throw an `ReferenceError` if the `body` argument is falsy. **]**
 
-**SRS_NODE_DEVICE_MQTT_18_022: [** The `propertyQuery` string shall be construced from the `properties` object. **]**  
+**SRS_NODE_DEVICE_MQTT_18_022: [** The `propertyQuery` string shall be construced from the `properties` object. **]**
 
-**SRS_NODE_DEVICE_MQTT_18_023: [** Each member of the `properties` object shall add another 'name=value&' pair to the `propertyQuery` string. **]**  
+**SRS_NODE_DEVICE_MQTT_18_023: [** Each member of the `properties` object shall add another 'name=value&' pair to the `propertyQuery` string. **]**
 
 **SRS_NODE_DEVICE_MQTT_18_004: [** If a `done` callback is passed as an argument, The `sendTwinRequest` method shall call `done` after the body has been published. **]**
 
@@ -194,10 +210,10 @@ The `sendTwinRequest` method sends the given body to the given endpoint on an Io
 
 **SRS_NODE_DEVICE_MQTT_18_017: [** If the `sendTwinRequest` method is successful, the first parameter to the `done` callback shall be null and the second parameter shall be a MessageEnqueued object. **]**
 
-### getTwinReceiver(done) 
+### getTwinReceiver(done)
 The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin response endpoint and returns it, or returns the existing instance.
 
-**SRS_NODE_DEVICE_MQTT_18_014: [** The `getTwinReceiver` method shall throw an `ReferenceError` if done is falsy **]** 
+**SRS_NODE_DEVICE_MQTT_18_014: [** The `getTwinReceiver` method shall throw an `ReferenceError` if done is falsy **]**
 
 **SRS_NODE_DEVICE_MQTT_18_003: [** If a twin receiver for this endpoint doesn’t exist, the `getTwinReceiver` method should create a new `MqttTwinReceiver` object. **]**
 

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -9,20 +9,21 @@
   "dependencies": {
     "azure-iot-common": "1.1.12",
     "azure-iot-device": "1.1.18",
-    "debug": "^2.6.0",
-    "mqtt": "^1.14.1"
+    "debug": "^3.0.1",
+    "machina": "^2.0.0",
+    "mqtt": "^2.13.0"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "@types/mqtt": "0.0.34",
+    "@types/node": "^8.0.30",
+    "chai": "^4.1.2",
+    "es5-shim": "^4.5.9",
     "istanbul": "^0.4.5",
     "jshint": "^2.9.4",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.7",
-    "es5-shim": "^4.5.9",
+    "sinon": "^3.3.0",
     "tslint": "^5.1.0",
-    "typescript": "2.2.2",
-    "@types/node": "^7.0.5",
-    "@types/mqtt": "0.0.34"
+    "typescript": "2.5.2"
   },
   "scripts": {
     "lint": "tslint --type-check --project . -c ../../../tslint.json",
@@ -33,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 89 --branches 76 --functions 76 --lines 90"
+    "check-cover": "istanbul check-coverage --statements 89 --branches 76 --functions 79 --lines 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/mqtt/test/_fake_mqtt.js
+++ b/device/transport/mqtt/test/_fake_mqtt.js
@@ -5,6 +5,8 @@
 var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 
+var sinon = require('sinon');
+
 var FakeMqtt = function() {
   EventEmitter.call(this);
 
@@ -12,7 +14,7 @@ var FakeMqtt = function() {
     this._publishSucceeds = shouldSucceed;
   };
 
-  this.publish = function(topic, message, options, callback) {
+  this.publish = sinon.stub().callsFake(function(topic, message, options, callback) {
     this.publishoptions = options;
     this.topicString = topic;
     if (this._publishSucceeds) {
@@ -20,27 +22,31 @@ var FakeMqtt = function() {
     } else {
       callback(new Error('Invalid topic'));
     }
-  };
+  });
 
-  this.connect = function() {
+  this.connect = sinon.stub().callsFake(function() {
     return this;
-  };
+  });
 
-  this.subscribe = function(topicName, param, done) {
+  this.subscribe = sinon.stub().callsFake(function(topicName, param, done) {
     if (this.subscribeShouldFail) {
       done (new Error('Not authorized'));
     } else {
       done(null, 'fake_object');
     }
-  };
+  });
 
-  this.unsubscribe = function(topicName, done) {
+  this.unsubscribe = sinon.stub().callsFake(function(topicName, done) {
     done();
-  };
+  });
 
   this.fakeMessageFromService = function(topic, message) {
     this.emit('message', topic, message);
   };
+
+  this.end = sinon.stub().callsFake(function (force, callback) {
+    callback();
+  });
 };
 
 util.inherits(FakeMqtt, EventEmitter);

--- a/device/transport/mqtt/test/_mqtt_devicetwin_test.js
+++ b/device/transport/mqtt/test/_mqtt_devicetwin_test.js
@@ -26,9 +26,9 @@ describe('Mqtt', function () {
     provider.publishShouldSucceed(true);
     transport = new Mqtt(config, provider);
   });
-  
+
   describe('#sendTwinRequest', function () {
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_18_001: [** The `sendTwinRequest` method shall call the publish method on `MqttTransport`. **]** */
     it('calls publish method on transport', function() {
       provider.publish = sinon.spy();
@@ -112,10 +112,9 @@ describe('Mqtt', function () {
     /* Tests_SRS_NODE_DEVICE_MQTT_18_022: [** The `propertyQuery` string shall be construced from the `properties` object. **]**   */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_023: [** Each member of the `properties` object shall add another 'name=value&' pair to the `propertyQuery` string. **]**   */
     it('correctly builds properties string', function() {
-      var publish = sinon.spy(provider, 'publish');
       transport.connect();
       transport.sendTwinRequest('a/', 'b/', {'rid' : 10, 'pid' : 20}, 'body', function() {});
-      assert(publish.calledWith('$iothub/twin/a/b/?rid=10&pid=20'));
+      assert(provider.publish.calledWith('$iothub/twin/a/b/?rid=10&pid=20'));
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_004: [** If a `done` callback is passed as an argument, The `sendTwinRequest` method shall call `done` after the body has been published. **]** */
@@ -127,18 +126,16 @@ describe('Mqtt', function () {
     /* Tests_SRS_NODE_DEVICE_MQTT_18_021: [** The topic name passed to the publish method shall be $iothub/twin/`method`/`resource`/?`propertyQuery` **]** */
     it('uses the correct topic name', function() {
       // 7.5.2: $iothub/twin/PATCH/properties/reported/?$rid={request id}&$version={base version}
-      var publish = sinon.spy(provider, 'publish');
       transport.connect();
       transport.sendTwinRequest('PATCH', '/properties/reported/', {'$rid':10, '$version': 200}, 'body', function() {});
-      assert(publish.calledWith('$iothub/twin/PATCH/properties/reported/?$rid=10&$version=200'));
+      assert(provider.publish.calledWith('$iothub/twin/PATCH/properties/reported/?$rid=10&$version=200'));
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_015: [** The `sendTwinRequest` shall publish the request with QOS=0, DUP=0, and Retain=0 **]** */
     it('uses the correct publish parameters', function() {
-      var publish = sinon.spy(provider, 'publish');
       transport.connect();
       transport.sendTwinRequest('PATCH', '/properties/reported/', {'$rid':10, '$version': 200}, 'body', function() {});
-      var publishoptions = publish.getCall(0).args[2];
+      var publishoptions = provider.publish.getCall(0).args[2];
       assert.equal(publishoptions.qos, 0);
       assert.equal(publishoptions.retain, false);
       // no way to verify DUP flag
@@ -168,7 +165,7 @@ describe('Mqtt', function () {
       });
     });
 
-    
+
   });
 
   describe('#getTwinReceiver', function () {
@@ -178,13 +175,13 @@ describe('Mqtt', function () {
         transport.getTwinReceiver();
       }, ReferenceError);
     });
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_18_005: [** The `getTwinReceiver` method shall call the `done` method after it completes **]** */
     it ('calls done when complete', function(done) {
       transport.connect();
       transport.getTwinReceiver(done);
     });
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_18_003: [** If a twin receiver for this endpoint doesn't exist, the `getTwinReceiver` method should create a new `MqttTwinReceiver` object. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_006: [** If a twin receiver for this endpoint did not previously exist, the `getTwinReceiver` method should return the a new `MqttTwinReceiver` object as the second parameter of the `done` function with null as the first parameter. **]** */
     it ('creates a new twin receiver object', function(done) {
@@ -195,7 +192,7 @@ describe('Mqtt', function () {
         done();
       });
     });
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_18_002: [** If a twin receiver for this endpoint has already been created, the `getTwinReceiver` method should not create a new `MqttTwinReceiver` object. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_007: [** If a twin receiver for this endpoint previously existed, the `getTwinReceiver` method should return the preexisting `MqttTwinReceiver` object as the second parameter of the `done` function with null as the first parameter. **]** */
     it ('only creates one twin receiver object', function(done) {
@@ -215,4 +212,4 @@ describe('Mqtt', function () {
   });
 
 });
-          
+

--- a/device/transport/mqtt/test/_mqtt_receiver_test.js
+++ b/device/transport/mqtt/test/_mqtt_receiver_test.js
@@ -54,7 +54,7 @@ describe('MqttReceiver', function () {
         var topicName = 'topic_subscribe_name';
         var mqttClient = new FakeMqttClient();
         mqttClient.on = sinon.spy();
-        mqttClient.subscribe = sinon.stub(mqttClient, 'subscribe', function (topic, options, callback) {
+        mqttClient.subscribe = sinon.stub(mqttClient, 'subscribe').callsFake(function (topic, options, callback) {
           assert(mqttClient.on.calledWith('message'));
           assert.isOk(options);
           assert.equal(topic, topicName);
@@ -86,12 +86,12 @@ describe('MqttReceiver', function () {
       it('unsubscribes from the topic when there are no more listeners', function () {
         var topicName = 'topic_subscribe_name';
         var mqttClient = new FakeMqttClient();
-        mqttClient.subscribe = sinon.stub(mqttClient, 'subscribe', function (topic, options, callback) {
+        mqttClient.subscribe = sinon.stub(mqttClient, 'subscribe').callsFake(function (topic, options, callback) {
           assert.isOk(options);
           assert.equal(topic, topicName);
           callback();
         });
-        mqttClient.unsubscribe = sinon.stub(mqttClient, 'unsubscribe', function (topic, callback) {
+        mqttClient.unsubscribe = sinon.stub(mqttClient, 'unsubscribe').callsFake(function (topic, callback) {
           assert.equal(topic, topicName);
           callback();
         });

--- a/device/transport/mqtt/test/_mqtt_twin_receiver_test.js
+++ b/device/transport/mqtt/test/_mqtt_twin_receiver_test.js
@@ -13,22 +13,20 @@ var provider;
 var receiver;
 
 var validateSubscription = function(shortname, topic, done) {
-  var subscribe = sinon.spy(provider, 'subscribe');
   receiver.on(shortname, function() {});
   process.nextTick(function() {
-    assert(subscribe.withArgs(topic).calledOnce);
+    assert(provider.subscribe.withArgs(topic).calledOnce);
     done();
   });
 };
 
 var validateUnsubscription = function(shortname, topic, done) {
-  var unsubscribe = sinon.spy(provider, 'unsubscribe');
   var func = function() { };
   receiver.on(shortname, func);
   process.nextTick(function() {
     receiver.removeListener(shortname, func);
     process.nextTick(function() {
-      assert(unsubscribe.withArgs(topic).calledOnce);
+      assert(provider.unsubscribe.withArgs(topic).calledOnce);
       done();
     });
   });
@@ -49,18 +47,18 @@ var validateEventFires = function(shortname, topic, done) {
 };
 
 describe('MqttTwinReceiver', function () {
-  
+
   beforeEach(function(done) {
     provider = new MqttProvider();
     receiver = new MqttTwinReceiver(provider);
     done();
   });
-    
+
   describe('#constructor', function () {
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_001: [** The `MqttTwinReceiver` constructor shall accept a `client` object **]** */
     it ('accepts a config object', function() {
-      assert.equal(receiver._client, provider);
+      assert.equal(receiver._mqtt, provider);
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_002: [** The `MqttTwinReceiver` constructor shall throw `ReferenceError` if the `client` object is falsy **]** */
@@ -113,7 +111,7 @@ describe('MqttTwinReceiver', function () {
       });
       provider.fakeMessageFromService('$iothub/twin/res/200/?$rid=42', 'fake_body');
     });
-    
+
     it ('ignores messages on invalid topics', function(done) {
       receiver.on(MqttTwinReceiver.responseEvent, function() {
         assert.fail();
@@ -130,11 +128,11 @@ describe('MqttTwinReceiver', function () {
       provider.fakeMessageFromService('$iothub/twin/res//$rid=');
       process.nextTick(done);
     });
-    
-  }); 
+
+  });
 
   describe('post event', function() {
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_018: [** When a listener is added to the post event, the appropriate topic shall be asynchronously subscribed to. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_019: [** The subscribed topic for post events shall be $iothub/twin/PATCH/properties/reported/# **]** */
     it ('asynchronously subscribes when  a listener is added', function(done) {
@@ -190,7 +188,7 @@ describe('MqttTwinReceiver', function () {
   });
 
   describe('subscribed event', function() {
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_025: [** If the `subscribed` event is subscribed to, a `subscribed` event shall be emitted after an MQTT topic is subscribed to. **]** */
     it ('emits a subscribed event after successful subscription to response event', function(done) {
       receiver.on('subscribed', function() {
@@ -206,7 +204,7 @@ describe('MqttTwinReceiver', function () {
       });
       receiver.on(MqttTwinReceiver.postEvent, function() {});
     });
-    
+
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_028: [** When the `subscribed` event is emitted, the parameter shall be an object which contains an `eventName` field and an `transportObject` field. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_026: [** When the `subscribed` event is emitted because the response MQTT topic was subscribed, the `eventName` field shall be the string 'response' **]**  */
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_029: [** When the subscribed event is emitted, the `transportObject` field shall contain the object returned by the library in the subscription response. **]** */

--- a/device/transport/mqtt/test/_mqtt_ws_test.js
+++ b/device/transport/mqtt/test/_mqtt_ws_test.js
@@ -9,7 +9,8 @@ var MqttWs = require('../lib/mqtt_ws.js').MqttWs;
 describe('MqttWs', function () {
   var fakeConfig = {
     host: 'host.name',
-    deviceId: 'deviceId'
+    deviceId: 'deviceId',
+    sharedAccessSignature: 'sas'
   };
 
   describe('#constructor', function () {


### PR DESCRIPTION
# Description of the problem
There is basically no state management for the connection in the MQTT transpor,t it's all left to the Client to manage the connection. This causes numerous issues (separation of concerns, transport implementation details leaking into the device client layer etc).

# Description of the solution
This is the first PR of a series that will introduce state management in the MQTT transport. the first step is to take care of MqttBase. In doing this we also cleaned up a couple of things with the receivers and Mqtt objects which were reaching in to manipulate the underlying MQTT client directly.
