### PR TITLE
Update pointers to API reference documentation

### DIFF
--- a/device/core/readme.md
+++ b/device/core/readme.md
@@ -91,7 +91,7 @@ If you want to modify the module's code and/or contribute changes, you will need
 [lnk-manage-iot-hub]: https://aka.ms/manageiothub
 [devbox-setup]: ../../doc/node-devbox-setup.md
 [device-samples]: ../samples/
-[node-api-reference]: http://azure.github.io/azure-iot-sdks/
+[node-api-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iot-device/
 [iot-dev-center]: http://azure.com/iotdev
 [iot-hub-documentation]: https://docs.microsoft.com/en-us/azure/iot-hub/
 

--- a/device/samples/readme.md
+++ b/device/samples/readme.md
@@ -21,7 +21,7 @@ This folder contains simple samples showing how to use the various features of t
    * **device_blob_upload.js**: Uploads a blob to Azure through IoT Hub
 
 ## How to run the samples
-   
+
 In order to run the device samples you will first need the following prerequisites:
 * Node.js v0.10 or above on your target device. (Check out [Nodejs.org](https://nodejs.org/) for more info)
 * [Create an Azure IoT Hub instance][lnk-setup-iot-hub]
@@ -62,7 +62,7 @@ For more information on how to use this library refer to the documents below:
 [lnk-setup-iot-hub]: https://aka.ms/howtocreateazureiothub
 [lnk-manage-iot-hub]: https://aka.ms/manageiothub
 [remote-monitoring-pcs]: https://docs.microsoft.com/en-us/azure/iot-suite/iot-suite-remote-monitoring-sample-walkthrough
-[node-api-reference]: http://azure.github.io/azure-iot-sdks/
+[node-api-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iot-device/
 [iothub-explorer]: https://github.com/azure/iothub-explorer
 [debug-with-vscode]: ../../doc/node-debug-vscode.md
 [node-devbox-setup]: ../../doc/node-devbox-setup.md

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ To find SDKs in other languages for Azure IoT, please refer to the [azure-iot-sd
 
 Visit [Azure IoT Dev Center][iot-dev-center] to learn more about developing applications for Azure IoT.
 
-## How to use the Azure IoT SDKs for Node.js 
+## How to use the Azure IoT SDKs for Node.js
 
 Devices and data sources in an IoT solution can range from a simple network-connected sensor to a powerful, standalone computing device. Devices may have limited processing capability, memory, communication bandwidth, and communication protocol support. The IoT device SDKs enable you to implement client applications for a wide variety of devices.
 The API reference documentation is [here][node-api-reference].
@@ -38,7 +38,7 @@ If you are having issues using one of the packages or using the Azure IoT Hub se
 To engage Microsoft support, you can create a support ticket directly from the [Azure portal](https://ms.portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade).
 Escalated support requests for Azure IoT Hub SDK's development questions will only be available Monday thru Friday during normal coverage hours of 6 a.m. to 6 p.m. PST.
 Here is what you can expect Microsoft Support to be able to help with:
-* **Client SDKs issues**: If you are trying to compile and run the libraries on a supported platform, the Support team will be able to assist with troubleshooting or questions related to compiler issues and communications to and from the IoT Hub.  They will also try to assist with questions related to porting to an unsupported platform, but will be limited in how much assistance can be provided.  The team will be limited with trouble-shooting the hardware device itself or drivers and or specific properties on that device. 
+* **Client SDKs issues**: If you are trying to compile and run the libraries on a supported platform, the Support team will be able to assist with troubleshooting or questions related to compiler issues and communications to and from the IoT Hub.  They will also try to assist with questions related to porting to an unsupported platform, but will be limited in how much assistance can be provided.  The team will be limited with trouble-shooting the hardware device itself or drivers and or specific properties on that device.
 * **IoT Hub / Connectivity Issues**: Communication from the device client to the Azure IoT Hub service and communication from the Azure IoT Hub service to the client.  Or any other issues specifically related to the Azure IoT Hub.
 * **Portal Issues**: Issues related to the portal, that includes access, security, dashboard, devices, Alarms, Usage, Settings and Actions.
 * **REST/API Issues**: Using the IoT Hub REST/APIs that are documented in the [documentation]( https://msdn.microsoft.com/library/mt548492.aspx).
@@ -46,7 +46,8 @@ Here is what you can expect Microsoft Support to be able to help with:
 ## Read more
 
 * [Azure IoT Hub documentation][iot-hub-documentation]
-* [Node.js API reference documentation][node-api-reference]
+* [Node.js API reference: Service SDK][node-api-service-reference]
+* [Node.js API reference: Device SDK][node-api-device-reference]
 
 # Long Term Support
 
@@ -80,4 +81,5 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 [iot-dev-center]: http://azure.com/iotdev
 [iot-hub-documentation]: https://docs.microsoft.com/en-us/azure/iot-hub/
 [azure-iot-sdks]: http://github.com/azure/azure-iot-sdks
-[node-api-reference]: http://azure.github.io/azure-iot-sdk-node/
+[node-api-service-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iothub/
+[node-api-device-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iot-device/

--- a/service/readme.md
+++ b/service/readme.md
@@ -82,6 +82,6 @@ Test files
 [npm_lnk]:https://docs.npmjs.com/getting-started/what-is-npm
 [samples]: ./samples/
 [lnk-setup-iot-hub]: https://aka.ms/howtocreateazureiothub
-[node-api-reference]: http://azure.github.io/azure-iot-sdk-node/
+[node-api-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iothub/
 [iot-dev-center]: http://azure.com/iotdev
 [iot-hub-documentation]: https://docs.microsoft.com/en-us/azure/iot-hub/

--- a/service/samples/readme.md
+++ b/service/samples/readme.md
@@ -16,7 +16,7 @@ This folder contains simple samples showing how to use the various features of t
    * **twin.js**: Interact with the Device Twins from a back-end app.
    * **twin_query.js**: Interact with the Device Twins using queries from a back-end app.
    * **device_method.js**: Invoke a C2D Direct Method on a device through IoT Hub.
-   * **dmpatterns_reboot_service.js**: Initiate a C2D method to reboot a device and view progress through the twin reported properties. 
+   * **dmpatterns_reboot_service.js**: Initiate a C2D method to reboot a device and view progress through the twin reported properties.
    * **dmpatterns_fwupdate_service.js**: Implement the service side of the firmware update DM pattern.
    * **job_query.js**: Use the jobs query feature of the service SDK.
    * **schedule_job.js**: Schedule device management jobs.
@@ -62,7 +62,7 @@ For more information on how to use this library refer to the documents below:
 
 [lnk-setup-iot-hub]: https://aka.ms/howtocreateazureiothub
 [remote-monitoring-pcs]: https://docs.microsoft.com/en-us/azure/iot-suite/iot-suite-remote-monitoring-sample-walkthrough
-[node-api-reference]: http://azure.github.io/azure-iot-sdks/
+[node-api-reference]: https://docs.microsoft.com/en-us/javascript/api/azure-iothub/
 [iothub-explorer]: https://github.com/azure/iothub-explorer
 [dm-patterns]: ../../doc/dmpatterns.md
 [debug-with-vscode]: ../../doc/get_started/node-debug-vscode.md


### PR DESCRIPTION
# Description of the problem
We used to have to maintain our own github pages for API reference - no more since docs.microsoft.com now supports javascript/typescript APIs!

# Description of the solution
Docs got updated and published and now we can update the links in the readme files
