### PR TITLE
Mqtt transport main state machine

### DIFF
--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -113,9 +113,11 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_DEVICE_MQTT_16_024: [** The `sendEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to establish a connection. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_025: [** The `sendEvent` method shall be deferred until either disconnected or connected if it is called while `MqttBase` is establishing the connection. **]**
+**SRS_NODE_DEVICE_MQTT_16_025: [** If `sendEvent` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the event. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_026: [** The `sendEvent` method shall be deferred until disconnected if it is called while `MqttBase` is disconnecting. **]**
+**SRS_NODE_DEVICE_MQTT_16_035: [** If `sendEvent` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then sendEvent shall fail. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_026: [** If `sendEvent` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the event.  **]**
 
 **SRS_NODE_DEVICE_MQTT_16_027: [** The `sendEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to publish the message. **]**
 
@@ -242,9 +244,11 @@ The `sendTwinRequest` method sends the given body to the given endpoint on an Io
 
 **SRS_NODE_DEVICE_MQTT_16_029: [** The `sendTwinRequest` method shall connect the Mqtt connection if it is disconnected. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_031: [** The `sendTwinRequest` method shall be deferred until either disconnected or connected if it is called while `MqttBase` is establishing the connection. **]**
+**SRS_NODE_DEVICE_MQTT_16_031: [** If `sendTwinRequest` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the twin request. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_032: [** The `sendTwinRequest` method shall be deferred until disconnected if it is called while `MqttBase` is disconnecting. **]**
+**SRS_NODE_DEVICE_MQTT_16_036: [** If `sendTwinRequest` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then `sendTwinRequest` shall fail. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_032: [** If `sendTwinRequest` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the twin request. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_033: [** The `sendTwinRequest` method shall call its callback with an error translated using `translateError` if `MqttBase` fails to connect. **]**
 

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 89 --branches 76 --functions 79 --lines 91"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 80 --functions 88 --lines 95"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -150,8 +150,11 @@ export class Mqtt extends EventEmitter implements Client.Transport, StableConnec
           disconnect: (disconnectCallback) => {
             this._fsm.transition('disconnecting', disconnectCallback);
           },
-          /*Codes_SRS_NODE_DEVICE_MQTT_16_025: [The `sendEvent` method shall be deferred until either disconnected or connected if it is called while `MqttBase` is establishing the connection.]*/
-          /*Codes_SRS_NODE_DEVICE_MQTT_16_031: [The `sendTwinRequest` method shall be deferred until either disconnected or connected if it is called while `MqttBase` is establishing the connection.]*/
+
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_025: [If `sendEvent` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the event.]*/
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_035: [If `sendEvent` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then sendEvent shall fail.]*/
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_031: [If `sendTwinRequest` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the twin request.]*/
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_036: [If `sendTwinRequest` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then `sendTwinRequest` shall fail.]*/
           '*': () => this._fsm.deferUntilTransition()
         },
         connected: {
@@ -242,8 +245,8 @@ export class Mqtt extends EventEmitter implements Client.Transport, StableConnec
               this._fsm.transition('disconnected', disconnectCallback, err, new results.Disconnected(result));
             });
           },
-          /*Codes_SRS_NODE_DEVICE_MQTT_16_026: [The `sendEvent` method shall be deferred until disconnected if it is called while `MqttBase` is disconnecting.]*/
-          /*Codes_SRS_NODE_DEVICE_MQTT_16_032: [The `sendTwinRequest` method shall be deferred until disconnected if it is called while `MqttBase` is disconnecting.]*/
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_026: [If `sendEvent` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the event. ]*/
+          /*Codes_SRS_NODE_DEVICE_MQTT_16_032: [If `sendTwinRequest` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the twin request.]*/
           '*': () => this._fsm.deferUntilTransition()
         }
       }

--- a/device/transport/mqtt/test/_mqtt_devicetwin_test.js
+++ b/device/transport/mqtt/test/_mqtt_devicetwin_test.js
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 'use strict';
-
+var EventEmitter = require('events').EventEmitter;
 var assert = require('chai').assert;
 
-var MqttProvider = require('./_fake_mqtt.js');
 var Mqtt = require('../lib/mqtt').Mqtt;
 var errors = require('azure-iot-common').errors;
 var sinon = require('sinon');
@@ -17,24 +16,50 @@ var config = {
   'sharedAccessSignature' : 'mock_sharedAccessSignature'
 };
 
-var provider;
+var fakeMqttBase;
 var transport;
 
-describe('Mqtt', function () {
+describe('Mqtt: Device Twin', function () {
   beforeEach(function() {
-    provider = new MqttProvider();
-    provider.publishShouldSucceed(true);
-    transport = new Mqtt(config, provider);
+    fakeMqttBase = new EventEmitter();
+    fakeMqttBase.connect = sinon.stub().callsArg(1);
+    fakeMqttBase.disconnect = sinon.stub().callsArg(0);
+    fakeMqttBase.publish = sinon.stub().callsArg(3);
+    fakeMqttBase.subscribe = sinon.stub().callsArg(2);
+    fakeMqttBase.unsubscribe = sinon.stub().callsArg(1);
+    fakeMqttBase.updateSharedAccessSignature = sinon.stub().callsArg(1);
+
+    transport = new Mqtt(config, fakeMqttBase);
   });
 
   describe('#sendTwinRequest', function () {
+    /*Tests_SRS_NODE_DEVICE_MQTT_16_029: [The `sendTwinRequest` method shall connect the Mqtt connection if it is disconnected.]*/
+    it('connects the transport if currently disconnected', function (testCallback) {
+      transport.sendTwinRequest('PUT', '/res', {'rid':10}, 'body', function () {
+        assert.isTrue(fakeMqttBase.connect.calledOnce);
+        assert.isTrue(fakeMqttBase.publish.calledOnce);
+        testCallback();
+      });
+    });
 
-    /* Tests_SRS_NODE_DEVICE_MQTT_18_001: [** The `sendTwinRequest` method shall call the publish method on `MqttTransport`. **]** */
-    it('calls publish method on transport', function() {
-      provider.publish = sinon.spy();
-      transport.connect();
-      transport.sendTwinRequest('PUT', '/res', {'rid':10}, 'body', function() {});
-      assert(provider.publish.calledOnce);
+    /*Tests_SRS_NODE_DEVICE_MQTT_16_033: [The `sendTwinRequest` method shall call its callback with an error translated using `translateError` if `MqttBase` fails to connect.]*/
+    it('calls the callback with an error if the transport fails to connect', function (testCallback) {
+      fakeMqttBase.connect = sinon.stub().callsArgWith(1, new Error('fake error'));
+      transport.sendTwinRequest('PUT', '/res', {'rid':10}, 'body', function (err) {
+        assert.isTrue(fakeMqttBase.connect.calledOnce);
+        assert.instanceOf(err, Error);
+        testCallback();
+      });
+    });
+
+    /* Tests_SRS_NODE_DEVICE_MQTT_18_001: [** The `sendTwinRequest` method shall call the publish method on `MqttBase`. **]** */
+    it('calls publish method on transport', function (testCallback) {
+      transport.connect(function() {
+        transport.sendTwinRequest('PUT', '/res', {'rid':10}, 'body', function() {
+          assert(fakeMqttBase.publish.calledOnce);
+          testCallback();
+        });
+      });
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_008: [** The `sendTwinRequest` method shall not throw if the `done` callback is falsy. **]** */
@@ -114,7 +139,7 @@ describe('Mqtt', function () {
     it('correctly builds properties string', function() {
       transport.connect();
       transport.sendTwinRequest('a/', 'b/', {'rid' : 10, 'pid' : 20}, 'body', function() {});
-      assert(provider.publish.calledWith('$iothub/twin/a/b/?rid=10&pid=20'));
+      assert(fakeMqttBase.publish.calledWith('$iothub/twin/a/b/?rid=10&pid=20'));
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_004: [** If a `done` callback is passed as an argument, The `sendTwinRequest` method shall call `done` after the body has been published. **]** */
@@ -128,14 +153,14 @@ describe('Mqtt', function () {
       // 7.5.2: $iothub/twin/PATCH/properties/reported/?$rid={request id}&$version={base version}
       transport.connect();
       transport.sendTwinRequest('PATCH', '/properties/reported/', {'$rid':10, '$version': 200}, 'body', function() {});
-      assert(provider.publish.calledWith('$iothub/twin/PATCH/properties/reported/?$rid=10&$version=200'));
+      assert(fakeMqttBase.publish.calledWith('$iothub/twin/PATCH/properties/reported/?$rid=10&$version=200'));
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_015: [** The `sendTwinRequest` shall publish the request with QOS=0, DUP=0, and Retain=0 **]** */
     it('uses the correct publish parameters', function() {
       transport.connect();
       transport.sendTwinRequest('PATCH', '/properties/reported/', {'$rid':10, '$version': 200}, 'body', function() {});
-      var publishoptions = provider.publish.getCall(0).args[2];
+      var publishoptions = fakeMqttBase.publish.getCall(0).args[2];
       assert.equal(publishoptions.qos, 0);
       assert.equal(publishoptions.retain, false);
       // no way to verify DUP flag
@@ -144,7 +169,7 @@ describe('Mqtt', function () {
     /* Tests_SRS_NODE_DEVICE_MQTT_18_016: [** If an error occurs in the `sendTwinRequest` method, the `done` callback shall be called with the error as the first parameter. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_024: [** If an error occurs, the `sendTwinRequest` shall use the MQTT `translateError` module to convert the mqtt-specific error to a transport agnostic error before passing it into the `done` callback. **]** */
     it('calls done with an error on failure', function(done) {
-      provider.publishShouldSucceed(false);
+      fakeMqttBase.publish = sinon.stub().callsArgWith(3, new Error('Invalid topic'));
       transport.connect();
       transport.sendTwinRequest('PATCH', '/properties/reported/', {'$rid':10, '$version': 200}, 'body', function(err) {
         assert.equal(err.constructor.name, 'FormatError');
@@ -178,38 +203,55 @@ describe('Mqtt', function () {
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_005: [** The `getTwinReceiver` method shall call the `done` method after it completes **]** */
     it ('calls done when complete', function(done) {
-      transport.connect();
-      transport.getTwinReceiver(done);
+      transport.connect(function () {
+        transport.getTwinReceiver(done);
+      });
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_003: [** If a twin receiver for this endpoint doesn't exist, the `getTwinReceiver` method should create a new `MqttTwinReceiver` object. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_006: [** If a twin receiver for this endpoint did not previously exist, the `getTwinReceiver` method should return the a new `MqttTwinReceiver` object as the second parameter of the `done` function with null as the first parameter. **]** */
     it ('creates a new twin receiver object', function(done) {
-      transport.connect();
-      transport.getTwinReceiver(function(err,receiver) {
-        assert.isNull(err);
-        assert.instanceOf(receiver, MqttTwinReceiver);
-        done();
+      transport.connect(function () {
+        transport.getTwinReceiver(function(err,receiver) {
+          assert.isNull(err);
+          assert.instanceOf(receiver, MqttTwinReceiver);
+          done();
+        });
       });
     });
 
     /* Tests_SRS_NODE_DEVICE_MQTT_18_002: [** If a twin receiver for this endpoint has already been created, the `getTwinReceiver` method should not create a new `MqttTwinReceiver` object. **]** */
     /* Tests_SRS_NODE_DEVICE_MQTT_18_007: [** If a twin receiver for this endpoint previously existed, the `getTwinReceiver` method should return the preexisting `MqttTwinReceiver` object as the second parameter of the `done` function with null as the first parameter. **]** */
     it ('only creates one twin receiver object', function(done) {
-      transport.connect();
-      transport.getTwinReceiver(function(err,receiver1) {
-        assert.isNull(err);
-        process.nextTick(function() {
-          transport.getTwinReceiver(function(err,receiver2) {
-            assert.isNull(err);
-            assert.equal(receiver1,receiver2);
-            assert.instanceOf(receiver1, MqttTwinReceiver);
-            done();
+      transport.connect(function () {
+        transport.getTwinReceiver(function(err,receiver1) {
+          assert.isNull(err);
+          process.nextTick(function() {
+            transport.getTwinReceiver(function(err,receiver2) {
+              assert.isNull(err);
+              assert.equal(receiver1,receiver2);
+              assert.instanceOf(receiver1, MqttTwinReceiver);
+              done();
+            });
           });
         });
       });
     });
   });
 
+  it('connects the transport if disconnected', function (testCallback) {
+    transport.getTwinReceiver(function () {
+      assert.isTrue(fakeMqttBase.connect.calledOnce);
+      testCallback();
+    });
+  });
+
+  it('calls the callback with an error if the transport fails to connect', function (testCallback) {
+    fakeMqttBase.connect = sinon.stub().callsArgWith(1, new Error('fake'));
+    transport.getTwinReceiver(function (err) {
+      assert.instanceOf(err, Error);
+      testCallback();
+    });
+  });
 });
 

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -80,7 +80,7 @@ describe('Mqtt', function () {
       });
     });
 
-    /*Tests_SRS_NODE_DEVICE_MQTT_16_025: [The `sendEvent` method shall be deferred until either disconnected or connected if it is called while `MqttBase` is establishing the connection.]*/
+    /*Tests_SRS_NODE_DEVICE_MQTT_16_025: [If `sendEvent` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the event.]*/
     it('waits until connected if called while connecting', function (testCallback) {
       var transport = new Mqtt(fakeConfig, fakeMqttBase);
       var connectCallback;
@@ -96,6 +96,7 @@ describe('Mqtt', function () {
       connectCallback();
     });
 
+    /*Tests_SRS_NODE_DEVICE_MQTT_16_035: [If `sendEvent` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then sendEvent shall fail.]*/
     it('calls the callback with an error if called while connecting and connecting fails', function (testCallback) {
       var transport = new Mqtt(fakeConfig, fakeMqttBase);
       var fakeError = new Error('test');
@@ -114,7 +115,7 @@ describe('Mqtt', function () {
       connectCallback(fakeError);
     });
 
-    /*Tests_SRS_NODE_DEVICE_MQTT_16_026: [The `sendEvent` method shall be deferred until disconnected if it is called while `MqttBase` is disconnecting.]*/
+    /*Tests_SRS_NODE_DEVICE_MQTT_16_026: [If `sendEvent` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the event. ]*/
     it('waits until disconnected to try to reconnect if called while disconnecting', function (testCallback) {
       var transport = new Mqtt(fakeConfig, fakeMqttBase);
       var disconnectCallback;


### PR DESCRIPTION
# Description of the problem
A lot of transport-specific issues are dealt with at the Device Client level, when really the device client shoudn't care.

# Description of the solution
This state machine pushes the management of connection, subscriptions and topics down in the MQTT transport, in preparation for a drastic simplification of the client that will lead the way for retry logic.
