### PR TITLE
Add enableC2D, disableC2D, enableMethods and disableMethods to the Mqtt object

### DIFF
--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -274,6 +274,10 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 
 **SRS_NODE_DEVICE_MQTT_16_049: [** `enableC2D` shall subscribe to the MQTT topic for messages. **]**
 
+**SRS_NODE_DEVICE_MQTT_16_050: [** `enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_052: [** `enableC2D` shall call its callback with an `Error` if subscribing to the topic fails. **]**
+
 ### enableMethods
 
 **SRS_NODE_DEVICE_MQTT_16_038: [** `enableMethods` shall connect the MQTT connection if it is disconnected. **]**
@@ -282,11 +286,17 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 
 **SRS_NODE_DEVICE_MQTT_16_040: [** `enableMethods` shall subscribe to the MQTT topic for direct methods. **]**
 
+**SRS_NODE_DEVICE_MQTT_16_051: [** `enableMethods` shall call its callback with no arguments when the `SUBACK` packet is received. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_053: [** `enableMethods` shall call its callback with an `Error` if subscribing to the topic fails. **]**
+
 ### disableC2D
 
 **SRS_NODE_DEVICE_MQTT_16_041: [** `disableC2D` shall call its callback immediately if the MQTT connection is already disconnected. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_042: [** `disableC2D` shall unsubscribe from the topic for C2D messages. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_054: [** `disableC2D` shall call its callback with no arguments when the `UNSUBACK` packet is received. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_043: [** `disableC2D` shall call its callback with an `Error` if an error is received while unsubscribing. **]**
 
@@ -295,5 +305,7 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 **SRS_NODE_DEVICE_MQTT_16_044: [** `disableMethods` shall call its callback immediately if the MQTT connection is already disconnected. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_045: [** `disableMethods` shall unsubscribe from the topic for direct methods. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_055: [** `disableMethods` shall call its callback with no arguments when the `UNSUBACK` packet is received. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_046: [** `disableMethods` shall call its callback with an `Error` if an error is received while unsubscribing. **]**

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -266,3 +266,34 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 **SRS_NODE_DEVICE_MQTT_18_007: [** If a twin receiver for this endpoint previously existed, the `getTwinReceiver` method should return the preexisting `MqttTwinReceiver` object as the second parameter of the `done` function with null as the first parameter. **]**
 
 
+### enableC2D
+
+**SRS_NODE_DEVICE_MQTT_16_047: [** `enableC2D` shall connect the MQTT connection if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_048: [** `enableC2D` shall calls its callback with an `Error` object if it fails to connect. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_049: [** `enableC2D` shall subscribe to the MQTT topic for messages. **]**
+
+### enableMethods
+
+**SRS_NODE_DEVICE_MQTT_16_038: [** `enableMethods` shall connect the MQTT connection if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_039: [** `enableMethods` shall calls its callback with an `Error` object if it fails to connect. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_040: [** `enableMethods` shall subscribe to the MQTT topic for direct methods. **]**
+
+### disableC2D
+
+**SRS_NODE_DEVICE_MQTT_16_041: [** `disableC2D` shall call its callback immediately if the MQTT connection is already disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_042: [** `disableC2D` shall unsubscribe from the topic for C2D messages. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_043: [** `disableC2D` shall call its callback with an `Error` if an error is received while unsubscribing. **]**
+
+### disableMethods
+
+**SRS_NODE_DEVICE_MQTT_16_044: [** `disableMethods` shall call its callback immediately if the MQTT connection is already disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_045: [** `disableMethods` shall unsubscribe from the topic for direct methods. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_046: [** `disableMethods` shall call its callback with an `Error` if an error is received while unsubscribing. **]**

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 81 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 81 --functions 92 --lines 95"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -161,7 +161,7 @@ export class Mqtt extends EventEmitter implements Client.Transport, StableConnec
           });
         }
       } else {
-        debug('new listener for which there\'s nothing to subscribe to: ' + eventName);
+        debug('nothing to unsubscribe for this event: ' + eventName);
       }
     });
 
@@ -360,21 +360,15 @@ export class Mqtt extends EventEmitter implements Client.Transport, StableConnec
             callback(null, this._twinReceiver);
           },
           enableC2D: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages.]*/
             this._setupSubscription(this._topics.message, callback);
           },
           enableMethods: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_040: [`enableMethods` shall subscribe to the MQTT topic for direct methods.]*/
             this._setupSubscription(this._topics.method, callback);
           },
           disableC2D: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_042: [`disableC2D` shall unsubscribe from the topic for C2D messages.]*/
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_043: [`disableC2D` shall call its callback with an `Error` if an error is received while unsubscribing.]*/
             this._removeSubscription(this._topics.message, callback);
           },
           disableMethods: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_045: [`disableMethods` shall unsubscribe from the topic for direct methods.]*/
-            /*Codes_SRS_NODE_DEVICE_MQTT_16_046: [`disableMethods` shall call its callback with an `Error` if an error is received while unsubscribing.]*/
             this._removeSubscription(this._topics.method, callback);
           }
         },
@@ -719,17 +713,31 @@ export class Mqtt extends EventEmitter implements Client.Transport, StableConnec
   private _setupSubscription(topic: TopicDescription, callback: (err?: Error) => void): void {
     debug('subscribe: ' + JSON.stringify(topic));
     topic.subscribeInProgress = true;
+
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages.]*/
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_040: [`enableMethods` shall subscribe to the MQTT topic for direct methods.]*/
     this._mqtt.subscribe(topic.name, { qos: 0 }, (err) => {
       topic.subscribeInProgress = false;
       topic.subscribed = true;
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_050: [`enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_051: [`enableMethods` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_052: [`enableC2D` shall call its callback with an `Error` if subscribing to the topic fails.]*/
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_053: [`enableMethods` shall call its callback with an `Error` if subscribing to the topic fails.]*/
       callback(err);
     });
   }
 
   private _removeSubscription(topic: TopicDescription, callback: (err?: Error) => void): void {
     debug('unsubscribe ' + JSON.stringify(topic));
+
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_042: [`disableC2D` shall unsubscribe from the topic for C2D messages.]*/
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_045: [`disableMethods` shall unsubscribe from the topic for direct methods.]*/
     this._mqtt.unsubscribe(topic.name, (err) => {
       topic.subscribed = !err;
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_054: [`disableC2D` shall call its callback with no arguments when the `UNSUBACK` packet is received.]*/
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_055: [`disableMethods` shall call its callback with no arguments when the `UNSUBACK` packet is received.]*/
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_043: [`disableC2D` shall call its callback with an `Error` if an error is received while unsubscribing.]*/
+      /*Codes_SRS_NODE_DEVICE_MQTT_16_046: [`disableMethods` shall call its callback with an `Error` if an error is received while unsubscribing.]*/
       callback(err);
     });
   }

--- a/device/transport/mqtt/test/_mqtt_receiver_test.js
+++ b/device/transport/mqtt/test/_mqtt_receiver_test.js
@@ -179,8 +179,8 @@ describe('Mqtt as MqttReceiver', function () {
         receiver.on('message', function () { });
 
         // assert
-        assert.isTrue(fakeMqttBase.on.calledTwice,
-        'fakeMqttBase.on was not called twice (error + message)');
+        assert.isTrue(fakeMqttBase.on.calledThrice,
+        'fakeMqttBase.on was not called twice (error + message + close)');
         assert.isTrue(fakeMqttBase.on.calledWith('error'),
         'fakeMqttBase.on was not called for "error" event');
         assert.isTrue(fakeMqttBase.on.calledWith('message'),
@@ -202,8 +202,8 @@ describe('Mqtt as MqttReceiver', function () {
         receiver.on('message', function () { });
 
         // assert
-        assert.isTrue(fakeMqttBase.on.calledTwice,
-          'mqttClient.on was not called twice (error + message)');
+        assert.isTrue(fakeMqttBase.on.calledThrice,
+          'mqttClient.on was not called twice (error + message + close)');
         assert.isTrue(fakeMqttBase.on.calledWith('message'),
           'mqttClient.on was not called for "message" event');
           assert.isTrue(fakeMqttBase.on.calledWith('error'),

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -596,12 +596,15 @@ describe('Mqtt', function () {
 
   ['enableC2D', 'enableMethods'].forEach(function (enableFeatureMethod) {
     describe('#' + enableFeatureMethod, function () {
-      /*Tests_SRS_NODE_DEVICE_MQTT_16_047: [`enableC2D` shall connect the MQTT connection if it is disconnected.]*/
-      /*Tests_SRS_NODE_DEVICE_MQTT_16_038: [`enableMethods` shall connect the MQTT connection if it is disconnected.]*/
       it('connects the transport if necessary', function (testCallback) {
         var transport = new Mqtt(fakeConfig, fakeMqttBase);
-        transport[enableFeatureMethod](function () {
+        transport[enableFeatureMethod](function (err) {
+          /*Tests_SRS_NODE_DEVICE_MQTT_16_047: [`enableC2D` shall connect the MQTT connection if it is disconnected.]*/
+          /*Tests_SRS_NODE_DEVICE_MQTT_16_038: [`enableMethods` shall connect the MQTT connection if it is disconnected.]*/
           assert.isTrue(fakeMqttBase.connect.calledOnce);
+          /*Tests_SRS_NODE_DEVICE_MQTT_16_050: [`enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
+          /*Tests_SRS_NODE_DEVICE_MQTT_16_051: [`enableMethods` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
+          assert.isUndefined(err);
           /*Tests_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages.]*/
           /*Tests_SRS_NODE_DEVICE_MQTT_16_040: [`enableMethods` shall subscribe to the MQTT topic for direct methods.]*/
           assert.isTrue(fakeMqttBase.subscribe.calledOnce);
@@ -618,6 +621,20 @@ describe('Mqtt', function () {
           assert.isTrue(fakeMqttBase.connect.calledOnce);
           assert.instanceOf(err, Error);
           testCallback();
+        });
+      });
+
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_052: [`enableC2D` shall call its callback with an `Error` if subscribing to the topic fails.]*/
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_053: [`enableMethods` shall call its callback with an `Error` if subscribing to the topic fails.]*/
+      it('calls its callback with an error if subscribing fails', function (testCallback) {
+        var transport = new Mqtt(fakeConfig, fakeMqttBase);
+        fakeMqttBase.subscribe = sinon.stub().callsArgWith(2, new Error('fake error'));
+        transport.connect(function () {
+          transport[enableFeatureMethod](function (err) {
+            assert.isTrue(fakeMqttBase.subscribe.calledOnce);
+            assert.instanceOf(err, Error);
+            testCallback();
+          });
         });
       });
     });
@@ -651,6 +668,23 @@ describe('Mqtt', function () {
               /*Tests_SRS_NODE_DEVICE_MQTT_16_045: [`disableMethods` shall unsubscribe from the topic for direct methods.]*/
               assert.isTrue(fakeMqttBase.unsubscribe.calledOnce);
               assert.instanceOf(err, Error);
+              testCallback();
+            });
+          });
+        });
+      });
+
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_054: [`disableC2D` shall call its callback with no arguments when the `UNSUBACK` packet is received.]*/
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_055: [`disableMethods` shall call its callback with no arguments when the `UNSUBACK` packet is received.]*/
+      it('unsubscribes and calls its callback', function (testCallback) {
+        var transport = new Mqtt(fakeConfig, fakeMqttBase);
+        transport.connect(function () {
+          transport[testConfig.enableFeatureMethod](function () {
+            transport[testConfig.disableFeatureMethod](function (err) {
+              /*Tests_SRS_NODE_DEVICE_MQTT_16_042: [`disableC2D` shall unsubscribe from the topic for C2D messages.]*/
+              /*Tests_SRS_NODE_DEVICE_MQTT_16_045: [`disableMethods` shall unsubscribe from the topic for direct methods.]*/
+              assert.isTrue(fakeMqttBase.unsubscribe.calledOnce);
+              assert.isUndefined(err);
               testCallback();
             });
           });


### PR DESCRIPTION
# Description of the problem
As with other transports we need to create a feedback channel from the transport to the client when enabling features that require persistent connections. 

# Description of the solution
This introduces methods and callbacks for C2D messaging and direct methods. Twin will come separately since it requires a bit of refactoring.
