### PR TITLE
Remove Device Client State Machine

### DIFF
--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -227,7 +227,7 @@ interface DeviceMethodEventHandler {
 
 **SRS_NODE_DEVICE_CLIENT_13_023: [** `onDeviceMethod` shall throw an `Error` if a listener is already subscribed for a given method call. **]**
 
-**SRS_NODE_DEVICE_CLIENT_13_021: [** `onDeviceMethod` shall throw an `Error` if the underlying transport does not support device methods. **]**
+**SRS_NODE_DEVICE_CLIENT_13_021: [** `onDeviceMethod` shall throw a `NotImplementedErrorError` if the underlying transport does not support device methods. **]**
 
 ### Events
 #### message

--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -80,17 +80,11 @@ client.sendEvent(new Message('hello world'), print);
 #### sendEvent(message, sendEventCallback)
 The `sendEvent` method sends an event message to the IoT Hub as the device indicated in the constructor argument.
 
-**SRS_NODE_DEVICE_CLIENT_16_081: [** The `sendEvent` method shall throw a `NotImplementedError` if the transport doesn't have that feature. **]**
-
 **SRS_NODE_DEVICE_CLIENT_05_002: [** The `sendEvent` method shall send the event (indicated by the `message` argument) via the transport associated with the Client instance. **]**
 
 **SRS_NODE_DEVICE_CLIENT_05_003: [** When the `sendEvent` method completes, the callback function (indicated by the `sendEventCallback` argument) shall be invoked with the same arguments as the underlying transport method's callback. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_047: [** The `sendEvent` method shall not throw if the `sendEventCallback` is not passed. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_048: [** The `sendEvent` method shall automatically connect the transport if necessary. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_049: [** If the transport fails to connect, the `sendEvent` method shall call the `sendEventCallback` method with the error returned while trying to connect. **]**
 
 #### sendEventBatch(messages, sendEventBatchCallback)
 The `sendEventBatch` method sends a list of event messages to the IoT Hub as the device indicated in the constructor argument.
@@ -102,10 +96,6 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 **SRS_NODE_DEVICE_CLIENT_07_005: [** When the `sendEventBatch` method completes the callback function shall be invoked with the same arguments as the underlying transport method's callback. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_051: [** The `sendEventBatch` method shall not throw if the `sendEventBatchCallback` is not passed. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_052: [** The `sendEventBatch` method shall automatically connect the transport if necessary. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_053: [** If the transport fails to connect, the `sendEventBatch` method shall call the `sendEventBatchCallback` method with the error returned while trying to connect. **]**
 
 #### setTransportOptions(options, done)
 **`setTransportOptions` is deprecated and will be removed at the next major release.**
@@ -133,8 +123,6 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 **SRS_NODE_DEVICE_CLIENT_16_016: [** The `complete` method shall throw a `ReferenceError` if the `message` parameter is falsy. **]**
 
-**SRS_NODE_DEVICE_CLIENT_16_078: [** The `complete` method shall throw a `NotImplementedError` if the transport doesn't have that feature. **]**
-
 **SRS_NODE_DEVICE_CLIENT_16_007: [** The `complete` method shall call the `complete` method of the transport with the message as an argument **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_008: [** The `completeCallback` callback shall be called with a `null` error object and a `MessageCompleted` result once the transport has completed the message. **]**
@@ -143,15 +131,9 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 **SRS_NODE_DEVICE_CLIENT_16_067: [** The `complete` method shall not throw if the `completeCallback` is not passed. **]**
 
-**SRS_NODE_DEVICE_CLIENT_16_068: [** The `complete` method shall automatically connect the transport if necessary. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_069: [** If the transport fails to connect, the `complete` method shall call the `completeCallback` method with the error returned while trying to connect. **]**
-
 #### reject(message, rejectCallback)
 
 **SRS_NODE_DEVICE_CLIENT_16_018: [** The `reject` method shall throw a ReferenceError if the `message` parameter is falsy. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_079: [** The `reject` method shall throw a `NotImplementedError` if the transport doesn't have that feature. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_010: [** The `reject` method shall call the `reject` method of the transport with the message as an argument **]**
 
@@ -161,15 +143,9 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 **SRS_NODE_DEVICE_CLIENT_16_071: [** The `reject` method shall not throw if the `rejectCallback` is not passed. **]**
 
-**SRS_NODE_DEVICE_CLIENT_16_072: [** The `reject` method shall automatically connect the transport if necessary. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_073: [** If the transport fails to connect, the `reject` method shall call the `rejectCallback` method with the error returned while trying to connect. **]**
-
 #### abandon(message, abandonCallback)
 
 **SRS_NODE_DEVICE_CLIENT_16_017: [** The `abandon` method shall throw a ReferenceError if the `message` parameter is falsy. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_080: [** The `abandon` method shall throw a `NotImplementedError` if the transport doesn't have that feature. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_013: [** The `abandon` method shall call the `abandon` method of the transport with the message as an argument **]**
 
@@ -179,10 +155,6 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 **SRS_NODE_DEVICE_CLIENT_16_075: [** The `abandon` method shall not throw if the `abandonCallback` is not passed. **]**
 
-**SRS_NODE_DEVICE_CLIENT_16_076: [** The `abandon` method shall automatically connect the transport if necessary. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_077: [** If the transport fails to connect, the `abandon` method shall call the `abandonCallback` method with the error returned while trying to connect. **]**
-
 #### updateSharedAccessSignature(sharedAccessSignature, done)
 
 **SRS_NODE_DEVICE_CLIENT_16_031: [** The `updateSharedAccessSignature` method shall throw a `ReferenceError` if the sharedAccessSignature parameter is falsy. **]**
@@ -190,10 +162,6 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 **SRS_NODE_DEVICE_CLIENT_06_002: [** The `updateSharedAccessSignature` method shall throw a `ReferenceError` if the client was created using x509. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_032: [** The `updateSharedAccessSignature` method shall call the `updateSharedAccessSignature` method of the transport currently in use with the sharedAccessSignature parameter. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_033: [** The `updateSharedAccessSignature` method shall reconnect the transport to the IoTHub service if it was connected before before the method is called. **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_034: [** The `updateSharedAccessSignature` method shall not reconnect when the 'needToReconnect' property of the result argument of the callback is false. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_035: [** The `updateSharedAccessSignature` method shall call the `done` callback with an error object if an error happened while renewing the token. **]**
 

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -9,23 +9,23 @@
   "dependencies": {
     "azure-iot-common": "1.2.0",
     "azure-iot-http-base": "1.2.0",
-    "azure-storage": "^2.0.0",
-    "debug": "^2.6.0",
+    "azure-storage": "^2.6.0",
+    "debug": "^3.1.0",
     "lodash": "^4.17.4",
     "machina": "^2.0.0",
     "traverse": "^0.6.6"
   },
   "devDependencies": {
-    "chai": "^3.5.0",
+    "chai": "^4.1.2",
     "istanbul": "^0.4.5",
-    "jshint": "^2.9.4",
+    "jshint": "^2.9.5",
     "mocha": "^3.2.0",
-    "sinon": "^1.17.7",
+    "sinon": "^4.0.1",
     "es5-shim": "^4.5.9",
-    "tslint": "^5.1.0",
-    "typescript": "2.2.2",
-    "@types/node": "^7.0.5",
-    "@types/debug": "0.0.29",
+    "tslint": "^5.7.0",
+    "typescript": "2.5.3",
+    "@types/node": "^8.0.37",
+    "@types/debug": "0.0.30",
     "@types/traverse": "^0.6.29"
   },
   "scripts": {
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 97 --branches 87 --lines 98 --functions 94"
+    "check-cover": "istanbul check-coverage --statements 97 --branches 88 --lines 98 --functions 93"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/client.ts
+++ b/device/core/src/client.ts
@@ -428,9 +428,9 @@ export class Client extends EventEmitter {
       throw new TypeError('callback\'s type is \'' + typeof(callback) + '\'. A function reference was expected.');
     }
 
-    // Codes_SRS_NODE_DEVICE_CLIENT_13_021: [ onDeviceMethod shall throw an Error if the underlying transport does not support device methods. ]
+    // Codes_SRS_NODE_DEVICE_CLIENT_13_021: [ onDeviceMethod shall throw an NotImplementedErrorError if the underlying transport does not support device methods. ]
     if (!((this._transport as DeviceMethodTransport).sendMethodResponse)) {
-      throw new Error('The transport for this client does not support device methods');
+      throw new errors.NotImplementedError('The transport for this client does not support device methods');
     }
 
     // Codes_SRS_NODE_DEVICE_CLIENT_13_023: [ onDeviceMethod shall throw an Error if a listener is already subscribed for a given method call. ]

--- a/device/core/src/interfaces.ts
+++ b/device/core/src/interfaces.ts
@@ -52,14 +52,9 @@ export interface MethodMessage {
  */
 export interface DeviceMethodTransport extends Client.Transport {
   sendMethodResponse(response: DeviceMethodResponse, done?: (err?: Error, result?: any) => void): void;
-}
-
-/**
- * @private
- * @deprecated
- */
-export interface DeviceMethodReceiver extends Receiver {
   onDeviceMethod(methodName: string, callback: (message: MethodMessage) => void): void;
+  enableMethods(callback: (err?: Error) => void): void;
+  disableMethods(callback: (err?: Error) => void): void;
 }
 
 /**

--- a/device/core/src/twin.ts
+++ b/device/core/src/twin.ts
@@ -6,7 +6,7 @@ import _ = require('lodash');
 import { EventEmitter } from 'events';
 import * as traverse from 'traverse';
 import * as dbg from 'debug';
-const debug = dbg('azure-iot-device.Twin');
+const debug = dbg('azure-iot-device:Twin');
 
 import { errors } from 'azure-iot-common';
 import { translateError } from './twin_errors';
@@ -53,15 +53,6 @@ export class Twin extends EventEmitter {
     super();
     this._client = client;
     this._rid = 4200; // arbitrary starting value.
-  }
-
-  /**
-   * @private
-   * used only by the client - no use for the SDK user.
-   */
-  updateSharedAccessSignature(): void {
-    this._receiver.removeAllListeners(Twin.responseEvent);
-    this._receiver.removeAllListeners(Twin.postEvent);
   }
 
   private _connectSubscribeAndGetProperties(done: (err?: Error, result?: Twin) => void): void {
@@ -332,11 +323,6 @@ export class Twin extends EventEmitter {
         throw new errors.NotImplementedError('transport does not support Twin');
       } else {
         client._twin = twin;
-        client.on('_connected', () => {
-          twin._connectSubscribeAndGetProperties(() => {
-            debug('Twin reconnected');
-          });
-        });
         twin._connectSubscribeAndGetProperties(done);
       }
     }

--- a/device/core/test/_client_test.js
+++ b/device/core/test/_client_test.js
@@ -621,7 +621,7 @@ describe('Client', function () {
       });
     });
 
-    // Tests_SRS_NODE_DEVICE_CLIENT_13_021: [ onDeviceMethod shall throw an Error if the underlying transport does not support device methods. ]
+    // Tests_SRS_NODE_DEVICE_CLIENT_13_021: [ onDeviceMethod shall throw an NotImplementedErrorError if the underlying transport does not support device methods. ]
     it('throws if underlying transport does not support device methods', function() {
       // setup
       var transport = new FakeTransport();
@@ -630,7 +630,7 @@ describe('Client', function () {
       // test & assert
       assert.throws(function() {
         client.onDeviceMethod('reboot', function() {});
-      });
+      }, errors.NotImplementedError);
     });
 
     it('emits an error if the transport fails to enable the methods feature', function (testCallback) {
@@ -722,8 +722,6 @@ describe('Client', function () {
         testCallback();
       })
 
-      // Calling 'on' twice to make sure it's called only once on the receiver.
-      // It works because the test will fail if the test callback is called multiple times, and it's called for every time the 'message' event is subscribed on the receiver.
       client.on('message', function () { });
       assert.isTrue(dummyTransport.enableC2D.calledOnce);
       client.removeAllListeners('message');

--- a/device/core/test/_twin_test.js
+++ b/device/core/test/_twin_test.js
@@ -39,8 +39,6 @@ var FakeReceiver = function() {
 };
 util.inherits(FakeReceiver, EventEmitter);
 
-
-
 var FakeTransport = function(receiver) {
   var self = this;
   this.status=200;
@@ -600,35 +598,4 @@ describe('Twin', function () {
     });
 
   });
-
-  it('updateSharedAccessSignature removes all listeners for the response and post events', function(done) {
-    var client = new FakeClient();
-    var removeAllListeners = sinon.spy(client._transport._receiver, "removeAllListeners");
-    Twin.fromDeviceClient(client, function(err, twin) {
-      if (err) return done(err);
-      twin.updateSharedAccessSignature();
-      assert(removeAllListeners.calledWith('response'));
-      assert(removeAllListeners.calledWith('post'));
-      done();
-    });
-
-  });
-
-  it('when _connected is fired, the twin object shall re-get and re-subscribe', function(done) {
-    var client = new FakeClient();
-    Twin.fromDeviceClient(client, function(err, twin) {
-      if (err) return done(err);
-      var on = sinon.spy(client._transport._receiver, "on");
-      twin.on('properties.desired', function() {
-        if (on.calledWith('response') && on.calledWith('post')) {
-          done();
-        }
-      });
-      process.nextTick(function() {
-        twin.updateSharedAccessSignature();
-        client.emit('_connected');
-      });
-    });
-  });
-
 });

--- a/device/core/test/fake_transport.js
+++ b/device/core/test/fake_transport.js
@@ -37,16 +37,20 @@ function FakeTransport() {
     callback(null, new results.MessageRejected());
   };
 
-  this.getReceiver = function (callback) {
-    callback(null, new EventEmitter());
-  };
-
   this.updateSharedAccessSignature = function (newSas, callback) {
     callback(null, new results.SharedAccessSignatureUpdated(false));
   };
 
   this.setOptions = function (newSas, callback) {
     callback(null, new results.TransportConfigured());
+  };
+
+  this.enableC2D = function (callback) {
+    callback();
+  };
+
+  this.disableC2D = function (callback) {
+    callback();
   };
 }
 

--- a/device/core/test/http_simulated.js
+++ b/device/core/test/http_simulated.js
@@ -4,6 +4,7 @@
 'use strict';
 
 var EventEmitter = require('events').EventEmitter;
+var util = require('util');
 var Message = require('azure-iot-common').Message;
 var ArgumentError = require('azure-iot-common').errors.ArgumentError;
 var SharedAccessSignature = require('../lib/shared_access_signature.js');
@@ -20,6 +21,7 @@ function makeError(statusCode) {
 }
 
 function SimulatedHttp(config) {
+  EventEmitter.call(this);
   this._receiver = null;
   this.handleRequest = function (done) {
     if (this._x509) {
@@ -46,6 +48,8 @@ function SimulatedHttp(config) {
   };
 }
 
+util.inherits(SimulatedHttp, EventEmitter);
+
 SimulatedHttp.prototype.setOptions = function() {
   this._x509 = true;
 };
@@ -66,11 +70,6 @@ SimulatedHttp.prototype.receive = function (done) {
   this.handleRequest(function (err, response) {
     done(err, err ? null : new Message(''), response);
   });
-};
-
-SimulatedHttp.prototype.getReceiver = function (done) {
-  if (!this._receiver) { this._receiver = new EventEmitter(); }
-  done(null, this._receiver);
 };
 
 SimulatedHttp.prototype.sendFeedback = function (feedbackAction, message, done) {

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -200,16 +200,6 @@ An new Amqp message shall be instantiated.
 
 **SRS_NODE_DEVICE_AMQP_16_028: [** The `getTwinReceiver` method shall call the `done` callback with the corresponding error if the transport fails connect or authenticate the AMQP connection. **]**
 
-### on('message', messageCallback)
-
-**SRS_NODE_DEVICE_AMQP_RECEIVER_16_003: [** The `Amqp` object shall listen to the `message` and error events of the underlying `ReceiverLink` object when it has listeners on its `message` event. **]**
-
-**SRS_NODE_DEVICE_AMQP_RECEIVER_16_008: [** The `Amqp` object shall remove the listeners on `message` and `error` events of the underlying `ReceiverLink` when no-one is listening to its own `message` event. **]**
-
-**SRS_NODE_DEVICE_AMQP_16_029: [** The `Amqp` object shall connect and authenticate the AMQP connection if necessary to attach the C2D `ReceiverLink` object. **]**
-
-**SRS_NODE_DEVICE_AMQP_16_030: [** The `Amqp` object shall attach the C2D `ReceiverLink` object if necessary to start receiving messages. **]**
-
 
 ### onDeviceMethod(methodName, methodCallback)
 

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 86  --lines 96 --functions 93"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 85  --lines 96 --functions 93"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 85  --lines 96 --functions 93"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 85  --lines 96 --functions 94"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -218,7 +218,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
             callback();
           },
           onDeviceMethod: (methodName, callback) => {
-            // TODO - confirm this is still what we want now that we have enableMethods
             /*Codes_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
@@ -368,12 +367,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           onDeviceMethod: (methodName, methodCallback) => {
             /*Codes_SRS_NODE_DEVICE_AMQP_16_022: [The `onDeviceMethod` method shall call the `onDeviceMethod` method on the `AmqpDeviceMethodClient` object with the same arguments.]*/
             this._deviceMethodClient.onDeviceMethod(methodName, methodCallback);
-            this._fsm.handle('enableMethods', (err) => {
-              if (err) {
-                debug('error while attaching the device method client: ' + err.toString());
-                // no need to emit anything: the general error handler registered in the constructor will do that for us.
-              }
-            });
           }
         },
         disconnecting: {

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -216,17 +216,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           disableTwin: (callback) => {
             // if we are disconnected the C2D link is already detached.
             callback();
-          },
-          onDeviceMethod: (methodName, callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
-            this._fsm.handle('connect', (err, result) => {
-              if (err) {
-                /*Codes_SRS_NODE_DEVICE_AMQP_16_023: [An `error` event shall be emitted by the Amqp object if the transport fails to connect while registering a method callback.]*/
-                this.emit('error', err);
-              } else {
-                this._fsm.handle('onDeviceMethod', methodName, callback);
-              }
-            });
           }
         },
         connecting: {
@@ -363,10 +352,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
             /*Codes_SRS_NODE_DEVICE_AMQP_16_049: [The `disableTwin` method shall call `detach` on the twin links and call its callback when these are successfully detached.]*/
             /*Codes_SRS_NODE_DEVICE_AMQP_16_050: [The `disableTwin` method shall call its `callback` with an `Error` if it fails to detach the twin links.]*/
             this._twinClient.detach(callback);
-          },
-          onDeviceMethod: (methodName, methodCallback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_022: [The `onDeviceMethod` method shall call the `onDeviceMethod` method on the `AmqpDeviceMethodClient` object with the same arguments.]*/
-            this._deviceMethodClient.onDeviceMethod(methodName, methodCallback);
           }
         },
         disconnecting: {
@@ -592,7 +577,8 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
    */
   /*Codes_SRS_NODE_DEVICE_AMQP_RECEIVER_16_007: [The `onDeviceMethod` method shall forward the `methodName` and `methodCallback` arguments to the underlying `AmqpDeviceMethodClient` object.]*/
   onDeviceMethod(methodName: string, methodCallback: (request: DeviceMethodRequest, response: DeviceMethodResponse) => void): void {
-    this._fsm.handle('onDeviceMethod', methodName, methodCallback);
+    /*Codes_SRS_NODE_DEVICE_AMQP_16_022: [The `onDeviceMethod` method shall call the `onDeviceMethod` method on the `AmqpDeviceMethodClient` object with the same arguments.]*/
+    this._deviceMethodClient.onDeviceMethod(methodName, methodCallback);
   }
 
   /**

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -5,7 +5,7 @@
 import * as machina from 'machina';
 import * as async from 'async';
 import * as dbg from 'debug';
-const debug = dbg('device-amqp:amqp');
+const debug = dbg('azure-iot-device-amqp:Amqp');
 import { EventEmitter } from 'events';
 
 import { ClientConfig, DeviceMethodRequest, DeviceMethodResponse, StableConnectionTransport, Client } from 'azure-iot-device';
@@ -81,22 +81,17 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
     this._deviceMethodClient = new AmqpDeviceMethodClient(this._config, this._amqp);
     /*Codes_SRS_NODE_DEVICE_AMQP_16_041: [Any `error` event received on any of the links used for device methods shall trigger the emission of an `error` event by the transport, with an argument that is a `MethodsDetachedError` object with the `innerError` property set to that error.]*/
     this._deviceMethodClient.on('error', (err) => {
-      this.emit('errorReceived', err); // this will be removed as we switch to the 'error' event instead.
-      // disabled until the client is capable of handling those
-      // at that point the existing errorReceived events should be removed or converted to normal errors
-      // let methodsError = new errors.DeviceMethodsDetachedError('Device Methods AMQP links failed');
-      // methodsError.innerError = err;
-      // this.emit('error', methodsError);
+      let methodsError = new errors.DeviceMethodsDetachedError('Device Methods AMQP links failed');
+      methodsError.innerError = err;
+      this.emit('error', methodsError);
     });
 
     this._twinClient = new AmqpTwinClient(this._config, this._amqp);
     /*Codes_SRS_NODE_DEVICE_AMQP_16_048: [Any `error` event received on any of the links used for twin shall trigger the emission of an `error` event by the transport, with an argument that is a `TwinDetachedError` object with the `innerError` property set to that error.]*/
-    this._deviceMethodClient.on('error', (err) => {
-      // disabled until the client is capable of handling those
-      // at that point the existing errorReceived events should be removed or converted to normal errors
-      // let twinError = new errors.TwinDetachedError('Twin AMQP links failed');
-      // twinError.innerError = err;
-      // this.emit('error', twinError);
+    this._twinClient.on('error', (err) => {
+      let twinError = new errors.TwinDetachedError('Twin AMQP links failed');
+      twinError.innerError = err;
+      this.emit('error', twinError);
     });
 
     this._c2dEndpoint = endpoint.messagePath(encodeURIComponent(this._config.deviceId));
@@ -105,11 +100,9 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
     /*Codes_SRS_NODE_DEVICE_AMQP_16_034: [Any `error` event received on the C2D link shall trigger the emission of an `error` event by the transport, with an argument that is a `C2DDetachedError` object with the `innerError` property set to that error.]*/
     this._c2dErrorListener = (err) => {
       debug('Error on the C2D link: ' + err.toString());
-      // disabled until the client is capable of handling those
-      // at that point the existing errorReceived events should be removed or converted to normal errors
-      // let c2dError = new errors.CloudToDeviceDetachedError('Cloud-to-device AMQP link failed');
-      // c2dError.innerError = err;
-      // this.emit('error', c2dError);
+      let c2dError = new errors.CloudToDeviceDetachedError('Cloud-to-device AMQP link failed');
+      c2dError.innerError = err;
+      this.emit('error', c2dError);
     };
 
     this._c2dMessageListener = (msg) => {
@@ -120,39 +113,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
       debug('Error on the D2C link: ' + err.toString());
       // we don't really care because we can reattach the link every time we send and surface the error at that time.
     };
-
-    /*Codes_SRS_NODE_DEVICE_AMQP_RECEIVER_16_008: [The `Amqp` object shall remove the listeners on `message` and `error` events of the underlying `ReceiverLink` when no-one is listening to its own `message` event.]*/
-    this.on('removeListener', (eventName, eventCallback) => {
-      if (eventName === 'message' && this.listeners('message').length === 0) {
-        debug('automatically detaching the link after the last message listener was removed');
-        this._fsm.handle('disableC2D', (err) => {
-          if (err) {
-            this.emit('errorReceived', err);
-          }
-        });
-      } else {
-        debug('removing listener for event: ' + eventName);
-      }
-    });
-
-    /*Codes_SRS_NODE_DEVICE_AMQP_RECEIVER_16_003: [The `Amqp` object shall listen to the `message` and error events of the underlying `ReceiverLink` object when it has listeners on its `message` event.]*/
-    this.on('newListener', (eventName, eventCallback) => {
-      debug('registering new event handler for: ' + eventName);
-      if (eventName === 'message') {
-        if (this.listeners('message').length === 0) {
-          debug('automatically attaching the link after the first message listener was registered');
-          this._fsm.handle('enableC2D', (err) => {
-            debug('C2D link attached automatically');
-            if (err) {
-              debug('error attaching the C2D link automatically: ' + err.toString());
-              this.emit('errorReceived', err);
-            }
-          });
-        }
-      } else {
-        debug('adding listener for event: ' + eventName);
-      }
-    });
 
     this._fsm = new machina.Fsm({
       initialState: 'disconnected',
@@ -165,6 +125,8 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
               } else {
                 callback(null, new results.Disconnected());
               }
+            } else if (err) {
+              this.emit('error', err);
             }
           },
           connect: (connectCallback) => this._fsm.transition('connecting', connectCallback),
@@ -209,7 +171,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_031: [The `enableC2D` method shall connect and authenticate the transport if it is disconnected.]*/
           enableC2D: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_029: [The `Amqp` object shall connect and authenticate the AMQP connection if necessary to attach the C2D `ReceiverLink` object.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
                 /*Codes_SRS_NODE_DEVICE_AMQP_16_033: [The `enableC2D` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach link.]*/
@@ -226,7 +187,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_038: [The `enableMethods` method shall connect and authenticate the transport if it is disconnected.]*/
           enableMethods: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_029: [The `Amqp` object shall connect and authenticate the AMQP connection if necessary to attach the C2D `ReceiverLink` object.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
                 /*Codes_SRS_NODE_DEVICE_AMQP_16_040: [The `enableMethods` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach method links.]*/
@@ -243,7 +203,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_045: [The `enableTwin` method shall connect and authenticate the transport if it is disconnected.]*/
           enableTwin: (callback) => {
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_029: [The `Amqp` object shall connect and authenticate the AMQP connection if necessary to attach the C2D `ReceiverLink` object.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
                 /*Codes_SRS_NODE_DEVICE_AMQP_16_047: [The `enableTwin` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach twin links.]*/
@@ -259,11 +218,12 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
             callback();
           },
           onDeviceMethod: (methodName, callback) => {
+            // TODO - confirm this is still what we want now that we have enableMethods
             /*Codes_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
             this._fsm.handle('connect', (err, result) => {
               if (err) {
-                /*Codes_SRS_NODE_DEVICE_AMQP_16_023: [An `errorReceived` event shall be emitted by the Amqp object if the transport fails to connect while registering a method callback.]*/
-                this.emit('errorReceived', err);
+                /*Codes_SRS_NODE_DEVICE_AMQP_16_023: [An `error` event shall be emitted by the Amqp object if the transport fails to connect while registering a method callback.]*/
+                this.emit('error', err);
               } else {
                 this._fsm.handle('onDeviceMethod', methodName, callback);
               }
@@ -365,7 +325,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
           },
           enableC2D: (callback) => {
             debug('attaching C2D link');
-            /*Codes_SRS_NODE_DEVICE_AMQP_16_030: [The `Amqp` object shall attach the C2D `ReceiverLink` object if necessary to start receiving messages.]*/
             this._amqp.attachReceiverLink(this._c2dEndpoint, null, (err, receiverLink) => {
               if (err) {
                 debug('error creating a C2D link: ' + err.toString());
@@ -524,18 +483,6 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
   /* Codes_SRS_NODE_DEVICE_AMQP_16_004: [If sendEvent encounters an error before it can send the request, it shall invoke the done callback function and pass the standard JavaScript Error object with a text description of the error (err.message). ] */
   sendEvent(message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void {
     this._fsm.handle('sendEvent', message, done);
-  }
-
-  /**
-   * @deprecated          Deprecating the receiver pattern in order to prepare for a cleaner transport layer that accomodates retry logic. use the Amqp object directly as a receiver now. it has the same APIs.
-   * @private
-   * @method              module:azure-iot-device-amqp.Amqp#getReceiver
-   * @description         Gets the {@linkcode AmqpReceiver} object that can be used to receive messages from the IoT Hub instance and accept/reject/release them.
-   * @param {Function}  done      Callback used to return the {@linkcode AmqpReceiver} object.
-   */
-  /*Codes_SRS_NODE_DEVICE_AMQP_16_021: [The `getReceiver` method shall call the `done` callback with a first argument that is `null` and a second argument that it `this`, ie the current `Amqp` instance.]*/
-  getReceiver(done: (err?: Error, receiver?: Receiver) => void): void {
-    done(null, this);
   }
 
   /**
@@ -743,25 +690,30 @@ export class Amqp extends EventEmitter implements Client.Transport, StableConnec
   private _stopC2DListener(err: Error | undefined, callback: (err?: Error) => void): void {
     const tmpC2DLink = this._c2dLink;
     this._c2dLink = undefined;
-    if (err) {
-      debug('forceDetaching C2D link');
-      tmpC2DLink.forceDetach(err);
-      // detaching listeners and getting rid of the object anyway.
-      tmpC2DLink.removeListener('error', this._c2dErrorListener);
-      tmpC2DLink.removeListener('message', this._c2dMessageListener);
-    } else {
-      tmpC2DLink.detach((err) => {
-        if (err) {
-          debug('error detaching C2D link: ' + err.toString());
-        } else {
-          debug('C2D link successfully detached');
-        }
-
+    if (tmpC2DLink) {
+      if (err) {
+        debug('forceDetaching C2D link');
+        tmpC2DLink.forceDetach(err);
         // detaching listeners and getting rid of the object anyway.
         tmpC2DLink.removeListener('error', this._c2dErrorListener);
         tmpC2DLink.removeListener('message', this._c2dMessageListener);
-        callback(err);
-      });
+      } else {
+        tmpC2DLink.detach((err) => {
+          if (err) {
+            debug('error detaching C2D link: ' + err.toString());
+          } else {
+            debug('C2D link successfully detached');
+          }
+
+          // detaching listeners and getting rid of the object anyway.
+          tmpC2DLink.removeListener('error', this._c2dErrorListener);
+          tmpC2DLink.removeListener('message', this._c2dMessageListener);
+          callback(err);
+        });
+      }
+    } else {
+      debug('No C2D Link to detach');
+      callback();
     }
   }
 }

--- a/device/transport/amqp/src/amqp_device_method_client.ts
+++ b/device/transport/amqp/src/amqp_device_method_client.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import * as machina  from 'machina';
 import * as async from 'async';
 import * as dbg from 'debug';
-const debug = dbg('azure-iot-device-amqp.AmqpDeviceMethodClient');
+const debug = dbg('azure-iot-device-amqp:AmqpDeviceMethodClient');
 
 import { Message, errors, endpoint } from 'azure-iot-common';
 import { ClientConfig, DeviceMethodRequest, DeviceMethodResponse } from 'azure-iot-device';
@@ -60,9 +60,8 @@ export class AmqpDeviceMethodClient extends EventEmitter {
             } else {
               if (err) {
                 debug('detached with error: ' + err.toString());
-                // This is the right thing to do but breaks the client until we have retry logic. deactivating for now.
                 /*Codes_SRS_NODE_AMQP_DEVICE_METHOD_CLIENT_16_015: [The `AmqpDeviceMethodClient` object shall forward any error received on a link to any listening client in an `error` event.]*/
-                // this.emit('error', err);
+                this.emit('error', err);
               }
             }
           },

--- a/device/transport/amqp/src/amqp_twin_client.ts
+++ b/device/transport/amqp/src/amqp_twin_client.ts
@@ -12,7 +12,7 @@ import { ClientConfig } from 'azure-iot-device';
 
 import * as uuid from 'uuid';
 import * as dbg from 'debug';
-const debug = dbg('azure-iot-device:twin');
+const debug = dbg('azure-iot-device-amqp:AmqpTwinClient');
 
 const responseTopic = '$iothub/twin/res';
 

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -130,69 +130,6 @@ describe('Amqp', function () {
     });
 
     describe('#onDeviceMethod', function () {
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
-      it('registers the callback and connects the transport if disconnected', function (testCallback) {
-        var fakeMethodRequest = {
-          requestId: 'foo',
-          payload: { key: 'value' },
-          methodName: 'fakeMethod'
-        }
-
-        transport.onDeviceMethod(fakeMethodRequest.methodName, function (methodRequest) {
-          assert.strictEqual(methodRequest, fakeMethodRequest)
-          testCallback();
-        });
-
-        transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
-      it('registers the callback and defers until connected or disconnected if called while connecting', function (testCallback) {
-        var fakeMethodRequest = {
-          requestId: 'foo',
-          payload: { key: 'value' },
-          methodName: 'fakeMethod'
-        }
-
-        var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake((uri, sslOptions, callback) => {
-          connectCallback = callback;
-        });
-
-        transport.connect(function () {});
-
-        transport.onDeviceMethod(fakeMethodRequest.methodName, function () {
-          testCallback();
-        });
-
-        connectCallback();
-        transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
-      it('registers the callback and connects the transport if already connected but not authenticated yet', function (testCallback) {
-        var fakeMethodRequest = {
-          requestId: 'foo',
-          payload: { key: 'value' },
-          methodName: 'fakeMethod'
-        }
-
-        var authCallback;
-        fakeBaseClient.initializeCBS = sinon.stub().callsFake((callback) => {
-          authCallback = callback;
-        });
-
-        transport.connect(function () {});
-
-        transport.onDeviceMethod(fakeMethodRequest.methodName, function () {
-          testCallback();
-        });
-
-        authCallback();
-        transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
       it('registers the callback and connects the transport if already connected and authenticated', function (testCallback) {
         var fakeMethodRequest = {
           requestId: 'foo',
@@ -204,46 +141,8 @@ describe('Amqp', function () {
           transport.onDeviceMethod(fakeMethodRequest.methodName, function () {
             testCallback();
           });
+          transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
         });
-
-        transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_021: [The`onDeviceMethod` method shall connect and authenticate the transport if necessary to start receiving methods.]*/
-      it('registers the callback and reconnects the transport if called while disconnecting', function (testCallback) {
-        var fakeMethodRequest = {
-          requestId: 'foo',
-          payload: { key: 'value' },
-          methodName: 'fakeMethod'
-        }
-        var disconnectCallback;
-        fakeBaseClient.disconnect = sinon.stub().callsFake((callback) => {
-          disconnectCallback = callback;
-        })
-
-        transport.connect(function () {
-          transport.disconnect(function () {});
-          assert(fakeBaseClient.connect.calledOnce);
-          transport.onDeviceMethod(fakeMethodRequest.methodName, function () {
-            assert(fakeBaseClient.connect.calledTwice);
-            testCallback();
-          });
-          disconnectCallback(null, new results.Disconnected());
-        });
-
-        transport._deviceMethodClient.emit('method_' + fakeMethodRequest.methodName, fakeMethodRequest);
-      });
-
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_023: [An `errorReceived` event shall be emitted by the Amqp object if the transport fails to connect while registering a method callback.]*/
-      it('emits an error event when it cannot connect the transport', function (testCallback) {
-        var fakeError = new Error('could not open');
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, fakeError)
-        transport.on('error', function (err) {
-          assert.strictEqual(err.amqpError, fakeError);
-          testCallback();
-        });
-
-        transport.onDeviceMethod('testMethod', function () {});
       });
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_024: [An `errorReceived` event shall be emitted by the `Amqp` object if an error is received on any of the `AmqpDeviceMethodClient` links.]*/
@@ -255,9 +154,10 @@ describe('Amqp', function () {
           testCallback();
         });
 
-        transport.onDeviceMethod('testMethod', function () {});
-
-        transport._deviceMethodClient.emit('error', fakeError);
+        transport.connect(function () {
+          transport.onDeviceMethod('testMethod', function () {});
+          transport._deviceMethodClient.emit('error', fakeError);
+        });
       });
     });
 

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -898,6 +898,9 @@ describe('Amqp', function () {
         });
       });
 
+      // This is being skipped because the error is not forwarded.
+      // Since we can reattach the link every time we send and surface the error at that time, I'm not sure it's useful to surface this to the client. it's just a transport-level thing at that point.
+      // If something is really bad and unrecoverable the failure will happen on the next sendEvent.
       it.skip('forwards errors from the D2C link', function (testCallback) {
         var fakeError = new Error('fake');
         transport.on('errorReceived', function (err) {

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -238,7 +238,7 @@ describe('Amqp', function () {
       it('emits an error event when it cannot connect the transport', function (testCallback) {
         var fakeError = new Error('could not open');
         fakeBaseClient.connect = sinon.stub().callsArgWith(2, fakeError)
-        transport.on('errorReceived', function (err) {
+        transport.on('error', function (err) {
           assert.strictEqual(err.amqpError, fakeError);
           testCallback();
         });
@@ -249,8 +249,9 @@ describe('Amqp', function () {
       /*Tests_SRS_NODE_DEVICE_AMQP_16_024: [An `errorReceived` event shall be emitted by the `Amqp` object if an error is received on any of the `AmqpDeviceMethodClient` links.]*/
       it('emits an error event when the receiver emits an errorReceived event', function (testCallback) {
         var fakeError = new Error('fake error');
-        transport.on('errorReceived', function (err) {
-          assert.strictEqual(err, fakeError);
+        transport.on('error', function (err) {
+          assert.strictEqual(err.innerError, fakeError);
+          assert.instanceOf(err, errors.DeviceMethodsDetachedError);
           testCallback();
         });
 
@@ -319,22 +320,21 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_040: [The `enableMethods` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach method links.]*/
-      // TODO: fix Twin code that emits error instead of calling callback.
-      it.skip('calls its callback with an Error if attaching the twin receiver link fails', function (testCallback) {
-        transport._deviceMethodClient.detach = sinon.stub().callsArgWith(0, new Error('fake failed to attach'));
+      it('calls its callback with an Error if attaching the method links fails', function (testCallback) {
+        var fakeError = new Error('fake failed to attach');
+        transport._deviceMethodClient.attach = sinon.stub().callsArgWith(0, fakeError);
         transport.connect(function () {
           assert(fakeBaseClient.attachReceiverLink.notCalled);
           transport.enableMethods(function (err) {
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._deviceMethodClient._methodEndpoint));
-            assert.instanceOf(err, Error);
+            assert.isTrue(transport._deviceMethodClient.attach.calledOnce);
+            assert.strictEqual(err, fakeError);
             testCallback();
           });
         });
       });
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_041: [Any `error` event received on any of the links used for device methods shall trigger the emission of an `error` event by the transport, with an argument that is a `MethodsDetachedError` object with the `innerError` property set to that error.]*/
-      // disabled until the client supports it
-      it.skip('emits a DeviceMethodsDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
+      it('emits a DeviceMethodsDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
         var fakeError = new Error('fake twin receiver link error');
         transport.on('error', function (err) {
           assert.instanceOf(err, errors.DeviceMethodsDetachedError);
@@ -523,35 +523,6 @@ describe('Amqp', function () {
           disconnectCallback();
         });
       });
-
-      it('attaches the C2D link if a listener is registered for the \'message\' event', function (testCallback) {
-        transport.on('message', function () {});
-        transport.connect(function () {
-          assert.isTrue(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
-          testCallback();
-        });
-      });
-
-      it('subscribes to the \'message\' event on the C2D link if a listener is registered for the \'message\' event', function (testCallback) {
-        var fakeReceiverLink = new EventEmitter();
-        var fakeMessageHandler = sinon.spy();
-        var fakeMessage = new Message('foo');
-        transport.on('message', fakeMessageHandler);
-
-        transport.connect(function () {
-          receiver.emit('message', fakeMessage);
-          assert(fakeMessageHandler.calledWith(fakeMessage));
-          testCallback();
-        });
-      });
-
-      it('subscribes to the \'error\' event on the C2D link', function (testCallback) {
-        transport.connect(function () {
-          transport.on('message', function () {});
-          assert.isTrue(receiver.on.calledWith('error'));
-          testCallback();
-        })
-      });
     });
 
     describe('#disconnect', function () {
@@ -628,11 +599,13 @@ describe('Amqp', function () {
         it('detaches the C2D link if it is attached', function (testCallback) {
           transport.connect(function () {
             transport.on('message', function () {});
-            transport.disconnect(function (err, result) {
-              assert.isTrue(receiver.removeListener.calledWith('message'));
-              assert.isTrue(receiver.removeListener.calledWith('error'));
-              assert.isTrue(receiver.detach.calledOnce);
-              testCallback();
+            transport.enableC2D(function () {
+              transport.disconnect(function (err, result) {
+                assert.isTrue(receiver.removeListener.calledWith('message'));
+                assert.isTrue(receiver.removeListener.calledWith('error'));
+                assert.isTrue(receiver.detach.calledOnce);
+                testCallback();
+              });
             });
           });
         });
@@ -925,7 +898,6 @@ describe('Amqp', function () {
         });
       });
 
-      // skipping until we have the logic in the device client to handle that
       it.skip('forwards errors from the D2C link', function (testCallback) {
         var fakeError = new Error('fake');
         transport.on('errorReceived', function (err) {
@@ -987,208 +959,16 @@ describe('Amqp', function () {
   });
 
   describe('C2D', function () {
-    describe('#on', function () {
-      describe('newListener', function () {
-        describe('if already connected', function () {
-          it('attaches the C2D link if a message listener is added and the transport is already connected', function (testCallback) {
-            transport.connect(function () {
-              assert(fakeBaseClient.attachReceiverLink.notCalled);
-              transport.on('message', function () {});
-              assert(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
-              testCallback();
-            });
-          });
-
-          it('reuses the existing C2D link if it is already attached', function (testCallback) {
-            transport.connect(function () {
-              transport.on('message', function () {});
-              transport.on('message', function () {});
-              assert(fakeBaseClient.attachReceiverLink.calledOnce);
-              testCallback();
-            });
-          });
-
-          it('emits an errorReceived event if the transport is connected but the link cannot be attached', function (testCallback) {
-            var fakeError = new Error('could not attach link');
-            var errorSpy = sinon.spy();
-            fakeBaseClient.attachReceiverLink = sinon.stub().callsArgWith(2, fakeError);
-
-            transport.on('errorReceived', function (err) {
-              assert(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
-              assert.strictEqual(err.amqpError, fakeError);
-              testCallback();
-            });
-
-            transport.connect(function () {
-              assert(fakeBaseClient.attachReceiverLink.notCalled);
-              transport.on('message', function () {});
-            });
-          });
-        });
-
-        describe('if not connected yet', function () {
-          /*Tests_SRS_NODE_DEVICE_AMQP_16_029: [The `Amqp` object shall connect and authenticate the AMQP connection if necessary to attach the C2D `ReceiverLink` object.]*/
-          it('automatically connects the transport', function () {
-            transport.on('message', function () {});
-            assert(fakeBaseClient.connect.calledOnce);
-            assert(fakeBaseClient.initializeCBS.calledOnce);
-            assert(fakeBaseClient.putToken.calledOnce);
-            assert(fakeBaseClient.attachReceiverLink.calledOnce);
-          });
-
-          /*Tests_SRS_NODE_DEVICE_AMQP_16_030: [The `Amqp` object shall attach the C2D `ReceiverLink` object if necessary to start receiving messages.]*/
-          it('attaches the C2D link when the transport is finally connected and authenticated (from disconnected)', function (testCallback) {
-            transport.on('message', function (msg) {
-              assert.strictEqual(msg, fakeMessage);
-            });
-
-            transport.connect(function () {
-              assert(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
-              testCallback();
-              receiver.emit('message', fakeMessage);
-            });
-          });
-
-          it('attaches the C2D link when the transport is finally connected and authenticated (from connecting)', function (testCallback) {
-            var fakeMessage = new Message('fake');
-            var connectCallback;
-            fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, callback) {
-              connectCallback = callback;
-            });
-
-            receiver.on('newListener', function (eventName, listener) {
-              if (eventName === 'message') {
-                assert.isTrue(fakeBaseClient.attachReceiverLink.calledOnce);
-                testCallback();
-              }
-            });
-
-            transport.connect(function () {});
-
-            // now in the "connecting" state
-            transport.on('message', function () {});
-
-            connectCallback(null, new results.Connected());
-          });
-
-          it('attaches the C2D link when the transport is finally connected and authenticated (from authenticating)', function (testCallback) {
-            var fakeMessage = new Message('fake');
-            var authCallback;
-            fakeBaseClient.putToken = sinon.stub().callsFake(function (token, audience, callback) {
-              authCallback = callback;
-            });
-
-            receiver.on('newListener', function (eventName, listener) {
-              if (eventName === 'message') {
-                assert.isTrue(fakeBaseClient.attachReceiverLink.calledOnce);
-                testCallback();
-              }
-            });
-
-            transport.connect(function () {});
-
-            // now in the "authenticating" state
-            transport.on('message', function () {});
-
-            authCallback(null, new results.Connected());
-          });
-
-          it('forwards messages to the client once connected and authenticated', function (testCallback) {
-            var fakeMessage = new Message('fake');
-
-            transport.on('message', function (msg) {
-              assert.strictEqual(msg, fakeMessage);
-              testCallback();
-            });
-
-            transport.connect(function () {
-              receiver.emit('message', fakeMessage);
-            });
-          });
-
-          it.skip('forwards errors to the client once connected and authenticated', function (testCallback) {
-            transport.on('errorReceived', function (err) {
-              assert.strictEqual(err, fakeError);
-              testCallback();
-            });
-
-            transport.on('message', function () {});
-            transport.connect(function () {
-              receiver.emit('error', fakeError);
-            });
-          });
-
-          it('emits an error if attaching the transport fails to connect', function (testCallback) {
-            var fakeError = new Error('could not connect');
-            fakeBaseClient.connect = sinon.stub().callsArgWith(2, fakeError);
-
-            transport.on('errorReceived', function (err) {
-              assert.strictEqual(err.amqpError, fakeError);
-              testCallback();
-            });
-            transport.on('message', function () {});
-          });
-
-          it('emits an error if attaching the link fails to attach', function (testCallback) {
-            var fakeError = new Error('could not attach link');
-            fakeBaseClient.attachReceiverLink = sinon.stub().callsArgWith(2, fakeError);
-
-            transport.on('errorReceived', function (err) {
-              assert.strictEqual(err.amqpError, fakeError);
-              assert(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
-              testCallback();
-            });
-            transport.on('message', function () {});
-          });
-        });
-      });
-
-      describe('removeListener', function () {
-        it('does not crash trying to remove listener while already disconnected', function () {
-          assert.doesNotThrow(function () {
-            transport.removeListener('message', function () {});
-          })
-        })
-
-        it('detaches the C2D link if no-one is listening for messages', function (testCallback) {
-          var listener1 = function () {};
-          var listener2 = function () {};
-          transport.on('message', listener1);
-          transport.on('message', listener2);
-          transport.connect(function () {
-            assert(fakeBaseClient.attachReceiverLink.calledOnce);
-            transport.removeListener('message', listener1);
-            assert(receiver.detach.notCalled);
-            transport.removeListener('message', listener2);
-            assert(receiver.detach.calledOnce);
-            testCallback();
-          });
-        });
-
-        it('emits an error if detaching the C2D link generates an error', function (testCallback) {
-          var fakeError = new Error('fake');
-          var msgCallback = function () {};
-          receiver.detach = sinon.stub().callsArgWith(0, fakeError);
-          transport.on('errorReceived', function (err) {
-            assert.strictEqual(err, fakeError);
-            testCallback();
-          })
-          transport.on('message', msgCallback);
-          transport.connect(function () {
-            transport.removeListener('message', msgCallback);
-          });
-        });
-      });
-    });;
-
     describe('#complete', function () {
       /*Tests_SRS_NODE_DEVICE_AMQP_16_013: [The ‘complete’ method shall call the ‘complete’ method of the receiver object and pass it the message and the callback given as parameters.] */
       it('calls the receiver `complete` method', function (testCallback) {
         transport.connect(function () {
           transport.on('message', function () {});
-          transport.complete(testMessage, function () {
-            assert(receiver.complete.calledWith(testMessage));
-            testCallback();
+          transport.enableC2D(function () {
+            transport.complete(testMessage, function () {
+              assert(receiver.complete.calledWith(testMessage));
+              testCallback();
+            });
           });
         });
       });
@@ -1206,9 +986,11 @@ describe('Amqp', function () {
       it('calls the receiver `reject` method', function (testCallback) {
         transport.connect(function () {
           transport.on('message', function () {});
-          transport.reject(testMessage, function () {
-            assert(receiver.reject.calledWith(testMessage));
-            testCallback();
+          transport.enableC2D(function () {
+            transport.reject(testMessage, function () {
+              assert(receiver.reject.calledWith(testMessage));
+              testCallback();
+            });
           });
         });
       });
@@ -1226,9 +1008,11 @@ describe('Amqp', function () {
       it('calls the receiver `abandon` method', function (testCallback) {
         transport.connect(function () {
           transport.on('message', function () {});
-          transport.abandon(testMessage, function () {
-            assert(receiver.abandon.calledWith(testMessage));
-            testCallback();
+          transport.enableC2D(function () {
+            transport.abandon(testMessage, function () {
+              assert(receiver.abandon.calledWith(testMessage));
+              testCallback();
+            });
           });
         });
       });
@@ -1263,6 +1047,15 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_033: [The `enableC2D` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach link.]*/
+      it('calls its callback with an Error if connecting the transport fails', function (testCallback) {
+        fakeBaseClient.connect = sinon.stub().callsArgWith(2, new Error('fake failed to connect'));
+        transport.enableC2D(function (err) {
+          assert(fakeBaseClient.connect.calledOnce);
+          assert.instanceOf(err, Error);
+          testCallback();
+        });
+      });
+
       it('calls its callback with an Error if attaching the C2D link fails', function (testCallback) {
         fakeBaseClient.attachReceiverLink = sinon.stub().callsArgWith(2, new Error('fake failed to attach'));
         transport.connect(function () {
@@ -1277,7 +1070,7 @@ describe('Amqp', function () {
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_034: [Any `error` event received on the C2D link shall trigger the emission of an `error` event by the transport, with an argument that is a `C2DDetachedError` object with the `innerError` property set to that error.]*/
       // disabled until the client supports it
-      it.skip('emits a CloudToDeviceDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
+      it('emits a CloudToDeviceDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
         var fakeError = new Error('fake C2D receiver link error');
         transport.on('error', function (err) {
           assert.instanceOf(err, errors.CloudToDeviceDetachedError);
@@ -1290,6 +1083,21 @@ describe('Amqp', function () {
           transport.enableC2D(function () {
             assert(fakeBaseClient.attachReceiverLink.calledWith(transport._c2dEndpoint));
             receiver.emit('error', fakeError);
+          });
+        });
+      });
+
+      it('forwards messages to the client once connected and authenticated', function (testCallback) {
+        var fakeMessage = new Message('fake');
+
+        transport.on('message', function (msg) {
+          assert.strictEqual(msg, fakeMessage);
+          testCallback();
+        });
+
+        transport.connect(function () {
+          transport.enableC2D(function () {
+            receiver.emit('message', fakeMessage);
           });
         });
       });
@@ -1640,22 +1448,19 @@ describe('Amqp', function () {
         });
       });
 
-      // TODO: fix Twin code that emits error instead of calling callback.
       /*Tests_SRS_NODE_DEVICE_AMQP_16_048: [Any `error` event received on any of the links used for twin shall trigger the emission of an `error` event by the transport, with an argument that is a `TwinDetachedError` object with the `innerError` property set to that error.]*/
-      it.skip('calls its callback with an Error if attaching the twin receiver link fails', function (testCallback) {
-        transport._twinClient.detach = sinon.stub().callsArgWith(0, new Error('fake failed to attach'));
+      it('calls its callback with an Error if attaching the twin receiver link fails', function (testCallback) {
+        transport._twinClient.attach = sinon.stub().callsArgWith(0, new Error('fake failed to attach'));
         transport.connect(function () {
-          assert(fakeBaseClient.attachReceiverLink.notCalled);
           transport.enableTwin(function (err) {
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
+            assert(transport._twinClient.attach.calledOnce);
             assert.instanceOf(err, Error);
             testCallback();
           });
         });
       });
 
-      // disabled until the client supports it
-      it.skip('emits a TwinDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
+      it('emits a TwinDetachedError with an innerError property if the link fails after being established correctly', function (testCallback) {
         var fakeError = new Error('fake twin receiver link error');
         transport.on('error', function (err) {
           assert.instanceOf(err, errors.TwinDetachedError);
@@ -1664,10 +1469,8 @@ describe('Amqp', function () {
         });
 
         transport.connect(function () {
-          assert(fakeBaseClient.attachReceiverLink.notCalled);
           transport.enableTwin(function () {
-            assert(fakeBaseClient.attachReceiverLink.calledWith(transport._twinClient._endpoint));
-            receiver.emit('error', fakeError);
+            transport._twinClient.emit('error', fakeError);
           });
         });
       });

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -98,13 +98,6 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_13_002: [** `sendEventBatch` shall prefix the key name for all message properties with the string **iothub-app**. **]**
 
-### getReceiver(done)
-
-the getReceiver method queries the client for an `HttpReceiver` object that can be used to receive messages and settle them.
-
-**SRS_NODE_DEVICE_HTTP_16_005: [**The `getReceiver` method shall call the `done` method passed as argument with the receiver object as a parameter**]**
-**SRS_NODE_DEVICE_HTTP_16_006: [**The `getReceiver` method shall return the same unique instance if called multiple times in a row**]**
-
 ### setOptions(options, done)
 
 **SRS_NODE_DEVICE_HTTP_16_004: [** The `setOptions` method shall call the `setOptions` method of the HTTP Receiver with the content of the `http.receivePolicy` property of the `options` parameter.**]**

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -33,7 +33,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 89 --branches 81 --lines 90 --functions 83"
+    "check-cover": "istanbul check-coverage --statements 91 --branches 82 --lines 93 --functions 86"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -85,21 +85,6 @@ export class Http extends EventEmitter implements Client.Transport, BatchingTran
     this._opts = defaultOptions;
     this._receiverStarted = false;
 
-    this.on('removeListener', () => {
-      if (this._receiverStarted && this.listeners('message').length === 0) {
-        this.disableC2D(() => {
-          debug('Http c2d message polling disabled');
-        });
-      }
-    });
-
-    this.on('newListener', (eventName) => {
-      if (!this._receiverStarted && eventName === 'message') {
-        this.enableC2D(() => {
-          debug('Http c2d message polling enabled');
-        });
-      }
-    });
   }
 
   /**
@@ -265,18 +250,6 @@ export class Http extends EventEmitter implements Client.Transport, BatchingTran
   }
 
   /**
-   * @deprecated      The receiver pattern is deprecated and `Http` now implements what was `HttpReceiver`
-   * @private
-   * @method          module:azure-iot-device-http.Http#getReceiver
-   * @description     This methods gets the unique instance of the receiver that is used to asynchronously retrieve messages from the IoT Hub service.
-   *
-   * @param {Function}      done      The callback to be invoked when `getReceiver` completes execution, passing the receiver object as an argument.
-   */
-  getReceiver(done: (err?: Error, result?: Receiver) => void): void {
-    done(null, this);
-  }
-
-  /**
    * @private
    * @method          module:azure-iot-device-http.Http#setOptions
    * @description     This methods sets the HTTP specific options of the transport.
@@ -355,8 +328,7 @@ export class Http extends EventEmitter implements Client.Transport, BatchingTran
         } else {
           (<any>err).response = res;
           (<any>err).responseBody = body;
-          // TODO: migrate to the `error` event when retry logic is implemented in the client.
-          this.emit('errorReceived', err);
+          this.emit('error', err);
         }
       });
       request.end();

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -377,7 +377,7 @@ describe('HttpReceiver', function () {
       var received = 0;
       receiver.on('message', function () {
         received++;
-        if (received === msgCount) {
+        if (received >= msgCount) {
           receiver.disableC2D(function () {});
           done();
         }

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -214,44 +214,6 @@ describe('Http', function () {
       });
     });
   });
-
-  describe('#on(\'message\')', function () {
-    it('enables the C2D link when a subscriber is added to the message event', function (testCallback) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
-      var fakeHttp = new FakeHttp();
-      fakeHttp.setMessageCount(1);
-      var http = new Http(config, fakeHttp);
-      var testEnv = this;
-
-      testEnv.clock = sinon.useFakeTimers();
-      http.setOptions({ interval: 5 });
-      http.on('message', function () {
-        testEnv.clock.restore();
-        testCallback();
-      });
-      testEnv.clock.tick(5001);
-    });
-  });
-
-  describe('#removeListener(\'message\')', function () {
-    it('stops the message polling timer', function (testCallback) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
-      var fakeHttp = new FakeHttp();
-      sinon.spy(fakeHttp, 'buildRequest');
-      var http = new Http(config, fakeHttp);
-      var testEnv = this;
-      var messageListener = function () {};
-
-      testEnv.clock = sinon.useFakeTimers();
-      http.setOptions({ interval: 5 });
-      http.on('message', messageListener);
-      http.removeListener('message', messageListener);
-      testEnv.clock.tick(5001);
-      assert(fakeHttp.buildRequest.notCalled);
-      testEnv.clock.restore();
-      testCallback();
-    });
-  });
 });
 
 describe('HttpReceiver', function () {
@@ -272,6 +234,7 @@ describe('HttpReceiver', function () {
 
     /*Tests_SRS_NODE_DEVICE_HTTP_RECEIVER_16_021: [If opts.interval is set, messages should be received repeatedly at that interval]*/
     it('receives messages after the set interval', function (done) {
+      var clock = this.clock;
       var messageCount = 2;
       var messageReceivedCount = 0;
       fakeHttp.setMessageCount(messageCount);
@@ -282,15 +245,19 @@ describe('HttpReceiver', function () {
           done();
         }
       });
-      this.clock.tick(4999);
-      assert.strictEqual(messageReceivedCount, 0);
-      this.clock.tick(5000);
-      assert.strictEqual(messageReceivedCount, 1);
-      this.clock.tick(1);
+      receiver.enableC2D(function () {
+        clock.tick(4999);
+        assert.strictEqual(messageReceivedCount, 0);
+        clock.tick(5000);
+        assert.strictEqual(messageReceivedCount, 1);
+        clock.tick(1);
+        receiver.disableC2D(function () {});
+      });
     });
 
     /*Tests_SRS_NODE_DEVICE_HTTP_RECEIVER_16_003: [if opts.at is set, messages shall be received at the Date and time specified.]*/
     it('receives messages at the set time', function (done) {
+      var clock = this.clock;
       var messageReceived = false;
       fakeHttp.setMessageCount(1);
       var inFiveSeconds = new Date((new Date()).getTime() + 5000);
@@ -299,13 +266,17 @@ describe('HttpReceiver', function () {
         messageReceived = true;
         done();
       });
-      this.clock.tick(4999);
-      assert.isFalse(messageReceived);
-      this.clock.tick(1);
+      receiver.enableC2D(function () {
+        clock.tick(4999);
+        assert.isFalse(messageReceived);
+        clock.tick(1);
+        receiver.disableC2D(function () {});
+      });
     });
 
     /*Tests_SRS_NODE_DEVICE_HTTP_RECEIVER_16_020: [If opts.cron is set messages shall be received according to the schedule described by the expression.]*/
     it('receives messages as configured with a cron string', function (done) {
+      var clock = this.clock;
       var messageReceivedCount = 0;
       var messageCount = 2;
       fakeHttp.setMessageCount(messageCount);
@@ -317,11 +288,14 @@ describe('HttpReceiver', function () {
           done();
         }
       });
-      this.clock.tick(59999);
-      assert.strictEqual(messageReceivedCount, 0);
-      this.clock.tick(60000);
-      assert.strictEqual(messageReceivedCount, 1);
-      this.clock.tick(1);
+      receiver.enableC2D(function () {
+        clock.tick(59999);
+        assert.strictEqual(messageReceivedCount, 0);
+        clock.tick(60000);
+        assert.strictEqual(messageReceivedCount, 1);
+        clock.tick(1);
+        receiver.disableC2D(function () {});
+      });
     });
   });
 
@@ -403,8 +377,32 @@ describe('HttpReceiver', function () {
       var received = 0;
       receiver.on('message', function () {
         received++;
-        if (received === msgCount) done();
+        if (received === msgCount) {
+          receiver.disableC2D(function () {});
+          done();
+        }
       });
+
+      receiver.enableC2D(function () {});
+    });
+
+    it('emits an error if the HTTP error fails', function (testCallback) {
+      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var fakeError = new Error();
+      fakeError.statusCode = 500;
+      var fakeHttp = {
+        buildRequest: function (method, path, httpHeaders, host, sslOptions, done) {
+          done(fakeError, { fake: 'response' }, 'fakeResponseBody')
+        }
+      };
+      var http = new Http(config, fakeHttp);
+      http.setOptions({ at: new Date(), drain: true });
+      http.on('error', function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+
+      http.enableC2D(function () {});
     });
   });
 
@@ -483,6 +481,20 @@ describe('HttpReceiver', function () {
         var receiver = new Http();
         receiver.setOptions({ interval: null, at: new Date(), cron: "* * * * *", manualPolling: false, drain: false });
       }, ArgumentError);
+    });
+
+    it('restarts the receiver if it is running', function (testCallback) {
+      var transport = new FakeHttp();
+      var http = new Http({ deviceId: 'deviceId', sharedAccessSignature: 'sharedAccessSignature' }, transport);
+      http.setOptions({ interval: 1, at: null, cron: null, drain: false });
+      http.enableC2D(function () {
+        sinon.spy(http, 'disableC2D');
+        sinon.spy(http, 'enableC2D');
+        http.setOptions({ interval: 1, at: null, cron: null, drain: true });
+        assert.isTrue(http.disableC2D.calledOnce);
+        assert.isTrue(http.enableC2D.calledOnce);
+        testCallback();
+      })
     });
   });
 

--- a/device/transport/mqtt/devdoc/mqtt_receiver_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_receiver_requirements.md
@@ -9,10 +9,6 @@ Object used to subscribe to the Cloud-to-Device messages endpoint and receive me
 
 ### Events
 
-**SRS_NODE_DEVICE_MQTT_RECEIVER_16_003: [** When a listener is added for the `message` event, the topic should be subscribed to. **]**
-
-**SRS_NODE_DEVICE_MQTT_RECEIVER_13_002: [** When a listener is added for the `method` event, the topic should be subscribed to. **]**
-
 **SRS_NODE_DEVICE_MQTT_RECEIVER_16_004: [** If there is a listener for the `message` event, a `message` event shall be emitted for each message received. **]**
 
 **SRS_NODE_DEVICE_MQTT_RECEIVER_13_003: [** If there is a listener for the `method` event, a `method_<METHOD NAME>` event shall be emitted for each message received. **]**
@@ -35,10 +31,6 @@ interface MethodMessage {
 **]**
 
 **SRS_NODE_DEVICE_MQTT_RECEIVER_16_005: [** When a `message` event is emitted, the parameter shall be of type `Message`. **]**
-
-**SRS_NODE_DEVICE_MQTT_RECEIVER_16_006: [** When there are no more listeners for the `message` event, the topic should be unsubscribed. **]**
-
-**SRS_NODE_DEVICE_MQTT_RECEIVER_13_004: [** When there are no more listeners for the `method` event, the topic should be unsubscribed. **]**
 
 **SRS_NODE_DEVICE_MQTT_RECEIVER_16_007: [** When a message is received, the receiver shall populate the generated `Message` object `properties` property with the user properties serialized in the topic. **]**
 

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 94 --branches 81 --functions 92 --lines 95"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 81 --functions 93 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/e2etests/test/sas_token_tests.js
+++ b/e2etests/test/sas_token_tests.js
@@ -4,12 +4,9 @@
 'use strict';
 
 var uuid = require('uuid');
-var assert = require('chai').assert;
 var Promise = require('bluebird');
 
 var serviceSdk = require('azure-iothub');
-var createDeviceClient = require('./testUtils.js').createDeviceClient;
-var closeDeviceServiceClients = require('./testUtils.js').closeDeviceServiceClients;
 var eventHubClient = require('azure-event-hubs').Client;
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-common').Message;
@@ -26,15 +23,15 @@ var runTests = function (hubConnectionString, deviceTransport, provisionedDevice
     }
 
     function thirtySecondsFromNow() {
-      const raw = (Date.now() / 1000) + 30;
+      var raw = (Date.now() / 1000) + 30;
       return Math.ceil(raw);
     }
 
     function createNewSas() {
-      var cs = ConnectionString.parse(provisionedDevice.connectionString)
-      var sas = SharedAccessSignature.create(cs.HostName, provisionedDevice.deviceId, cs.SharedAccessKey, thirtySecondsFromNow())
+      var cs = ConnectionString.parse(provisionedDevice.connectionString);
+      var sas = SharedAccessSignature.create(cs.HostName, provisionedDevice.deviceId, cs.SharedAccessKey, thirtySecondsFromNow());
       return sas.toString();
-    };
+    }
 
     it('Renews SAS after connection and is still able to receive C2D messages', function (testCallback) {
       this.timeout(60000);
@@ -48,7 +45,7 @@ var runTests = function (hubConnectionString, deviceTransport, provisionedDevice
         if (err) return testCallback(err);
 
         deviceClient.on('message', function (msg) {
-          deviceClient.complete(msg, function (err, result) {
+          deviceClient.complete(msg, function (err) {
             if (err) return testCallback(err);
 
             if (msg.data.toString() === beforeUpdateSas) {
@@ -58,7 +55,7 @@ var runTests = function (hubConnectionString, deviceTransport, provisionedDevice
                 serviceClient.send(provisionedDevice.deviceId, createTestMessage(afterUpdateSas), function (err) {
                   if (err) return testCallback(err);
                 });
-              })
+              });
             } else if (msg.data.toString() === afterUpdateSas) {
               deviceClient.close(function () {
                 serviceClient.close(function () {


### PR DESCRIPTION
# Description of the problem
Now that all transports have state machines, so the client state machine becomes redundant and a source of bugs. Let's remove it before we can move on to adding the actual retry logic.

# Description of the solution
The state machine has been removed from the device client class, which now makes use of the enable/disable feature methods of the transports. this means we get all errors from the transports either through callbacks or the error event, which means we'll be able to introduce the retry logic next.

I've left the end to end tests untouched to prove that this is not breaking changes (not with the public client API anyway, we are indeed breaking some of the internal contracts between the client and the transports). Actually I've even re-enabled a couple of them to prove robustness.