### PR TITLE
Added Twin export to module definition

### DIFF
--- a/service/iothub.d.ts
+++ b/service/iothub.d.ts
@@ -10,3 +10,4 @@ export { AmqpWs } from './lib/amqp_ws';
 export { DeviceMethodParams } from './lib/interfaces';
 export { JobClient } from './lib/job_client';
 export { Device } from './lib/device';
+export { Twin } from './lib/twin';


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
When using this library from a TypeScript project, I found it difficult to work with device twin information. Consider the following example:

```TypeScript
import { Registry } from 'azure-iothub';

const IOT_HUB_CONNECTION_STRING = process.env.IOT_HUB_CONNECTION_STRING;
if (typeof IOT_HUB_CONNECTION_STRING !== 'string') {
  throw new Error('Environment variable IOT_HUB_DEVICE_CONNECTION_STRING is not defined');
}
const registry = Registry.fromConnectionString(IOT_HUB_CONNECTION_STRING);
registry.getTwin(deviceId, (err, twin) => {
  // twin has type 'any' here
});
```

When getting twin information, all callbacks are typed to [Response.Callback](https://github.com/Azure/azure-iot-sdk-node/blob/master/service/src/registry.ts#L801), which casts the `twin` argument to type `any`. This means auto completion and type checking are disabled for this property.

Normally my workaround would be to explicitly specify the type in the callback signature, e.g.:

```TypeScript
import { Twin } from 'azure-iothub';

...

registry.getTwin(deviceId, (err, twin: Twin) => {
  // twin has type 'Twin' here
});
```

However, the `Twin` type is not exported anywhere that I could find in the module.

# Description of the solution

This solution is small and straightforward, it exports the `Twin` type from the main module so that the type definition can be used in user code, solving my problem.
