### PR TITLE
remove deprecated --type-check option in tslint npm script

### DIFF
--- a/common/core/package.json
+++ b/common/core/package.json
@@ -18,7 +18,7 @@
     "typescript": "2.0.6"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../tslint.json",
+    "lint": "tslint --project . -c ../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -28,7 +28,7 @@
     "typescript": "2.5.2"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/common/transport/http/package.json
+++ b/common/transport/http/package.json
@@ -21,7 +21,7 @@
     "@types/node": "^7.0.12"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -23,7 +23,7 @@
     "typescript": "2.5.2"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -29,7 +29,7 @@
     "@types/traverse": "^0.6.29"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../tslint.json",
+    "lint": "tslint --project . -c ../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot \"test/**/_*_test.js\"",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot \"test/**/_*_test*.js\"",

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -29,7 +29,7 @@
     "@types/debug": "0.0.30"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -25,7 +25,7 @@
     "@types/node": "^8.0.45"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -26,7 +26,7 @@
     "typescript": "2.5.2"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -22,7 +22,7 @@
     "@types/node": "^7.0.5"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../tslint.json",
+    "lint": "tslint --project . -c ../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/provisioning/service/package.json
+++ b/provisioning/service/package.json
@@ -23,7 +23,7 @@
     "@types/debug": "0.0.29"
   },
   "scripts": {
-    "lint": "tslint --exclude ./samples --type-check --project . -c ../../tslint.json",
+    "lint": "tslint --exclude ./samples --project . -c ../../tslint.json",
     "typings": "typings install",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^7.0.5"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^7.0.5"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/provisioning/transport/mqtt/package.json
+++ b/provisioning/transport/mqtt/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^7.0.5"
   },
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../../../tslint.json",
+    "lint": "tslint --project . -c ../../../tslint.json",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
     "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",

--- a/service/package.json
+++ b/service/package.json
@@ -27,7 +27,7 @@
     "uuid": "^2.0.1"
   },
   "scripts": {
-    "lint": "tslint --exclude ./samples --type-check --project . -c ../tslint.json",
+    "lint": "tslint --exclude ./samples --project . -c ../tslint.json",
     "typings": "typings install",
     "build": "tsc",
     "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",

--- a/ts-e2e/package.json
+++ b/ts-e2e/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "lint": "tslint --type-check --project . -c ../tslint.json",
+    "lint": "tslint --project . -c ../tslint.json",
     "pretest": "tsc",
     "test": "mocha ./lib/*.tests.js"
   },


### PR DESCRIPTION
# Description of the problem
The build emits warnings because we're using a deprecated tslint option (--type-check)

# Description of the solution
Remove the deprecated option since the type-checking now is default when using the --project option.