### PR TITLE
moving http_errors.ts to common in preparation to unify error mapping…

### DIFF
--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -13,6 +13,7 @@ export { Message }
 export { SharedAccessSignature } from './lib/shared_access_signature';
 export { RetryOperation } from './lib/retry_operation';
 export { RetryPolicy, NoRetry, ExponentialBackOffWithJitter } from './lib/retry_policy';
+export { httpTranslateError } from './lib/http_errors';
 
 // Typescript only, used by other modules in azure-iot-sdk
 export interface X509 {

--- a/common/core/common.js
+++ b/common/core/common.js
@@ -22,4 +22,5 @@ module.exports = {
   RetryPolicy: require('./lib/retry_policy.js').RetryPolicy,
   NoRetry: require('./lib/retry_policy.js').NoRetry,
   ExponentialBackOffWithJitter: require('./lib/retry_policy.js').ExponentialBackOffWithJitter,
+  httpTranslateError: require('./lib/http_errors.js').httpTranslateError
 };

--- a/common/core/devdoc/http_errors_requirements.md
+++ b/common/core/devdoc/http_errors_requirements.md
@@ -1,13 +1,14 @@
-# azure-iot-device-http.translateError Requirements
+# azure-iot-common.httpTranslateError Requirements
 
 ## Overview
-`translateError` is a method that translates HTTP errors into Azure IoT Hub errors, effectively abstracting the error that is returned to the SDK user of from the transport layer.
+`httpTtranslateError` is a method that translates HTTP errors into Azure IoT Hub errors, effectively abstracting the error that is returned to the SDK user of from the transport layer.
 
 ## Requirements
 
-**SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [** Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 3 properties:
-- `response` shall contain the `IncomingMessage` object returned by the HTTP layer.
-- `reponseBody` shall contain the content of the HTTP response.
+**SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [** Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 4 properties:
+- `statusCode` shall contain the http status code
+- `response` shall contain the protocol-specific response object itself
+- `responseBody` shall contain the body of the response, containing the explanation of why the request failed
 - `message` shall contain a human-readable error message **]**
 
 **SRS_NODE_DEVICE_HTTP_ERRORS_16_002: [** If the HTTP error code is unknown, `translateError` should return a generic Javascript `Error` object. **]**
@@ -26,7 +27,8 @@
 
 **SRS_NODE_DEVICE_HTTP_ERRORS_16_009: [** `translateError` shall return an `ServiceUnavailableError` if the HTTP response status code is `503`. **]**
 
-**SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [** `translateError` shall accept 3 arguments:
+**SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [** `translateError` shall accept 4 arguments:
 - A custom error message to give context to the user.
-- the body of  the HTTP response, containing the explanation of why the request failed
-- the HTTP response object itself **]**
+- The status code
+- the body of the response, containing the explanation of why the request failed
+- the protocol-specific response object itself **]**

--- a/common/core/package.json
+++ b/common/core/package.json
@@ -26,7 +26,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 99 --branches 97 --functions 98 --lines 99"
+    "check-cover": "istanbul check-coverage --statements 99 --branches 93 --functions 97 --lines 99"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/core/src/http_errors.ts
+++ b/common/core/src/http_errors.ts
@@ -3,28 +3,29 @@
 
 'use strict';
 
-import { errors } from 'azure-iot-common';
-import { IncomingMessage } from 'http';
+import * as errors from './errors';
 
 /**
  * @private
  */
-export class HttpTransportError extends Error {
-  response?: IncomingMessage;
+export class HttpStatusError extends Error {
+  statusCode?: number;
+  response?: any;
   responseBody?: any;
 }
 
-/* Codes_SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [`translateError` shall accept 3 arguments:
+/* Codes_SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [`translateError` shall accept 4 arguments:
  * - A custom error message to give context to the user.
- * - the body of  the HTTP response, containing the explanation of why the request failed
- * - the HTTP response object itself]
+ * - The status code
+ * - the body of the response, containing the explanation of why the request failed
+ * - the protocol-specific response object itself]
  */
 /**
  * @private
  */
-export function translateError(message: string, body: any, response: IncomingMessage): HttpTransportError {
-  let error: HttpTransportError;
-  switch (response.statusCode) {
+export function httpTranslateError(message: string, statusCode: number, body?: any, response?: any): HttpStatusError {
+  let error: HttpStatusError;
+  switch (statusCode) {
     case 400:
       /*Codes_SRS_NODE_DEVICE_HTTP_ERRORS_16_003: [`translateError` shall return an `ArgumentError` if the HTTP response status code is `400`.]*/
       error = new errors.ArgumentError(message);
@@ -58,11 +59,13 @@ export function translateError(message: string, body: any, response: IncomingMes
       error = new Error(message);
   }
 
-/* Codes_SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 3 properties:
- * - `response` shall contain the `IncomingMessage` object returned by the HTTP layer.
- * - `reponseBody` shall contain the content of the HTTP response.
+/* Codes_SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 4 properties:
+ * - `statusCode` shall contain the http status code
+ * - `response` shall contain the protocol-specific response object itself
+ * - `responseBody` shall contain the body of the response, containing the explanation of why the request failed
  * - `message` shall contain a human-readable error message]
  */
+  error.statusCode = statusCode;
   error.response = response;
   error.responseBody = body;
   return error;

--- a/common/core/test/_http_errors_test.js
+++ b/common/core/test/_http_errors_test.js
@@ -4,8 +4,8 @@
 'use strict';
 
 var assert = require('chai').assert;
-var errors = require('azure-iot-common').errors;
-var translateError = require('../lib/http_errors.js').translateError;
+var errors = require('../lib/errors');
+var translateError = require('../lib/http_errors.js').httpTranslateError;
 
 describe('translateError', function() {
 
@@ -33,20 +33,22 @@ describe('translateError', function() {
     };
     var fake_response_body = testParams.statusCode + ': ' + testParams.statusMessage;
 
-    /* Tests_SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [`translateError` shall accept 3 arguments:
-     * - A custom error message to give context to the user.
-     * - the body of  the HTTP response, containing the explanation of why the request failed
-     * - the HTTP response object itself]
-     */
-    var err = translateError(new Error(testParams.errorMessage), fake_response_body, fake_response);
+/* Tests_SRS_NODE_DEVICE_HTTP_ERRORS_16_010: [`translateError` shall accept 4 arguments:
+ * - A custom error message to give context to the user.
+ * - The status code
+ * - the body of the response, containing the explanation of why the request failed
+ * - the protocol-specific response object itself]
+ */
+var err = translateError(new Error(testParams.errorMessage), testParams.statusCode, fake_response_body, fake_response);
     assert.instanceOf(err, testParams.expectedErrorType);
 
-    /* Tests_SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 3 properties:
-     * - `response` shall contain the `IncomingMessage` object returned by the HTTP layer.
-     * - `reponseBody` shall contain the content of the HTTP response.
-     * - `message` shall contain a human-readable error message]
-     */
-    assert.equal(err.message, 'Error: ' + testParams.errorMessage);
+  /* Tests_SRS_NODE_DEVICE_HTTP_ERRORS_16_001: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 4 properties:
+  * - `statusCode` shall contain the http status code
+  * - `response` shall contain the protocol-specific response object itself
+  * - `responseBody` shall contain the body of the response, containing the explanation of why the request failed
+  * - `message` shall contain a human-readable error message]
+  */
+  assert.equal(err.message, 'Error: ' + testParams.errorMessage);
     assert.equal(err.responseBody, fake_response_body);
     assert.equal(err.response, fake_response);
     });

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -10,7 +10,7 @@ const debug = dbg('azure-iot-device-http:Http');
 import { EventEmitter } from 'events';
 import { Http as Base } from 'azure-iot-http-base';
 import { endpoint, errors, results, Message } from 'azure-iot-common';
-import { translateError } from './http_errors.js';
+import { httpTranslateError as translateError } from 'azure-iot-common';
 import { IncomingMessage } from 'http';
 import { DeviceMethodResponse, Client } from 'azure-iot-device';
 

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -7,6 +7,7 @@
   "main": "index.js",
   "typings": "index.d.ts",
   "dependencies": {
+    "azure-device-provisioning-client": "0.0.1",
     "azure-iot-http-base": "1.2.0",
     "azure-iot-common": "1.2.1",
     "debug": "^3.0.1",


### PR DESCRIPTION
# Description of the problem

I'm tired of having at least 3 different pieces of code that map http status codes to iothub errors.  (one in device/transport/http, one in common/transport/http, and one in the twin code.  I don't want to add another one for provisioning, so I'm moving it to common/core.

This is the first commit, just moving the existing implementation.  I'll resolve the other 2 implementations (which are slightly different than the first) in my next commit.
