### PR TITLE
Fix for #73 (premature close error over MQTT)

### DIFF
--- a/common/transport/mqtt/devdoc/mqtt_translate_errors_requirements.md
+++ b/common/transport/mqtt/devdoc/mqtt_translate_errors_requirements.md
@@ -28,6 +28,6 @@
 
 **SRS_NODE_DEVICE_MQTT_ERRORS_18_011: [** `translateError` shall return an `Error` if none of the other string rules match **]**
 
-**SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [** `translateError` shall return a `NotConnectedError` if the error object as a truthy `code` property (node socket errors) **]**
+**SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [** `translateError` shall return a `NotConnectedError` if the error object has a truthy `code` property (node socket errors) **]**
 
 **SRS_NODE_DEVICE_MQTT_ERRORS_16_002: [** `translateError` shall return a `NotConnectedError` if the error message contains 'premature close' (from `end-of-stream`) **]**

--- a/common/transport/mqtt/devdoc/mqtt_translate_errors_requirements.md
+++ b/common/transport/mqtt/devdoc/mqtt_translate_errors_requirements.md
@@ -27,3 +27,7 @@
 **SRS_NODE_DEVICE_MQTT_ERRORS_18_010: [** `translateError` shall return a `InternalServerError` if the MQTT error message contains the string 'unrecognized packet type' **]**
 
 **SRS_NODE_DEVICE_MQTT_ERRORS_18_011: [** `translateError` shall return an `Error` if none of the other string rules match **]**
+
+**SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [** `translateError` shall return a `NotConnectedError` if the error object as a truthy `code` property (node socket errors) **]**
+
+**SRS_NODE_DEVICE_MQTT_ERRORS_16_002: [** `translateError` shall return a `NotConnectedError` if the error message contains 'premature close' (from `end-of-stream`) **]**

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -31,7 +31,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 92 --branches 80 --functions 83 --lines 94"
+    "check-cover": "istanbul check-coverage --statements 92 --branches 81 --functions 83 --lines 94"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -108,9 +108,7 @@ export class MqttBase extends EventEmitter {
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_033: [The `updateSharedAccessSignature` method shall disconnect and reconnect the mqtt client with the new `sharedAccessSignature`.]*/
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_035: [The `updateSharedAccessSignature` method shall call the `callback` argument with no parameters if the operation succeeds.]*/
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_036: [The `updateSharedAccessSignature` method shall call the `callback` argument with an `Error` if the operation fails.]*/
-            // Force the disconnection (by setting the argument to true) because we might be disconnected
-            // and the mqtt library will hang if we call disconnect on a socket that appears connected even though the connection is down
-            this._disconnectClient(true, () => {
+            this._disconnectClient(false, () => {
               this._connectClient((err, connack) => {
                 if (err) {
                   this._fsm.transition('disconnected', callback, err);

--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -108,6 +108,8 @@ export class MqttBase extends EventEmitter {
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_033: [The `updateSharedAccessSignature` method shall disconnect and reconnect the mqtt client with the new `sharedAccessSignature`.]*/
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_035: [The `updateSharedAccessSignature` method shall call the `callback` argument with no parameters if the operation succeeds.]*/
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_036: [The `updateSharedAccessSignature` method shall call the `callback` argument with an `Error` if the operation fails.]*/
+            // Force the disconnection (by setting the argument to true) because we might be disconnected
+            // and the mqtt library will hang if we call disconnect on a socket that appears connected even though the connection is down
             this._disconnectClient(true, () => {
               this._connectClient((err, connack) => {
                 if (err) {

--- a/common/transport/mqtt/src/mqtt_translate_error.ts
+++ b/common/transport/mqtt/src/mqtt_translate_error.ts
@@ -33,7 +33,7 @@ export function translateError(mqttError: Error): MqttTransportError {
   debug('translating: ' + mqttError.toString());
   if ((<any>mqttError).code) {
     // the 'code' property denotes a socket-level error (ENOTFOUND, EAI_AGAIN, etc)
-    /*Codes_SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [`translateError` shall return a `NotConnectedError` if the error object as a truthy `code` property (node socket errors)]*/
+    /*Codes_SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [`translateError` shall return a `NotConnectedError` if the error object has a truthy `code` property (node socket errors)]*/
     err = new errors.NotConnectedError(mqttError.message);
   } else if (mqttError.message) {
     if (mqttError.message.indexOf('premature close') > -1) {

--- a/common/transport/mqtt/test/_mqtt_translate_error_test.js
+++ b/common/transport/mqtt/test/_mqtt_translate_error_test.js
@@ -75,7 +75,20 @@ describe('MqttTranslateError', function () {
 
   it('returns a generic error when there is no message property on the mqtt error', function () {
     assert(translateError(new Error()) instanceof Error);
-  })
+  });
+
+  /*Tests_SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [`translateError` shall return a `NotConnectedError` if the error object as a truthy `code` property (node socket errors)]*/
+  it('converts socket errors to NotConnectedError', function () {
+    var fakeSocketError = new Error('getaddrinfo: not found');
+    fakeSocketError.code = 'ENOTFOUND';
+    assert(translateError(fakeSocketError) instanceof errors.NotConnectedError);
+  });
+
+  /*Tests_SRS_NODE_DEVICE_MQTT_ERRORS_16_002: [`translateError` shall return a `NotConnectedError` if the error message contains 'premature close' (from `end-of-stream`)]*/
+  it('converts \'premature close\' errors into NotConnectedError', function () {
+    var fakeError = new Error('premature close');
+    assert(translateError(fakeError) instanceof errors.NotConnectedError);
+  });
 });
 
 

--- a/common/transport/mqtt/test/_mqtt_translate_error_test.js
+++ b/common/transport/mqtt/test/_mqtt_translate_error_test.js
@@ -77,7 +77,7 @@ describe('MqttTranslateError', function () {
     assert(translateError(new Error()) instanceof Error);
   });
 
-  /*Tests_SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [`translateError` shall return a `NotConnectedError` if the error object as a truthy `code` property (node socket errors)]*/
+  /*Tests_SRS_NODE_DEVICE_MQTT_ERRORS_16_001: [`translateError` shall return a `NotConnectedError` if the error object has a truthy `code` property (node socket errors)]*/
   it('converts socket errors to NotConnectedError', function () {
     var fakeSocketError = new Error('getaddrinfo: not found');
     fakeSocketError.code = 'ENOTFOUND';

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -336,6 +336,10 @@ export class Mqtt extends EventEmitter implements Client.Transport {
         }
       }
     });
+
+    this._fsm.on('transition', (data) => {
+      debug(data.fromState + ' -> ' + data.toState + ' (' + data.action + ')');      
+    });
   }
 
   /**
@@ -403,10 +407,11 @@ export class Mqtt extends EventEmitter implements Client.Transport {
 
     /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_010: [** The `sendEvent` method shall use QoS level of 1.]*/
     this._fsm.handle('sendEvent', topic, message.data, { qos: 1, retain: false }, (err, puback) => {
-      debug('PUBACK: ' + JSON.stringify(puback));
       if (err) {
+        debug('send error: ' + err.toString());
         done(err);
       } else {
+        debug('PUBACK: ' + JSON.stringify(puback));
         done(null, new results.MessageEnqueued(puback));
       }
     });

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -338,7 +338,7 @@ export class Mqtt extends EventEmitter implements Client.Transport {
     });
 
     this._fsm.on('transition', (data) => {
-      debug(data.fromState + ' -> ' + data.toState + ' (' + data.action + ')');      
+      debug(data.fromState + ' -> ' + data.toState + ' (' + data.action + ')');
     });
   }
 


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#73 

# Description of the problem
There are 2 problems that are solved in this PR.
- #73 we weren't capturing socket errors that could be retried and were instead failing
- The `updateSharedAccessSignature`, if called while the socket was disconnected, would hang indefinitely

# Description of the solution
- Catch and convert the socket errors properly
- force disconnection of the socket, meaning it'll work even if the device is disconnected from the network.
