### PR TITLE
Fix for #138: Default to SAS authentication when x509 thumbprints are not populated

### DIFF
--- a/service/devdoc/registry_requirements.md
+++ b/service/devdoc/registry_requirements.md
@@ -77,7 +77,7 @@ authentication : {
 
 **SRS_NODE_IOTHUB_REGISTRY_06_029: [** A device information with an authentication object that contains a `type` property is considered normalized. **]**
 
-**SRS_NODE_IOTHUB_REGISTRY_06_030: [** A device information with an authentication object that contains the x509Thumbprint property will be normalized with a `type` property with value "selfSigned". **]**
+**SRS_NODE_IOTHUB_REGISTRY_06_030: [** A device information with an authentication object that contains an `x509Thumbprint` property with at least one of `primaryThumbprint` or `secondaryThumbprint` sub-properties will be normalized with a `type` property with value "selfSigned". **]**
 
 **SRS_NODE_IOTHUB_REGISTRY_06_031: [** A device information with an authentication object that doesn't contain the x509Thumbprint property will be normalized with a `type` property with value "sas". **]**
 

--- a/service/src/registry.ts
+++ b/service/src/registry.ts
@@ -715,12 +715,12 @@ export class Registry {
         };
     /* Codes_SRS_NODE_IOTHUB_REGISTRY_06_029: [** A device information with an authentication object that contains a `type` property is considered normalized.] */
     } else if (!deviceInfo.authentication.hasOwnProperty('type')) {
-      if (!deviceInfo.authentication.hasOwnProperty('x509Thumbprint')) {
+      if (deviceInfo.authentication.x509Thumbprint && (deviceInfo.authentication.x509Thumbprint.primaryThumbprint || deviceInfo.authentication.x509Thumbprint.secondaryThumbprint)) {
+        /* Codes_SRS_NODE_IOTHUB_REGISTRY_06_030: [A device information with an authentication object that contains the x509Thumbprint property with at least one of `primaryThumbprint` or `secondaryThumbprint` sub-properties will be normalized with a `type` property with value "selfSigned".] */
+        deviceInfo.authentication.type = 'selfSigned';
+      } else {
         /* Codes_SRS_NODE_IOTHUB_REGISTRY_06_031: [A device information with an authentication object that doesn't contain the x509Thumbprint property will be normalized with a `type` property with value "sas".] */
         deviceInfo.authentication.type = 'sas';
-      } else {
-        /* Codes_SRS_NODE_IOTHUB_REGISTRY_06_030: [A device information with an authentication object that contains the x509Thumbprint property will be normalized with a `type` property with value "selfSigned".] */
-        deviceInfo.authentication.type = 'selfSigned';
       }
     }
   }


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#138 

# Description of the problem
The `normalizeAuthentication` function was defaulting to the `selfSigned` authentication type as soon as the device had an `x509Thumprint` property without checking if the `primaryThumbprint` or `secondaryThumbprint` fields were actually populated. The service accepts an authentication structure of type `selfSigned` with both keys and thumbprints as valid but the device is unusable.

# Description of the solution
check that at least one of `primaryThumbprint` or `secondaryThumbprint` is not falsy before setting the authentication type to `selfSigned` and default to `sas` if no thumbprint is provided.
