### PR TITLE
Fix for #141 - disconnected event handler leak in base AMQP transport

### DIFF
--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -36,7 +36,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 91 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --functions 91 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#141 

# Description of the problem
The `disconnected` event of the amqp10 library client is subscribed every time the AMQP common state machine switches to the `connecting` state but is never removed. in the case where a device is trying to repeatedly reconnect, there's a leak.

# Description of the solution
subscribe to the `disconnected` event only once in the constructor - and move actual handling of the event into the state machine depending on which state it's in.
