### PR TITLE
Remove hubname everywhere in config objects

### DIFF
--- a/device/core/src/client.ts
+++ b/device/core/src/client.ts
@@ -645,8 +645,7 @@ export class Client extends EventEmitter {
 
     let config: Client.Config = {
       host: cn.HostName,
-      deviceId: cn.DeviceId,
-      hubName: cn.HostName.split('.')[0]
+      deviceId: cn.DeviceId
     };
 
     if (cn.hasOwnProperty('SharedAccessKey')) {
@@ -681,7 +680,6 @@ export class Client extends EventEmitter {
     const config: Client.Config = {
       host: uriSegments[0],
       deviceId: uriSegments[uriSegments.length - 1],
-      hubName: uriSegments[0].split('.')[0],
       sharedAccessSignature: sharedAccessSignature
     };
 
@@ -705,9 +703,10 @@ export namespace Client {
      */
     host: string;
     /**
+     * @deprecated This is not used anywhere anymore.
      * Name of the Azure IoT hub. (The first section of the Azure IoT hub hostname)
      */
-    hubName: string;
+    hubName?: string;
     /**
      * If using symmetric key authentication, this is used to generate the shared access signature tokens used to authenticate the connection.
      */

--- a/device/core/test/_client_test.js
+++ b/device/core/test/_client_test.js
@@ -121,7 +121,6 @@ describe('Client', function () {
         this.on = function() {};
         assert.strictEqual(config.host, 'hubName.azure-devices.net');
         assert.strictEqual(config.deviceId, 'deviceId');
-        assert.strictEqual(config.hubName, 'hubName');
         assert.strictEqual(config.sharedAccessSignature, sharedAccessSignature);
       };
       Client.fromSharedAccessSignature(sharedAccessSignature, DummyTransport);
@@ -133,7 +132,6 @@ describe('Client', function () {
         this.on = function() {};
         assert.strictEqual(config.host, 'hubName.azure-devices.net');
         assert.strictEqual(config.deviceId, 'deviceId');
-        assert.strictEqual(config.hubName, 'hubName');
         assert.strictEqual(config.sharedAccessSignature, sharedAccessSignature);
       };
       Client.fromSharedAccessSignature(sharedAccessSignature, DummyTransport);

--- a/device/core/test/blob_upload/_blob_upload_client_test.js
+++ b/device/core/test/blob_upload/_blob_upload_client_test.js
@@ -20,7 +20,6 @@ var FakeBlobUploader = function() {
 
 var fakeConfig = {
   host: 'hub.host.com',
-  hubName: 'hub',
   sharedAccessSignature: 'sas',
   deviceId: 'deviceId'
 };
@@ -48,7 +47,7 @@ describe('BlobUploadClient', function() {
 
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_003: [If specified, `BlobUploadClient` shall use the `blobUploader` passed as a parameter instead of the default one.]*/
   });
-  
+
   describe('#updateSharedAccessSignature', function() {
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_011: [`updateSharedAccessSignature` shall update the value used by the `BlobUploadClient` instance to the value passed as an argument.]*/
     it('updates the shared access signature with the new one', function() {
@@ -173,7 +172,7 @@ describe('BlobUploadClient', function() {
       fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
         callback(null, fakeBlobInfo);
       };
-      
+
       fakeFileUpload.notifyUploadComplete = function(correlationId, result, sharedAccessSignature, callback) {
         callback(new Error('could not notify hub'));
       };
@@ -188,7 +187,7 @@ describe('BlobUploadClient', function() {
         done();
       });
     });
-    
+
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_010: [`uploadToBlob` shall call the `done` callback with no arguments if IoT Hub was successfully notified of the blob upload outcome, regardless of the success state of the transfer itself.]*/
     it('calls the done callback with no arguments if the upload as completed successfully and IoT Hub has been notified.', function(done) {
       var fakeStream = new stream.Readable();
@@ -207,7 +206,7 @@ describe('BlobUploadClient', function() {
       fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
         callback(null, fakeBlobInfo);
       };
-      
+
       fakeFileUpload.notifyUploadComplete = function(correlationId, result, sharedAccessSignature, callback) {
         callback();
       };

--- a/device/transport/amqp/devdoc/amqp_device_method_client_requirements.md
+++ b/device/transport/amqp/devdoc/amqp_device_method_client_requirements.md
@@ -14,7 +14,6 @@ var Amqp = require('azure-iot-device-amqp').Amqp;
 var config = {
   deviceId: '<deviceId>',
   host: '<host>',
-  hubName: '<hubName>',
   sharedAccessSignature: '<sas>'
 };
 

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -53,7 +53,6 @@ amqp.on('errorReceived', function (err) {
 
 **SRS_NODE_DEVICE_AMQP_16_001: [**The Amqp constructor shall accept a config object with four properties:
 `host` – (string) the fully-qualified DNS hostname of an IoT Hub
-`hubName` - (string) the name of the IoT Hub instance (without suffix such as .azure-devices.net)
 `deviceId` – (string) the identifier of a device registered with the IoT Hub
 `sharedAccessSignature` – (string) the shared access signature associated with the device registration.**]**
 

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -42,7 +42,6 @@ const getTranslatedError = function(err?: Error, message?: string): Error {
  */
 /*Codes_SRS_NODE_DEVICE_AMQP_16_001: [The Amqp constructor shall accept a config object with four properties:
 host – (string) the fully-qualified DNS hostname of an IoT Hub
-hubName - (string) the name of the IoT Hub instance (without suffix such as .azure-devices.net).
 deviceId – (string) the identifier of a device registered with the IoT Hub
 sharedAccessSignature – (string) the shared access signature associated with the device registration.] */
 /*Codes_SRS_NODE_DEVICE_AMQP_RECEIVER_16_001: [The `Amqp` constructor shall implement the `Receiver` interface.]*/

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -23,9 +23,9 @@ describe('Amqp', function () {
   var testMessage = new Message();
   testMessage._transportObj = {};
   var testCallback = function () { };
-  var configWithSSLOptions = { host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', x509: 'some SSL options' };
+  var configWithSSLOptions = { host: 'hub.host.name', deviceId: 'deviceId', x509: 'some SSL options' };
   var simpleSas = 'SharedAccessSignature sr=foo&sig=123&se=123';
-  var configWithSAS = { host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', sharedAccessSignature: simpleSas};
+  var configWithSAS = { host: 'hub.host.name', deviceId: 'deviceId', sharedAccessSignature: simpleSas};
 
   beforeEach(function () {
     sender = new EventEmitter();

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -130,7 +130,6 @@ export class Http extends EventEmitter implements Client.Transport {
    * | Key     | Value                                                   |
    * |---------|---------------------------------------------------------|
    * | host    | The host URL of the Azure IoT Hub                       |
-   * | hubName | The name of the Azure IoT Hub                           |
    * | keyName | The identifier of the device that is being connected to |
    * | key     | The shared access key auth                              |
    *
@@ -212,7 +211,6 @@ export class Http extends EventEmitter implements Client.Transport {
    * | Key     | Value                                                   |
    * |---------|---------------------------------------------------------|
    * | host    | The host URL of the Azure IoT Hub                       |
-   * | hubName | The name of the Azure IoT Hub                           |
    * | keyName | The identifier of the device that is being connected to |
    * | key     | The shared access key auth                              |
    *

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -40,7 +40,7 @@ describe('Http', function () {
   var testCallback = function () { };
 
   beforeEach(function () {
-    transport = new Http({ host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', sharedAccessSignature: 'sas.key' });
+    transport = new Http({ host: 'hub.host.name', deviceId: 'deviceId', sharedAccessSignature: 'sas.key' });
   });
 
   afterEach(function () {
@@ -251,13 +251,13 @@ describe('Http', function () {
 
     /*Tests_SRS_NODE_DEVICE_HTTP_16_005: [If `done` has been specified the `setOptions` method shall call the `done` callback with no arguments when successful.]*/
     it('calls the done callback with no arguments if successful', function(done) {
-      var transport = new Http({ host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', sas: 'sas.key' });
+      var transport = new Http({ host: 'hub.host.name', deviceId: 'deviceId', sas: 'sas.key' });
       transport.setOptions(testOptions, done);
     });
 
     /*Tests_SRS_NODE_DEVICE_HTTP_16_010: [`setOptions` should not throw if `done` has not been specified.]*/
     it('does not throw if `done` is not specified', function() {
-      var transport = new Http({ host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', sas: 'sas.key' });
+      var transport = new Http({ host: 'hub.host.name', deviceId: 'deviceId', sas: 'sas.key' });
       assert.doesNotThrow(function() {
         transport.setOptions({});
       });
@@ -268,7 +268,7 @@ describe('Http', function () {
     /*Codes_SRS_NODE_DEVICE_HTTP_16_006: [The updateSharedAccessSignature method shall save the new shared access signature given as a parameter to its configuration.] */
     /*Codes_SRS_NODE_DEVICE_HTTP_16_007: [The updateSharedAccessSignature method shall call the `done` callback with a null error object and a SharedAccessSignatureUpdated object as a result, indicating that the client does not need to reestablish the transport connection.] */
     it('updates its configuration object with the new shared access signature', function(done) {
-      var transportWithoutReceiver = new Http({ host: 'hub.host.name', hubName: 'hub', deviceId: 'deviceId', sas: 'sas.key' });
+      var transportWithoutReceiver = new Http({ host: 'hub.host.name', deviceId: 'deviceId', sas: 'sas.key' });
       var newSas = 'newsas';
       transportWithoutReceiver.updateSharedAccessSignature(newSas, function(err, result) {
         if(err) {
@@ -287,7 +287,7 @@ describe('HttpReceiver', function () {
   describe('#receiveTimers', function () {
     var fakeHttp, receiver;
     beforeEach(function () {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       fakeHttp = new FakeHttp();
       receiver = new Http(config, fakeHttp);
       this.clock = sinon.useFakeTimers();
@@ -369,7 +369,7 @@ describe('HttpReceiver', function () {
   describe('#receive', function () {
     /*Tests_SRS_NODE_DEVICE_HTTP_RECEIVER_16_023: [If opts.manualPolling is true, messages shall be received only when receive() is called]*/
     it('receives 1 message when receive() is called and drain is false', function (done) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       var fakeHttp = new FakeHttp();
       var receiver = new Http(config, fakeHttp);
       var msgCount = 5;
@@ -389,7 +389,7 @@ describe('HttpReceiver', function () {
     });
 
     it('receives all messages when receive() is called and drain is true', function (done) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       var fakeHttp = new FakeHttp();
       var receiver = new Http(config, fakeHttp);
       var msgCount = 5;
@@ -404,7 +404,7 @@ describe('HttpReceiver', function () {
     });
 
     it('emits messages only when all requests are done', function(done){
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       var fakeHttp = new FakeHttp();
       var requestsCount = 0;
       fakeHttp.buildRequest = function (method, path, httpHeaders, host, sslOptions, done) {
@@ -435,7 +435,7 @@ describe('HttpReceiver', function () {
   describe('#drain', function () {
     /*Tests_SRS_NODE_DEVICE_HTTP_RECEIVER_16_017: [If opts.drain is true all messages in the queue should be pulled at once.]*/
     it('drains the message queue', function (done) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       var fakeHttp = new FakeHttp();
       var receiver = new Http(config, fakeHttp);
       var msgCount = 5;
@@ -454,7 +454,7 @@ describe('HttpReceiver', function () {
     });
 
     it('emits an error if the HTTP error fails', function (testCallback) {
-      var config = { deviceId: "deviceId", hubName: "hubName", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
+      var config = { deviceId: "deviceId", host: "hubname.azure-devices.net", sharedAccessSignature: "sas" };
       var fakeError = new Error();
       fakeError.statusCode = 500;
       var fakeHttp = {

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -46,7 +46,6 @@ function getTranslatedError(err: Error, message: string): Error {
  */
 /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_16_001: [The Amqp constructor shall accept a config object with those 4 properties:
 host – (string) the fully-qualified DNS hostname of an IoT Hub
-hubName - (string) the name of the IoT Hub instance (without suffix such as .azure-devices.net).
 keyName – (string) the name of a key that can be used to communicate with the IoT Hub instance
 sharedAccessSignature – (string) the key associated with the key name.] */
 export class Amqp extends EventEmitter implements Client.Transport {

--- a/service/src/amqp_ws.ts
+++ b/service/src/amqp_ws.ts
@@ -12,7 +12,6 @@ import { Client } from './client';
  */
 /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_WS_16_001: [The `AmqpWs` constructor shall accept a config object with those four properties:
 - `host` – (string) the fully-qualified DNS hostname of an IoT Hub
-- `hubName` - (string) the name of the IoT Hub instance (without suffix such as .azure-devices.net).
 - `keyName` – (string) the name of a key that can be used to communicate with the IoT Hub instance
 - `sharedAccessSignature–` (string) the key associated with the key name.]*/
 /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_WS_16_002: [`AmqpWs` should inherit from `Amqp`.]*/

--- a/service/src/client.ts
+++ b/service/src/client.ts
@@ -321,7 +321,6 @@ export class Client extends EventEmitter {
     const cn = ConnectionString.parse(connStr);
 
     const config: Client.TransportConfigOptions = {
-      hubName: cn.HostName.split('.', 1)[0],
       host: cn.HostName,
       keyName: cn.SharedAccessKeyName,
       sharedAccessSignature: SharedAccessSignature.create(cn.HostName, cn.SharedAccessKeyName, cn.SharedAccessKey, anHourFromNow())
@@ -359,7 +358,6 @@ export class Client extends EventEmitter {
 
     /*Codes_SRS_NODE_IOTHUB_CLIENT_16_018: [The `fromSharedAccessSignature` method shall create a new transport instance and pass it a config object formed from the connection string given as argument.]*/
     const config: Client.TransportConfigOptions = {
-      hubName: decodedUri.split('.', 1)[0],
       host: decodedUri,
       keyName: sas.skn,
       sharedAccessSignature: sas.toString()
@@ -374,9 +372,22 @@ export class Client extends EventEmitter {
 export namespace Client {
   export type Callback<T> = (err: Error, result?: T) => void;
   export interface TransportConfigOptions {
+    /**
+     * Hostname of the Azure IoT hub. (<IoT hub name>.azure-devices.net).
+     */
       host: string;
-      hubName: string;
+      /**
+       * @deprecated This is not used anywhere anymore.
+       * Name of the Azure IoT hub. (The first section of the Azure IoT hub hostname)
+       */
+      hubName?: string;
+      /**
+       * The name of the policy used to connect to the Azure IoT Hub service.
+       */
       keyName: string;
+      /**
+       * The shared access signature token used to authenticate the connection with the Azure IoT hub.
+       */
       sharedAccessSignature: string | SharedAccessSignature;
   }
 

--- a/service/test/_amqp_test.js
+++ b/service/test/_amqp_test.js
@@ -16,14 +16,12 @@ var AmqpMessage = require('azure-iot-amqp-base').AmqpMessage;
 
 var fakeConfig = {
   host: 'hub.host.name',
-  hubName: 'hub',
   keyName: 'keyName',
   sharedAccessSignature: 'SharedAccessSignature sr=a.hub.net&sig=1234&skn=keyName&se=1234'
 };
 
 var sasConfig = {
   host: 'hub.host.name',
-  hubName: 'hub',
   keyName: 'keyName',
   sharedAccessSignature: SharedAccessSignature.create('uri', 'name', 'key', 123)
 };
@@ -52,7 +50,6 @@ describe('Amqp', function() {
     var clock = this.clock;
     var renewingSasConfig = {
       host: 'hub.host.name',
-      hubName: 'hub',
       keyName: 'keyName',
       sharedAccessSignature: SharedAccessSignature.create('uri', 'name', 'key', 1)
     };

--- a/service/test/_amqp_ws_test.js
+++ b/service/test/_amqp_ws_test.js
@@ -13,7 +13,6 @@ describe('AmqpWs', function() {
     it('inherits from `Amqp`', function() {
       var amqpWs = new AmqpWs({
         host: 'host',
-        hubName: 'hubName',
         keyName: 'keyName',
         sharedAccessSignature: 'sas'
       });
@@ -26,7 +25,6 @@ describe('AmqpWs', function() {
     it('calls the connect method on the base AMQP object with the correct URL', function() {
       var testConfig = {
         host: 'host',
-        hubName: 'hubName',
         keyName: 'keyName',
         sharedAccessSignature: 'sas'
       };

--- a/service/test/_client_test.js
+++ b/service/test/_client_test.js
@@ -70,7 +70,6 @@ describe('Client', function () {
     /*Tests_SRS_NODE_IOTHUB_CLIENT_16_018: [The `fromSharedAccessSignature` method shall create a new transport instance and pass it a config object formed from the connection string given as argument.]*/
     it('correctly populates the config structure', function() {
       var client = Client.fromSharedAccessSignature(token);
-      assert.equal(client._transport._config.hubName, 'hubName');
       assert.equal(client._transport._config.host, 'hubName.azure-devices.net');
       assert.equal(client._transport._config.keyName, 'keyname');
       assert.equal(client._transport._config.sharedAccessSignature, token);


### PR DESCRIPTION
since it's not used anywhere. deprecate public APIs,.

# Description of the problem
Customers can now [pick custom DNS names for their hubs](https://docs.microsoft.com/en-us/azure/dns/dns-custom-domain#azure-iot). I'm worried we're going to start to see connection strings with those and at this point the SDK hub name parsing logic will break. which would be sad since the `hubName` property of config objects is never used anywhere.

# Description of the solution
- remove the `hubName` anywhere internally
- deprecate public API/docs referencing `hubName`.
