### PR TITLE
Fix type issue in MQTT twin response that prevent errors from being parsed properly

### DIFF
--- a/device/transport/mqtt/src/mqtt_twin_receiver.ts
+++ b/device/transport/mqtt/src/mqtt_twin_receiver.ts
@@ -219,7 +219,7 @@ export class MqttTwinReceiver extends EventEmitter {
       /* Codes_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_013: [** The `body` parameter of the `response` event shall be the body of the received MQTT message **]**  */
       const response = {
         'topic' : topic,
-        'status' : path[3],
+        'status' : Number(path[3]),
         '$rid' : query.$rid,
         'body' : message
       };

--- a/device/transport/mqtt/test/_mqtt_twin_receiver_test.js
+++ b/device/transport/mqtt/test/_mqtt_twin_receiver_test.js
@@ -110,7 +110,7 @@ describe('MqttTwinReceiver', function () {
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_006: [** When a `response` event is emitted, the parameter shall be an object which contains `status`, `requestId` and `body` members **]**  */
     it ('has a parameter with an object with the correct properties', function(done) {
       receiver.on(MqttTwinReceiver.responseEvent, function(data) {
-        assert.isDefined(data.status);
+        assert.isNumber(data.status);
         assert.isDefined(data.$rid);
         assert.isDefined(data.body);
         done();
@@ -124,9 +124,9 @@ describe('MqttTwinReceiver', function () {
     /* Tests_SRS_NODE_DEVICE_MQTT_TWIN_RECEIVER_18_013: [** The `body` parameter of the `response` event shall be the body of the received MQTT message **]**  */
     it ('parses the topic name correctly', function(done) {
       receiver.on(MqttTwinReceiver.responseEvent, function(data) {
-        assert.equal(data.status, 200);
-        assert.equal(data.$rid, 42);
-        assert.equal(data.body, 'fake_body');
+        assert.strictEqual(data.status, 200);
+        assert.strictEqual(data.$rid, '42');
+        assert.strictEqual(data.body, 'fake_body');
         done();
       });
       provider.fakeMessageFromService('$iothub/twin/res/200/?$rid=42', 'fake_body');


### PR DESCRIPTION
# Description of the problem
When using MQTT the `status` property of the `response` event argument is sent as a string where the higher layer (that parses errors) expects an number, leading the error translation at the client level to fail.

# Description of the solution
cast the property as a number since it'll always be a number

- AMQP has been checked and is already returning the response as a number.
- this change is non-breaking even when crossing client/transport versions.
