### PR TITLE
Add devDependencies scanning to build_parallel.js

### DIFF
--- a/build/build_parallel/build_parallel.js
+++ b/build/build_parallel/build_parallel.js
@@ -84,15 +84,20 @@ var preprocessConfigFile = promisify(function (callback) {
     let project = config.projects[i];
     project.dependencies = [];
     project.consumers = [];
-    for (var dependency in project.packageJson.dependencies) {
-      if (project.packageJson.dependencies.hasOwnProperty(dependency)) {
-        if (!!tempProjectObject[dependency]) {
-          debug(project.name + ' depends on ' + dependency);
-          project.dependencies.push(tempProjectObject[dependency]);
-          tempProjectObject[dependency].consumers.push(project);
+    [
+      'dependencies',
+      'devDependencies'
+    ].forEach(function (dependencyList) {
+      for (var dependency in project.packageJson[dependencyList]) {
+        if (project.packageJson[dependencyList].hasOwnProperty(dependency)) {
+          if (!!tempProjectObject[dependency]) {
+            debug(project.name + ' depends on ' + dependency);
+            project.dependencies.push(tempProjectObject[dependency]);
+            tempProjectObject[dependency].consumers.push(project);
+          }
         }
       }
-    }
+    });
   }
   callback();
 });
@@ -152,7 +157,7 @@ var readyToRunTask = function (project) {
     return true;
   } else {
     // If we're not doing consumers first, we're doing dependencies first.  This is the
-    // normal case (build, teset, setup, etc).  We first do our dependencies, then we
+    // normal case (build, test, setup, etc).  We first do our dependencies, then we
     // do ourselves.
     for (let i = 0; i < project.dependencies.length; i++) {
       if (!project.dependencies[i].completed) {

--- a/build/build_parallel/config.json
+++ b/build/build_parallel/config.json
@@ -57,6 +57,9 @@
       "directory": "device/core"
     },
     {
+      "directory": "service"
+    },
+    {
       "directory": "device/transport/mqtt"
     },
     {
@@ -64,9 +67,6 @@
     },
     {
       "directory": "device/transport/amqp"
-    },
-    {
-      "directory": "service"
     },
     {
       "directory": "e2etests",


### PR DESCRIPTION
# Description of the problem
build_parallel.js only scans dependencies - and therefore misses to establish necessary links listed in packageJson.devDependencies.

# Description of the solution
Now scanning both dependencies and devDependencies.
Also moved service package up in config.json order to make sure it's installed/built before the packages depending on it.
