### PR TITLE
build e2e tests

### DIFF
--- a/build/build_parallel/build_parallel.js
+++ b/build/build_parallel/build_parallel.js
@@ -70,6 +70,8 @@ var preprocessConfigFile = promisify(function (callback) {
     project.fullpath = path.join(config.gitRoot, project.directory);
     project.packageJson = require(path.join(project.fullpath, 'package.json'));
     project.name = project.packageJson.name;
+    project.dependencies = [];
+    project.consumers = [];
     if (project['skip_' + config.task.name]) {
       project.runTask = false;
       debug('skipping ' + project.name);
@@ -82,8 +84,6 @@ var preprocessConfigFile = promisify(function (callback) {
   // In the second sweep. we build arrays of dependencies and consumers
   for (let i = 0; i < config.projects.length; i++) {
     let project = config.projects[i];
-    project.dependencies = [];
-    project.consumers = [];
     [
       'dependencies',
       'devDependencies'
@@ -270,7 +270,8 @@ initializeEnvironment()
   })
   .catch(err => {
     console.log();
-    console.log('job failed:' + err.toString());
+    console.log('job failed: ' + err.toString());
+    console.log(err.stack);
     exitCode = 1;
   })
   .then(() => {

--- a/build/build_parallel/config.json
+++ b/build/build_parallel/config.json
@@ -54,6 +54,12 @@
       "directory": "provisioning/transport/mqtt"
     },
     {
+      "directory": "provisioning/e2e",
+      "skip_build": true,
+      "skip_test": true,
+      "skip_ci": true
+    },
+    {
       "directory": "device/core"
     },
     {

--- a/provisioning/e2e/_provisioning_e2e.js
+++ b/provisioning/e2e/_provisioning_e2e.js
@@ -12,8 +12,8 @@ var Http = require('azure-iot-provisioning-device-http').Http;
 var ProvisioningServiceClient = require('azure-iot-provisioning-service').ProvisioningServiceClient;
 var Registry = require('azure-iothub').Registry;
 
-var idScope = process.env.IOTHUB_PROVISIONING_IDSCOPE;
-var provisioningConnectionString = process.env.IOTHUB_PROVISIONING_CONNECTION_STRING;
+var idScope = process.env.IOT_PROVISIONING_IDSCOPE;
+var provisioningConnectionString = process.env.IOT_PROVISIONING_SERVICE_CONNECTION_STRING;
 var registryConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
 var provisioningTransports = [ Http ];

--- a/provisioning/e2e/_service_create_delete.js
+++ b/provisioning/e2e/_service_create_delete.js
@@ -4,7 +4,6 @@
 'use strict';
 
 var assert = require('chai').assert;
-var debug = require('debug')('azure-device-provisioning-e2e');
 var uuid = require('uuid');
 
 

--- a/provisioning/e2e/package.json
+++ b/provisioning/e2e/package.json
@@ -25,7 +25,8 @@
   "scripts": {
     "lint": "jshint --show-non-errors .",
     "e2e": "node node_modules/mocha/bin/_mocha -- _*.js",
-    "test": "npm -s run lint && npm -s run e2e"
+    "test": "npm -s run lint && npm -s run e2e",
+    "build": "echo nothing to build"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
# Description of the solution

Interim step for running provisioning E2E in the gate.  
1) Update build_parallel to fix a bug with package consumers and config.json ordering.  
2) Added provisioning E2E to config.json
3) Updated E2E package.json to work with build_parallel
4) Updated E2E for consistent env variable usage.  
