### PR TITLE
flow and api updates

### DIFF
--- a/provisioning/device/devdoc/polling_state_machine_requirements.md
+++ b/provisioning/device/devdoc/polling_state_machine_requirements.md
@@ -1,4 +1,4 @@
-# client_state_machine Requirements
+# polling_state_machine Requirements
 
 ## Overview
 This module provides a state machine used by the ProvisioningDeviceClient to communicate with the Azure device provisioning service

--- a/provisioning/device/index.d.ts
+++ b/provisioning/device/index.d.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { Authentication, TransportHandlers, ResponseCallback, ClientConfiguration, DeviceConfiguration } from './lib/interfaces';
-export { ClientStateMachine } from './lib/client_state_machine';
+export { ProvisioningAuthentication, PollingTransportHandlers, ProvisioningTransportOptions, ProvisioningDeviceConfiguration, ProvisioningTransportHandlersBase, ProvisioningTransportHandlersX509 } from './lib/interfaces';
+export { PollingStateMachine } from './lib/polling_state_machine';
 export { ProvisioningDeviceClient } from './lib/client';
+export { ProvisioningDeviceConstants } from './lib/constants';
 

--- a/provisioning/device/index.js
+++ b/provisioning/device/index.js
@@ -3,8 +3,6 @@
 
 'use strict';
 
-var Interface = require('./lib/interfaces');
-
 /**
  * The `azure-iot-provisioning-device` module provides access to the Azure Device Provisoning Service.
  *
@@ -13,11 +11,13 @@ var Interface = require('./lib/interfaces');
  */
 
 module.exports = {
-  ResponseCallback: Interface.ResponseCallback,
-  TransportHandlers: Interface.TransportHandlers,
-  Authentication: Interface.Authentication,
-  DeviceConfiguration: Interface.DeviceConfiguration,
-  ClientConfiguration: Interface.ClientConfiguration,
-  ClientStateMachine: require('./lib/client_state_machine').ClientStateMachine,
+  PollingTransportHandlers: require('./lib/interfaces').PollingTransportHandlers,
+  ProvisioningTransportOptions: require('./lib/interfaces').ProvisioningTransportOptions,
+  ProvisioningAuthentication: require('./lib/interfaces').ProvisioningAuthentication,
+  ProvisioningDeviceConfiguration: require('./lib/interfaces').ProvisioningDeviceConfiguration,
+  ProvisioningTransportHandlersBase: require('./lib/interfaces').ProvisioningTransportHandlersBase,
+  ProvisioningTransportHandlersX509: require('./lib/interfaces').ProvisioningTransportHandlersX509,
+  PollingStateMachine: require('./lib/polling_state_machine').PollingStateMachine,
   ProvisioningDeviceClient: require('./lib/client').ProvisioningDeviceClient,
+  ProvisioningDeviceConstants: require('./lib/constants').ProvisioningDeviceConstants,
 };

--- a/provisioning/device/src/constants.ts
+++ b/provisioning/device/src/constants.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+// tslint:disable-next-line:no-var-requires
+const packageJson = require('../package.json');
+
+export class ProvisioningDeviceConstants {
+  /**
+   * User-Agent string passed to the service as part of communication
+   */
+  static userAgent: string = packageJson.name + '/' + packageJson.version;
+
+  /**
+   * Default interval for polling, to use in case service doesn't provide it to us.
+   */
+  static defaultPollingInterval: number = 2000;
+
+  /**
+   * Default host for the provisioning service
+   */
+  static defaultProvisioningHost: string = 'global.azure-devices-provisioning.net';
+
+  /**
+   * apiVersion to use while communicating with service.
+   */
+  static apiVersion: string = '2017-08-31-preview';
+
+  /**
+   * default timeout to use when communicating with the service
+   */
+  static defaultTimeoutInterval: number = 4000;
+
+
+
+
+}

--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -6,52 +6,31 @@
 import { SharedAccessSignature, X509 } from 'azure-iot-common';
 
 /**
- * @private
- * Callback for responses from the previsioning service
- */
-export type ResponseCallback = (err?: Error, response?: any) => void;
-
-/**
  * type defining the types of authentication we support
  */
-export type Authentication = string | X509 | SharedAccessSignature;
+export type ProvisioningAuthentication = string | X509 | SharedAccessSignature;
 
-export interface ClientConfiguration {
-  /**
-   * User-Agent string passed to the service as part of communication
-   */
-  userAgent: string;
-
+export interface ProvisioningTransportOptions {
   /**
    * Default interval for polling, to use in case service doesn't provide it to us.
    */
-  pollingInterval: number;
+  pollingInterval?: number;
 
   /**
    * Default host for the provisioning service
    */
-  provisioningHost: string;
-
-  /**
-   * apiVersion to use while communicating with service.
-   */
-  apiVersion: string;
+  provisioningHost?: string;
 
   /**
    * default timeout to use when communicating with the service
    */
-  timeoutInterval: number;
-
-  /**
-   * idScope to use when communicating with the provisioning service
-   */
-  idScope: string;
+  timeoutInterval?: number;
 }
 
 /**
  * Device configuration returned when registration is complete
  */
-export interface DeviceConfiguration {
+export interface ProvisioningDeviceConfiguration {
   iotHubUri: string;
   deviceId: string;
 }
@@ -59,8 +38,18 @@ export interface DeviceConfiguration {
 /**
  * Interface that all provisioning transports must implement in order to support the provisioning service
  */
-export interface TransportHandlers {
-  setClientConfig(config: ClientConfiguration): void;
+
+export interface ProvisioningTransportHandlersBase {
+  setTransportOptions(options: ProvisioningTransportOptions): void;
+  endSession(callback: (err?: Error) => void): void;
+}
+
+export interface ProvisioningTransportHandlersX509 extends ProvisioningTransportHandlersBase {
+  registerX509(registrationId: string, authorization: X509, forceRegistration: boolean, callback: (err?: Error, assignedHub?: string, deviceId?: string, body?: any, result?: any) => void): void;
+}
+
+export interface PollingTransportHandlers {
+  setTransportOptions(options: ProvisioningTransportOptions): void;
   registrationRequest(registrationId: string, authorization: SharedAccessSignature | X509 | string, requestBody: any, forceRegistration: boolean, callback: (err?: Error, body?: any, result?: any, pollingInterval?: number) => void): void;
   queryOperationStatus(registrationId: string, operationId: string, callback: (err?: Error, body?: any, result?: any, pollingInterval?: number) => void): void;
   endSession(callback: (err?: Error) => void): void;

--- a/provisioning/device/test/_polling_state_machine_test.js
+++ b/provisioning/device/test/_polling_state_machine_test.js
@@ -3,7 +3,7 @@
 
 'use strict';
 
-var ClientStateMachine = require('../lib/client_state_machine').ClientStateMachine;
+var PollingStateMachine = require('../lib/polling_state_machine').PollingStateMachine;
 var sinon = require('sinon');
 var assert = require('chai').assert;
 
@@ -40,7 +40,7 @@ describe('state machine', function () {
 
   var makeNewMachine = function () {
     /* Tests_SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_001: [ The `constructor` shall accept no arguments ] */
-    var machine = new ClientStateMachine({
+    var machine = new PollingStateMachine({
       endSession: sinon.stub().callsArg(0),
       registrationRequest: registrationRequestReturnsAssigned(),
       queryOperationStatus: operationStatusReturnsAssigned(),

--- a/provisioning/e2e/package.json
+++ b/provisioning/e2e/package.json
@@ -11,6 +11,7 @@
     "azure-iot-provisioning-device-amqp": "0.0.1",
     "azure-iot-provisioning-device-http": "0.0.1",
     "azure-iot-provisioning-device-mqtt": "0.0.1",
+    "azure-iot-security-x509": "0.0.1",
     "azure-iothub": "1.2.1",
     "bluebird": "^3.5.1",
     "chai": "^3.5.0",

--- a/provisioning/transport/http/devdoc/http_requirements.md
+++ b/provisioning/transport/http/devdoc/http_requirements.md
@@ -10,11 +10,11 @@ This module provides HTTP protocol support to communicate with the Azure device 
 
 ## Public Interface
 
-### constructor(idScope: string, registrationId: string) : void
+### constructor(idScope: number, httpBase?: Base)
 The `constructor` creates an Http transport object used to communicate with the Azure device provisioning service
 
 **SRS_NODE_PROVISIONING_HTTP_18_001: [** The `Http` constructor shall accept the following properties:
-  - `config` - a configuration object describing the connection to the service.
+  - `idScope` - the ID Scope value for the provisioning service
   - `httpBase` - an optional test implementation of azure-iot-http-base **]**
 
 

--- a/provisioning/transport/http/index.d.ts
+++ b/provisioning/transport/http/index.d.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { Http } from './lib/http';
+export { Http } from './lib/http_transport';
 

--- a/provisioning/transport/http/index.js
+++ b/provisioning/transport/http/index.js
@@ -3,8 +3,6 @@
 
 'use strict';
 
-var Http = require('./lib/http.js').Http;
-
 /**
  * The `azure-iot-provisioning-http` module provides support for the HTTPS protocol to the Azure Device Provisoning Service.
  *
@@ -14,5 +12,5 @@ var Http = require('./lib/http.js').Http;
  */
 
 module.exports = {
-  Http: Http
+  Http: require('./lib/http_transport.js').Http
 };

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -32,7 +32,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 92 --branches 83 --lines 92 --functions 70"
+    "check-cover": "istanbul check-coverage --statements 92 --branches 72 --lines 92 --functions 70"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/transport/http/src/http_transport.ts
+++ b/provisioning/transport/http/src/http_transport.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import { EventEmitter } from 'events';
+import { X509 } from 'azure-iot-common';
+import { ProvisioningTransportOptions, ProvisioningTransportHandlersX509, PollingStateMachine } from 'azure-iot-provisioning-device';
+import { Http as Base } from 'azure-iot-http-base';
+import { HttpPollingHandlers } from './http_polling_handlers';
+
+export class Http  extends EventEmitter implements ProvisioningTransportHandlersX509 {
+  private _stateMachine: PollingStateMachine;
+  private _pollingHandlers: HttpPollingHandlers;
+
+  constructor(idScope: number, httpBase?: Base) {
+    super();
+    this._pollingHandlers = new HttpPollingHandlers(idScope, httpBase);
+    this._stateMachine = new PollingStateMachine(this._pollingHandlers);
+
+    this._stateMachine.on('operationStatus', (eventBody) => {
+      this.emit('operationStatus', eventBody);
+    });
+  }
+
+  endSession(callback: (err?: Error) => void): void {
+    this._stateMachine.endSession(callback);
+  }
+
+  setTransportOptions(options: ProvisioningTransportOptions): void {
+    this._pollingHandlers.setTransportOptions(options);
+  }
+
+  registerX509(registrationId: string, authorization: X509, forceRegistration: boolean, callback: (err?: Error, assignedHub?: string, deviceId?: string, responseBody?: any, result?: any) => void): void {
+    this._stateMachine.register(registrationId, authorization, {'registrationId' : registrationId}, forceRegistration, (err, responseBody, result) => {
+      if (err) {
+        callback(err, null, null, responseBody, result );
+      } else {
+        callback(err, responseBody.registrationStatus.assignedHub, responseBody.registrationStatus.deviceId, responseBody, result);
+     }
+    });
+  }
+}

--- a/security/tpm/index.js
+++ b/security/tpm/index.js
@@ -4,5 +4,5 @@
 'use strict';
 
 module.exports = {
-  TpmSecurityClient : require('lib/tpm').TpmSecurityClient 
+  TpmSecurityClient : require('./lib/tpm').TpmSecurityClient
 };

--- a/security/x509/index.js
+++ b/security/x509/index.js
@@ -4,5 +4,5 @@
 'use strict';
 
 module.exports = {
-  X509SecurityClient: require('lib/x509').X509SecurityClient
+  X509SecurityClient: require('./lib/x509').X509SecurityClient
 };

--- a/security/x509/src/x509.ts
+++ b/security/x509/src/x509.ts
@@ -2,11 +2,17 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 'use strict';
-import { errors } from 'azure-iot-common';
+import { errors, X509 } from 'azure-iot-common';
 
 export class X509SecurityClient {
-  getCertificate(callback: (err?: Error, cert?: string) => void): void {
-    throw new errors.NotImplementedError();
+  private _cert: X509;
+
+  constructor(cert: X509) {
+    this._cert = cert;
+  }
+
+  getCertificate(callback: (err?: Error, cert?: X509) => void): void {
+    callback(null, this._cert);
   }
 
   getCertificateChain(callback: (err?: Error, cert?: string) => void): void {

--- a/security/x509/test/_x509_test.js
+++ b/security/x509/test/_x509_test.js
@@ -6,16 +6,20 @@
 var X509SecurityClient = require('../lib/x509').X509SecurityClient;
 var assert = require('chai').assert;
 
+var fakeCert = "fake certificate"
+
 describe('x509', function () {
   this.timeout(1000);
 
-  var obj = new X509SecurityClient();
+  var obj = new X509SecurityClient(fakeCert);
 
   describe('getCertificate', function() {
-    it ('throws', function() {
-      assert.throws(function() {
-        obj.getCertificate();
-      });
+    it ('returns the cert', function(callback) {
+        obj.getCertificate(function(err, cert) {
+          assert(!err);
+          assert.equal(cert, fakeCert);
+          callback();
+        });
     });
   });
 


### PR DESCRIPTION
stubbed out a bunch of objects to show the user experience with the api.
Now the user does the following to register:
1. Create the transport object 
1. Create the securityClient object
1. Creates the ProvisioningDeviceClient and calls the registration method.

I'm expecting to change the following:
1. EndSession will be removed from the top level API.  The session will end when the registration is complete.
1. New interfaces will be added for TPM.  Every time you see x509, assume there will be a corresponding change for TPM.
1. Interfaces will be added for X509 and TPM security clients.  I haven't created any interfaces because there's only really 1 implementation so far.
1. The registerX509 method will become a register method.  The client will determine if it's x509 or TPM based on the security client.