### PR TITLE
DPS SDK: TPM Provisioning state machine (cancel method not tested)

### DIFF
--- a/provisioning/device/devdoc/tpm_registration_requirements.md
+++ b/provisioning/device/devdoc/tpm_registration_requirements.md
@@ -1,0 +1,74 @@
+# TpmRegistration requirements
+
+## Overview
+
+The `TpmRegistration` class is used to control the registration flow of a TPM-enabled device, regardless of the transport, or `TpmSecurityClient` implementation.
+
+## Example usage
+
+```js
+// TODO once all the pieces are there in the SDK
+
+```
+
+## Public API
+
+### register()
+
+The `register` method completes the authentication and registration flow for the user.
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_001: [** The `register` method shall get the endorsement key by calling `getEndorsementKey` on the `TpmSecurityClient` object passed to the constructor. **]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_002: [** The `register` method shall get the storage root key by calling `getStorageRootKey` on the `TpmSecurityClient` object passed to the constructor. **]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_003: [** The `register` method shall initiate the authentication flow with the device provisioning service by calling the `getAuthenticationChallenge` method of the `TpmProvisioningTransport` object passed to the constructor with an object with the following properties:
+- `registrationId`: a unique identifier computed from the endorsement key
+- `endorsementKey`: the `endorsementKey` value obtained from the `TpmSecurityClient` object
+- `storageRootKey`: the `storageRootKey` value obtained from the `TpmSecurityClient` object
+- a callback that will handle either an error or a `TpmChallenge` object containing a session key to be used later in the authentication process.
+**]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_004: [** The `register` method shall store the session key in the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+- `sessionKey`: the session key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+- a callback that will handle an optional error if the operation fails.
+**]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_005: [** The `register` method shall create a signature for the initial SAS token by signing the following payload with the session key and the `TpmSecurityClient`:
+```
+<idScope>/registrations/<registrationId>\n<expiryTimeUtc>
+```
+with:
+- `idScope` being the value of the `idScope` argument passed to the `TpmRegistration` constructor.
+- `registrationId` being the previously computed registration id.
+- `expiryTimeUtc` being the number of seconds since Epoch + a delay during which the initial sas token should be valid (1 hour by default).
+ **]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_006: [** The `register` method shall create a SAS token to be used to get the actual registration result as follows:
+```
+SharedAccessSignature sr=<audience>&sig=<signature>&se=<expiryTimeUtc>&skn=registration
+```
+With the following fields:
+- `audience`: <idScope>/registrations/<registrationId>
+- `signature`: the base64 encoded version of the signature generated per `SRS_NODE_DPS_TPM_REGISTRATION_16_005`
+- `expiryTimeUtc`: the same value that was used to generate the signature.
+ **]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_007: [** The `register` method shall start the actual registration process by calling the `register` method on the `TpmProvisioningTransport` object passed to the constructor with the following parameters:
+- `sasToken`: the SAS token generated according to `SRS_NODE_DPS_TPM_REGISTRATION_16_006`
+- `registrationInfo`: an object with the following properties `endorsementKey`, `storageRootKey`, `registrationId` and their previously set values.
+- a callback that will handle an optional error and a `result` object containing the IoT hub name, device id and symmetric key for this device.
+**]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_008: [** When the callback for the registration process is called, the `register` method shall store the symmetric key within the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+- `symmetricKey`: the symmetric key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+- a callback that will handle an optional error if the operation fails.
+
+**]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_009: [** Once the symmetric key has been stored, the `register` method shall call its own callback with a `null` error object and a `TpmRegistrationResult` object containing the information that the `TpmProvisioningTransport` returned once the registration was successful. **]**
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_010: [** If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure. **]**
+
+### cancel()
+
+**SRS_NODE_DPS_TPM_REGISTRATION_16_011: [** The `cancel` method shall interrupt the ongoing registration process. **]**

--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -30,7 +30,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 81 --branches 71 --lines 83 --functions 76"
+    "check-cover": "istanbul check-coverage --statements 77 --branches 65 --lines 79 --functions 69"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -67,6 +67,39 @@ export interface TransportHandlers {
   getErrorResult(result: any): any;
 }
 
+export interface RegistrationClient {
+  register(callback: (err?: Error) => void): void;
+  cancel(callback: (err?: Error) => void): void;
+}
 
+export interface TpmRegistrationInfo {
+  registrationId: string;
+  endorsementKey: string;
+  storageRootKey: string;
+}
 
+export interface TpmRegistrationResult {
+  deviceId: string;
+  iotHubUri: string;
+  symmetricKey: string;
+}
 
+export interface TpmProvisioningTransport {
+  getAuthenticationChallenge(registrationInfo: TpmRegistrationInfo, callback: (err: Error, tpmChallenge?: TpmChallenge) => void): void;
+  register(registrationInfo: TpmRegistrationInfo, sasToken: string, callback: (err: Error, result?: TpmRegistrationResult) => void): void;
+  cancel(callback: (err: Error) => void): void;
+}
+
+export interface TpmSecurityClient {
+  getEndorsementKey(callback: (err: Error, endorsementKey?: string) => void): void;
+  getStorageRootKey(callback: (err: Error, storageRootKey?: string) => void): void;
+  signWithIdentity(toSign: string, callback: (err: Error, signedData?: string) => void): void;
+  activateIdentityKey(key: string, callback: (err: Error) => void): void;
+  cancel(callback: (err: Error) => void): void;
+}
+
+export interface TpmChallenge {
+  message: string;
+  authenticationKey: string;
+  keyName: string;
+}

--- a/provisioning/device/src/tpm_registration.ts
+++ b/provisioning/device/src/tpm_registration.ts
@@ -1,0 +1,239 @@
+import { EventEmitter } from 'events';
+import * as machina from 'machina';
+import * as dbg from 'debug';
+const debug = dbg('azure-iot-provisioning-device:TpmRegistration');
+import { RegistrationClient, TpmProvisioningTransport, TpmSecurityClient, TpmRegistrationInfo } from './interfaces';
+
+export class TpmRegistration extends EventEmitter implements RegistrationClient {
+  private _fsm: machina.Fsm;
+  private _transport: TpmProvisioningTransport;
+  private _securityClient: TpmSecurityClient;
+  private _idScope: string;
+
+  constructor(idScope: string, transport: TpmProvisioningTransport, securityClient: TpmSecurityClient) {
+    super();
+    this._idScope = idScope;
+    this._transport = transport;
+    this._securityClient = securityClient;
+
+    this._fsm = new machina.Fsm({
+      namespace: 'tpm-registration',
+      initialState: 'notStarted',
+      states: {
+        notStarted: {
+          _onEnter: (err, callback) => {
+            if (callback) {
+              callback(err);
+            } else if (err) {
+              this.emit('error', err);
+            }
+          },
+          register: (callback) => this._fsm.transition('authenticating', callback),
+          cancel: (callback) => callback()
+        },
+        authenticating: {
+          _onEnter: (registerCallback) => {
+            let registrationInfo: TpmRegistrationInfo = {
+              endorsementKey: undefined,
+              storageRootKey: undefined,
+              registrationId: undefined
+            };
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_001: [The `register` method shall get the endorsement key by calling `getEndorsementKey` on the `TpmSecurityClient` object passed to the constructor.]*/
+            this._securityClient.getEndorsementKey((err, ek) => {
+              if (err) {
+                debug('failed to get endorsement key from TPM security client: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                registrationInfo.endorsementKey = ek;
+                registrationInfo.registrationId = this._createRegistrationIdFromEndorsementKey(ek);
+                this._fsm.handle('getStorageRootKey', registrationInfo, registerCallback);
+              }
+            });
+          },
+          getStorageRootKey: (registrationInfo, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_002: [The `register` method shall get the storage root key by calling `getStorageRootKey` on the `TpmSecurityClient` object passed to the constructor.]*/
+            this._securityClient.getStorageRootKey((err, srk) => {
+              if (err) {
+                debug('failed to get storage root key from TPM security client: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                registrationInfo.storageRootKey = srk;
+                this._fsm.handle('getTpmChallenge', registrationInfo, registerCallback);
+              }
+            });
+          },
+          getTpmChallenge: (registrationInfo, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_003: [The `register` method shall initiate the authentication flow with the device provisioning service by calling the `getAuthenticationChallenge` method of the `TpmProvisioningTransport` object passed to the constructor with an object with the following properties:
+            - `registrationId`: a unique identifier computed from the endorsement key
+            - `endorsementKey`: the `endorsementKey` value obtained from the `TpmSecurityClient` object
+            - `storageRootKey`: the `storageRootKey` value obtained from the `TpmSecurityClient` object
+            - a callback that will handle either an error or a `TpmChallenge` object containing a session key to be used later in the authentication process.]*/
+            this._transport.getAuthenticationChallenge(registrationInfo, (err, tpmChallenge) => {
+              if (err) {
+                debug('failed to get sessionKey from provisioning service: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                this._fsm.handle('activateSessionKey', tpmChallenge, registrationInfo, registerCallback);
+              }
+            });
+          },
+          activateSessionKey: (tpmChallenge, registrationInfo, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_004: [The `register` method shall store the session key in the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+            - `sessionKey`: the session key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+            - a callback that will handle an optional error if the operation fails.]*/
+            this._securityClient.activateIdentityKey(tpmChallenge.authenticationKey, (err) => {
+              if (err) {
+                debug('failed to activate the sessionKey: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                this._fsm.handle('createRegistrationSas', registrationInfo, registerCallback);
+              }
+            });
+          },
+          createRegistrationSas: (registrationInfo, registerCallback) => {
+            this._createRegistrationSas(registrationInfo.registrationId, (err, sasToken) => {
+              if (err) {
+                debug('failed to get sign the initial authentication payload with the sessionKey: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                  this._fsm.transition('notStarted', err, registerCallback);
+                } else {
+                this._fsm.transition('registrationInProgress', registrationInfo, sasToken, registerCallback);
+              }
+            });
+          },
+          cancel: (callback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_011: [The `cancel` method shall interrupt the ongoing registration process.]*/
+            this._transport.cancel((err) => {
+              if (err) {
+                debug('failed to stop provisioning transport: ' + err.toString());
+              }
+              this._securityClient.cancel((err) => {
+                if (err) {
+                  debug('failed to stop provisioning transport: ' + err.toString());
+                }
+                this._fsm.transition('notStarted', err, callback);
+              });
+            });
+          },
+          '*': () => this._fsm.deferUntilTransition()
+        },
+        registrationInProgress: {
+          _onEnter: (registrationInfo, sasToken, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_007: [The `register` method shall start the actual registration process by calling the `register` method on the `TpmProvisioningTransport` object passed to the constructor with the following parameters:
+            - `sasToken`: the SAS token generated according to `SRS_NODE_DPS_TPM_REGISTRATION_16_006`
+            - `registrationInfo`: an object with the following properties `endorsementKey`, `storageRootKey`, `registrationId` and their previously set values.
+            - a callback that will handle an optional error and a `result` object containing the IoT hub name, device id and symmetric key for this device.]*/
+            this._transport.register(registrationInfo, sasToken, (err, result) => {
+              if (err) {
+                debug('failed to register with provisioning transport: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                this._fsm.transition('storingSecret', result, registerCallback);
+              }
+            });
+          },
+          cancel: (callback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_011: [The `cancel` method shall interrupt the ongoing registration process.]*/
+            this._transport.cancel((err) => {
+              if (err) {
+                debug('failed to stop provisioning transport: ' + err.toString());
+              }
+              this._fsm.transition('notStarted', err, callback);
+            });
+          },
+          '*': () => this._fsm.deferUntilTransition()
+        },
+        storingSecret: {
+          _onEnter: (registrationResult, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_008: [When the callback for the registration process is called, the `register` method shall store the symmetric key within the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+            - `symmetricKey`: the symmetric key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+            - a callback that will handle an optional error if the operation fails.
+            ]*/
+            this._securityClient.activateIdentityKey(registrationResult.symmetricKey, (err) => {
+              if (err) {
+                debug('failed to stop provisioning transport: ' + err.toString());
+                /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+                this._fsm.transition('notStarted', err, registerCallback);
+              } else {
+                this._fsm.transition('completed', registrationResult, registerCallback);
+              }
+            });
+          },
+          cancel: (callback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_011: [The `cancel` method shall interrupt the ongoing registration process.]*/
+            this._securityClient.cancel((err) => {
+              if (err) {
+                debug('failed to stop provisioning transport: ' + err.toString());
+              }
+              this._fsm.transition('notStarted', err, callback);
+            });
+          },
+           '*': () => this._fsm.deferUntilTransition()
+        },
+        completed: {
+          _onEnter: (registrationResult, registerCallback) => {
+            /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_009: [Once the symmetric key has been stored, the `register` method shall call its own callback with a `null` error object and a `TpmRegistrationResult` object containing the information that the `TpmProvisioningTransport` returned once the registration was successful.]*/
+            registerCallback(null, registrationResult);
+          },
+          cancel: (callback) => {
+            // TODO: is this weird? also what type of error?
+            callback(new Error('cannot cancel - registration was successfully completed'));
+          }
+        }
+      }
+    });
+  }
+
+  register(callback: (err?: Error) => void): void {
+    this._fsm.handle('register', callback);
+  }
+
+  cancel(callback: (err?: Error) => void): void {
+    this._fsm.handle('cancel', callback);
+  }
+
+  private _createRegistrationIdFromEndorsementKey(endorsementKey: string): string {
+    // figure out encoding of EK or if user should set it
+    return 'fakeRegistrationId';
+  }
+
+  private _createRegistrationSas(registrationId: string, callback: (err: Error, sasToken?: string) => void): void {
+
+    /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_005: [The `register` method shall create a signature for the initial SAS token by signing the following payload with the session key and the `TpmSecurityClient`:
+    ```
+    <idScope>/registrations/<registrationId>\n<expiryTimeUtc>
+    ```
+    with:
+    - `idScope` being the value of the `idScope` argument passed to the `TpmRegistration` constructor.
+    - `registrationId` being the previously computed registration id.
+    - `expiryTimeUtc` being the number of seconds since Epoch + a delay during which the initial sas token should be valid (1 hour by default).
+    ]*/
+    const expiryTimeUtc = Date.now() / 1000 + 3600; // 1 hour from now.
+    const audience = encodeURIComponent(this._idScope + '/registrations/' + registrationId);
+    const payload = audience + '\n' + expiryTimeUtc.toString();
+
+    this._securityClient.signWithIdentity(payload, (err, signedBytes) => {
+      const signature = new Buffer(payload).toString('base64');
+      if (err) {
+        debug('failed to sign the initial authentication payload with sessionKey: ' + err.toString());
+        callback(err);
+      } else {
+        /*Codes_SRS_NODE_DPS_TPM_REGISTRATION_16_006: [The `register` method shall create a SAS token to be used to get the actual registration result as follows:
+        ```
+        SharedAccessSignature sr=<audience>&sig=<signature>&se=<expiryTimeUtc>&skn=registration
+        ```
+        With the following fields:
+        - `audience`: <idScope>/registrations/<registrationId>
+        - `signature`: the base64 encoded version of the signature generated per `SRS_NODE_DPS_TPM_REGISTRATION_16_005`
+        - `expiryTimeUtc`: the same value that was used to generate the signature.
+        ]*/
+        callback(null, 'SharedAccessSignature sr=' + audience + '&sig=' + signature + '&se=' + expiryTimeUtc.toString() + '&skn=registration');
+      }
+    });
+  }
+}

--- a/provisioning/device/test/_tpm_registration_test.js
+++ b/provisioning/device/test/_tpm_registration_test.js
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+
+var TpmRegistration = require('../lib/tpm_registration.js').TpmRegistration;
+
+describe('TpmRegistration', function () {
+  describe('#register', function () {
+    var fakeSecurityClient, fakeProvisioningTransport;
+
+    var fakeEndorsementKey = 'fakeEndorsementKey';
+    var fakeStorageRootKey = 'fakeStorageRootKey';
+    var fakeSignedData = 'fakeSignedData';
+    var fakeIdScope = 'fakeIdScope';
+
+    var fakeTpmChallenge = {
+      authenticationKey: 'fakeSessionKey'
+    };
+
+    var fakeTpmRegistrationResult = {
+      symmetricKey: 'fakeSymmetricKey'
+    };
+
+    beforeEach(function () {
+      fakeSecurityClient = {
+        getEndorsementKey: sinon.stub().callsArgWith(0, null, fakeEndorsementKey),
+        getStorageRootKey: sinon.stub().callsArgWith(0, null, fakeStorageRootKey),
+        signWithIdentity: sinon.stub().callsArgWith(1, null, fakeSignedData),
+        activateIdentityKey: sinon.stub().callsArg(1),
+        cancel: sinon.stub().callsArg(0)
+      };
+
+      fakeProvisioningTransport = {
+        getAuthenticationChallenge: sinon.stub().callsArgWith(1, null, fakeTpmChallenge),
+        register: sinon.stub().callsArgWith(2, null, fakeTpmRegistrationResult),
+        cancel: sinon.stub().callsArg(0)
+      };
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_001: [The `register` method shall get the endorsement key by calling `getEndorsementKey` on the `TpmSecurityClient` object passed to the constructor.]*/
+    it('calls getEndorsementKey on the TpmSecurityClient', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeSecurityClient.getEndorsementKey.calledOnce);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_002: [The `register` method shall get the storage root key by calling `getStorageRootKey` on the `TpmSecurityClient` object passed to the constructor.]*/
+    it('calls getStorageRootKey on the TpmSecurityClient', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeSecurityClient.getStorageRootKey.calledOnce);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_003: [The `register` method shall initiate the authentication flow with the device provisioning service by calling the `getAuthenticationChallenge` method of the `TpmProvisioningTransport` object passed to the constructor with an object with the following properties:
+    - `registrationId`: a unique identifier computed from the endorsement key
+    - `endorsementKey`: the `endorsementKey` value obtained from the `TpmSecurityClient` object
+    - `storageRootKey`: the `storageRootKey` value obtained from the `TpmSecurityClient` object
+    - a callback that will handle either an error or a `TpmChallenge` object containing a session key to be used later in the authentication process.]*/
+    it('calls getAuthenticationChallenge on the TpmProvisioningTransport', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeProvisioningTransport.getAuthenticationChallenge.calledOnce);
+        var authArg = fakeProvisioningTransport.getAuthenticationChallenge.firstCall.args[0];
+        assert.strictEqual(authArg.endorsementKey, fakeEndorsementKey);
+        assert.strictEqual(authArg.storageRootKey, fakeStorageRootKey);
+        assert.strictEqual(authArg.registrationId, 'fakeRegistrationId');
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_004: [The `register` method shall store the session key in the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+    - `sessionKey`: the session key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+    - a callback that will handle an optional error if the operation fails.]*/
+    it('calls activateIdentityKey on the TpmSecurityClient with the session key', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeSecurityClient.activateIdentityKey.calledTwice);
+        assert.strictEqual(fakeSecurityClient.activateIdentityKey.firstCall.args[0], fakeTpmChallenge.authenticationKey);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_007: [The `register` method shall start the actual registration process by calling the `register` method on the `TpmProvisioningTransport` object passed to the constructor with the following parameters:
+    - `sasToken`: the SAS token generated according to `SRS_NODE_DPS_TPM_REGISTRATION_16_006`
+    - `registrationInfo`: an object with the following properties `endorsementKey`, `storageRootKey`, `registrationId` and their previously set values.
+    - a callback that will handle an optional error and a `result` object containing the IoT hub name, device id and symmetric key for this device.]*/
+    it('calls register on the TpmProvisioningTransport', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeProvisioningTransport.register.calledOnce);
+        var authArg = fakeProvisioningTransport.getAuthenticationChallenge.firstCall.args[0];
+        assert.strictEqual(authArg.endorsementKey, fakeEndorsementKey);
+        assert.strictEqual(authArg.storageRootKey, fakeStorageRootKey);
+        assert.strictEqual(authArg.registrationId, 'fakeRegistrationId');
+
+        // TODO: SAS token format test could be improved (see SRS_NODE_DPS_TPM_REGISTRATION_16_005 and SRS_NODE_DPS_TPM_REGISTRATION_16_006)
+        assert.isString(fakeProvisioningTransport.register.firstCall.args[1]);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_008: [When the callback for the registration process is called, the `register` method shall store the symmetric key within the TPM by calling the `activateIdentityKey` method of the `TpmSecurityClient` object passed to the constructor with the following arguments:
+    - `symmetricKey`: the symmetric key property of the `TpmChallenge` object returned by the previous call to `TpmProvisioningTransport.getAuthenticationChallenge`
+    - a callback that will handle an optional error if the operation fails.]*/
+    it('calls the activateIdentityKey method on the TpmSecurityClient with the actual symmetric key when the registration is successful', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function () {
+        assert.isTrue(fakeSecurityClient.activateIdentityKey.calledTwice);
+        assert.strictEqual(fakeSecurityClient.activateIdentityKey.secondCall.args[0], fakeTpmRegistrationResult.symmetricKey);
+        testCallback();
+      });
+    });
+
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_009: [Once the symmetric key has been stored, the `register` method shall call its own callback with a `null` error object and a `TpmRegistrationResult` object containing the information that the `TpmProvisioningTransport` returned once the registration was successful.]*/
+    it('calls the register callback once the registration is successful', function (testCallback) {
+      var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+      tpmReg.register(function (err, result) {
+        assert.isNull(err);
+        assert.strictEqual(result.symmetricKey, fakeTpmRegistrationResult.symmetricKey);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DPS_TPM_REGISTRATION_16_010: [If any of the calls the the `TpmSecurityClient` or the `TpmProvisioningTransport` fails, the `register` method shall call its callback with the error resulting from the failure.]*/
+    [
+       { methodName: 'getEndorsementKey', stub: sinon.stub().callsArgWith(0, new Error('failed')) },
+       { methodName: 'getStorageRootKey', stub: sinon.stub().callsArgWith(0, new Error('failed')) },
+       { methodName: 'signWithIdentity', stub: sinon.stub().callsArgWith(1, new Error('failed')) },
+       { methodName: 'activateIdentityKey', stub: sinon.stub().callsArgWith(1, new Error('failed')) }
+    ].forEach(function (testConfig) {
+      it('calls the register callback with an error if TpmSecurityClient.' + testConfig.methodName + ' fails', function (testCallback) {
+        fakeSecurityClient[testConfig.methodName] = testConfig.stub;
+        var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+        tpmReg.register(function (err, result) {
+          assert.instanceOf(err, Error);
+          testCallback();
+        });
+      });
+    });
+
+    [
+      { methodName: 'getAuthenticationChallenge', stub: sinon.stub().callsArgWith(1, new Error('failed')) },
+      { methodName: 'register', stub: sinon.stub().callsArgWith(2, new Error('failed')) },
+   ].forEach(function (testConfig) {
+     it('calls the register callback with an error if TpmProvisioningTransport.' + testConfig.methodName + ' fails', function (testCallback) {
+       fakeProvisioningTransport[testConfig.methodName] = testConfig.stub;
+       var tpmReg = new TpmRegistration(fakeIdScope, fakeProvisioningTransport, fakeSecurityClient);
+       tpmReg.register(function (err, result) {
+         assert.instanceOf(err, Error);
+         testCallback();
+       });
+     });
+   });
+  });
+
+  describe('#cancel', function () {
+
+  });
+});


### PR DESCRIPTION
# Description of the problem
TPM registration flow requires a state machine that is independent of the transport used

# Description of the solution
This is the state machine for the TPM registration flow.
I've added a `cancel` method to the API but haven't tested it because we need to agree whether we want this in our objects or not. I think we do... the C# SDK has a cancellation token. if we decide to go with it I'll populate the tests and coverage will go back up.
