### PR TITLE
Do not try to stringify the err result.

### DIFF
--- a/provisioning/service/samples/create_delete.js
+++ b/provisioning/service/samples/create_delete.js
@@ -29,12 +29,12 @@ var enrollment2 = {
 
 serviceClient.createOrUpdateIndividualEnrollment(enrollment1, function(err, firstEnrollmentResponse) {
   if (err) {
-    console.log('error creating the first enrollment: ' + JSON.stringify(err));
+    console.log('error creating the first enrollment: ' + err);
   } else {
     console.log("enrollment record returned for first: " + JSON.stringify(firstEnrollmentResponse, null, 2));
     serviceClient.createOrUpdateIndividualEnrollment(enrollment2, function(err, secondEnrollmentResponse) {
       if (err) {
-        console.log('error creating the second enrollment: ' + JSON.stringify(err));
+        console.log('error creating the second enrollment: ' + err);
       } else {
         console.log("enrollment record returned for second: " + JSON.stringify(secondEnrollmentResponse, null, 2));
         //
@@ -45,11 +45,11 @@ serviceClient.createOrUpdateIndividualEnrollment(enrollment1, function(err, firs
           if (err) {
             serviceClient.deleteIndividualEnrollment(firstEnrollmentResponse.registrationId, firstEnrollmentResponse.etag, function(err) {
               if (err) {
-                console.log('error deleting the first enrollment: ' + JSON.stringify(err, null, 2));
+                console.log('error deleting the first enrollment: ' + err);
               } else {
                 serviceClient.deleteIndividualEnrollment(secondEnrollmentResponse, function(err) {
                   if (err) {
-                    console.log('error deleting the second enrollment: ' + JSON.stringify(err, null, 2));
+                    console.log('error deleting the second enrollment: ' + err);
                   }
                 });
               }

--- a/provisioning/service/samples/create_enrollment_group.js
+++ b/provisioning/service/samples/create_enrollment_group.js
@@ -25,7 +25,7 @@ var enrollment = {
 
 serviceClient.createOrUpdateEnrollmentGroup(enrollment, function(err, enrollmentResponse) {
   if (err) {
-    console.log('error creating the group enrollment: ' + JSON.stringify(err));
+    console.log('error creating the group enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
   }

--- a/provisioning/service/samples/create_individual_enrollment.js
+++ b/provisioning/service/samples/create_individual_enrollment.js
@@ -21,7 +21,7 @@ var enrollment = {
 
 serviceClient.createOrUpdateIndividualEnrollment(enrollment, function(err, enrollmentResponse) {
   if (err) {
-    console.log('error creating the individual enrollment: ' + JSON.stringify(err));
+    console.log('error creating the individual enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
   }


### PR DESCRIPTION

# Description of the problem
Some of the samples were attempting to stringify the error result of an operation.  This causes a circular exception.

# Description of the solution
Removed the stringfy and just let it print,