### PR TITLE
Fixes for device enrollment update test and #162

### DIFF
--- a/provisioning/service/devdoc/provisioningserviceclient.md
+++ b/provisioning/service/devdoc/provisioningserviceclient.md
@@ -32,6 +32,7 @@ The `createOrUpdateIndividualEnrollment` method adds a device enrollment.
 
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_009: [** The `createOrUpdateIndividualEnrollment` method shall throw `ReferenceError` if the `enrollment` argument is falsy.  **]**
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_011: [** The `createOrUpdateIndividualEnrollment` method shall throw `ArgumentError` if the `enrollment.registrationId` property is falsy. **]**
+**SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_056: [** If the `enrollment` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request. **]**
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_010: [** The `createOrUpdateIndividualEnrollment` method shall construct an HTTP request using information supplied by the caller, as follows:
 ```
 PUT /enrollments/<uri-encoded-enrollment.registrationId>?api-version=<version> HTTP/1.1
@@ -48,6 +49,7 @@ The `createOrUpdateEnrollmentGroup` method adds a device enrollment group.
 
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_012: [** The `createOrUpdateEnrollmentGroup` method shall throw `ReferenceError` if the `EnrollmentGroup` argument is falsy. **]**
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_013: [** `createOrUpdateEnrollmentGroup` method shall throw `ArgumentError` if the `enrollmentGroup.enrollmentGroupsId` property is falsy. **]**
+**SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_055: [** If the `enrollmentGroup` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request. **]**
 **SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_014: [** The `createOrUpdateEnrollmentGroup` method shall construct an HTTP request using information supplied by the caller, as follows:
 ```
 PUT /enrollmentGroups/<uri-encoded-enrollmentGroup.enrollmentGroupsId>?api-version=<version> HTTP/1.1

--- a/provisioning/service/samples/create_delete.js
+++ b/provisioning/service/samples/create_delete.js
@@ -29,12 +29,12 @@ var enrollment2 = {
 
 serviceClient.createOrUpdateIndividualEnrollment(enrollment1, function(err, firstEnrollmentResponse) {
   if (err) {
-    console.log('error creating the first enrollment: ' + JSON.stringify(err));
+    console.log('error creating the first enrollment: ' + err);
   } else {
     console.log("enrollment record returned for first: " + JSON.stringify(firstEnrollmentResponse, null, 2));
     serviceClient.createOrUpdateIndividualEnrollment(enrollment2, function(err, secondEnrollmentResponse) {
       if (err) {
-        console.log('error creating the second enrollment: ' + JSON.stringify(err));
+        console.log('error creating the second enrollment: ' + err);
       } else {
         console.log("enrollment record returned for second: " + JSON.stringify(secondEnrollmentResponse, null, 2));
         //
@@ -45,11 +45,11 @@ serviceClient.createOrUpdateIndividualEnrollment(enrollment1, function(err, firs
           if (err) {
             serviceClient.deleteIndividualEnrollment(firstEnrollmentResponse.registrationId, firstEnrollmentResponse.etag, function(err) {
               if (err) {
-                console.log('error deleting the first enrollment: ' + JSON.stringify(err, null, 2));
+                console.log('error deleting the first enrollment: ' + err);
               } else {
                 serviceClient.deleteIndividualEnrollment(secondEnrollmentResponse, function(err) {
                   if (err) {
-                    console.log('error deleting the second enrollment: ' + JSON.stringify(err, null, 2));
+                    console.log('error deleting the second enrollment: ' + err);
                   }
                 });
               }

--- a/provisioning/service/samples/create_enrollment_group.js
+++ b/provisioning/service/samples/create_enrollment_group.js
@@ -19,7 +19,8 @@ var enrollment = {
         }
       }
     }
-  }
+  },
+  provisioningStatus: 'disabled'
 };
 
 
@@ -28,5 +29,13 @@ serviceClient.createOrUpdateEnrollmentGroup(enrollment, function(err, enrollment
     console.log('error creating the group enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
+    enrollmentResponse.provisioningStatus = 'enabled';
+    serviceClient.createOrUpdateEnrollmentGroup(enrollmentResponse, function(err, enrollmentResponse) {
+      if (err) {
+        console.log('error updating the group enrollment: ' + err);
+      } else {
+        console.log("updated enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
+      }
+    });
   }
 });

--- a/provisioning/service/samples/create_enrollment_group.js
+++ b/provisioning/service/samples/create_enrollment_group.js
@@ -25,7 +25,7 @@ var enrollment = {
 
 serviceClient.createOrUpdateEnrollmentGroup(enrollment, function(err, enrollmentResponse) {
   if (err) {
-    console.log('error creating the group enrollment: ' + JSON.stringify(err));
+    console.log('error creating the group enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
   }

--- a/provisioning/service/samples/create_individual_enrollment.js
+++ b/provisioning/service/samples/create_individual_enrollment.js
@@ -21,7 +21,7 @@ var enrollment = {
 
 serviceClient.createOrUpdateIndividualEnrollment(enrollment, function(err, enrollmentResponse) {
   if (err) {
-    console.log('error creating the individual enrollment: ' + JSON.stringify(err));
+    console.log('error creating the individual enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2));
   }

--- a/provisioning/service/src/provisioningserviceclient.ts
+++ b/provisioning/service/src/provisioningserviceclient.ts
@@ -245,6 +245,12 @@ export class ProvisioningServiceClient {
       'Accept': 'application/json',
       'Content-Type': 'application/json; charset=utf-8'
     };
+
+    /*Codes_SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_055: [If the `enrollmentGroup` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request.] */
+    /*Codes_SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_056: [If the `enrollment` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request.] */
+    if (enrollment.etag) {
+      httpHeaders['If-Match'] = enrollment.etag;
+    }
     /*Codes_SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_010: [The `createOrUpdateIndividualEnrollment` method shall construct an HTTP request using information supplied by the caller, as follows:
       PUT /enrollments/<uri-encoded-enrollment.registrationId>?api-version=<version> HTTP/1.1
       Authorization: <sharedAccessSignature>

--- a/provisioning/service/test/_provisioningserviceclient_test.js
+++ b/provisioning/service/test/_provisioningserviceclient_test.js
@@ -218,6 +218,28 @@ describe('ProvisioningServiceClient', function() {
       var de = new ProvisioningServiceClient({ host: 'host', sharedAccessSignature: 'sas' }, fakeHttpHelper);
       de.createOrUpdateIndividualEnrollment(fakeEnrollmentNoEtag, testCallback);
     });
+
+    /*Tests_SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_056: [If the `enrollment` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request.] */
+    it('Add If-Match if etag property present', function(testCallback) {
+      var fakeHttpHelper = {
+        executeApiCall: function (method, path, httpHeaders, body, done) {
+          assert.equal(method, 'PUT');
+          assert.equal(path, '/enrollments/' + encodeURIComponent(fakeRegistrationId) + _versionQueryString());
+          assert.equal(httpHeaders['Content-Type'], 'application/json; charset=utf-8');
+          assert.equal(httpHeaders['Accept'], 'application/json');
+          assert.equal(httpHeaders['If-Match'], 'etag');
+          assert.equal(Object.keys(httpHeaders).length, 3,'Should be only three headers');
+          assert.deepEqual(body, fakeEnrollment);
+
+          done();
+        }
+      };
+
+      var de = new ProvisioningServiceClient({ host: 'host', sharedAccessSignature: 'sas' }, fakeHttpHelper);
+      de.createOrUpdateIndividualEnrollment(fakeEnrollment, testCallback);
+    });
+
+
   });
 
   describe('#createOrUpdateEnrollmentGroup', function(){
@@ -260,6 +282,27 @@ describe('ProvisioningServiceClient', function() {
       var de = new ProvisioningServiceClient({ host: 'host', sharedAccessSignature: 'sas' }, fakeHttpHelper);
       de.createOrUpdateEnrollmentGroup(fakeEnrollmentGroupNoEtag, testCallback);
     });
+
+    /*Tests_SRS_NODE_PROVISIONING_SERVICE_CLIENT_06_055: [If the `enrollmentGroup` object contains an `etag` property it will be added as the value of the `If-Match` header of the http request.] */
+    it('Add If-Match if etag property present', function(testCallback) {
+      var fakeHttpHelper = {
+        executeApiCall: function (method, path, httpHeaders, body, done) {
+          assert.equal(method, 'PUT');
+          assert.equal(path, '/enrollmentGroups/' + encodeURIComponent(fakeGroupId) + _versionQueryString());
+          assert.equal(httpHeaders['Content-Type'], 'application/json; charset=utf-8');
+          assert.equal(httpHeaders['Accept'], 'application/json');
+          assert.equal(httpHeaders['If-Match'], 'etag');
+          assert.equal(Object.keys(httpHeaders).length, 3,'Should be only three headers');
+          assert.deepEqual(body, fakeEnrollmentGroup);
+
+          done();
+        }
+      };
+
+      var de = new ProvisioningServiceClient({ host: 'host', sharedAccessSignature: 'sas' }, fakeHttpHelper);
+      de.createOrUpdateEnrollmentGroup(fakeEnrollmentGroup, testCallback);
+    });
+
   });
 
   function testDeleteAPI(methodUnderTest, uriPath, falsyArgArgumentName, firstArgumentObject, firstArgumentObjectNoEtag, firstArgumentObjectIdPropertyName) {

--- a/service/src/query.ts
+++ b/service/src/query.ts
@@ -87,7 +87,7 @@ export class Query {
    * @param {Function}    done                 The callback that will be called with either an Error object or
    *                                           the results of the query.
    */
-  nextAsTwin(continuationToken: string | Callback<Twin[]>, done: Callback<Twin[]>): void {
+  nextAsTwin(continuationToken: string | Callback<Twin[]>, done?: Callback<Twin[]>): void {
     /*Codes_SRS_NODE_SERVICE_QUERY_16_016: [If `continuationToken` is a function and `done` is undefined the `next` method shall assume that `continuationToken` is actually the callback and us it as such (see requirements associated with the `done` parameter)]*/
     if (typeof continuationToken === 'function' && !done) {
       done = continuationToken;


### PR DESCRIPTION
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Enrollment updates were broken.  We need to pass an etag on the update.

Additional fix for an incorrect parameter optional specification for the done function of nextAsTwin

# Description of the solution

The fix for the update was to copy the property (if it existed) etag from the enrollment object into the header "If-Match".  This is a reasonable fix in that unlike delete there is ALWAYS an enrollment object given as the first argument to the update.  Added updating for the enrollment group object to the enrollment group sample.  Also added an e2e test for updating the enrollment group and the individual enrollment.

A github issue (#162) was raised in that the done function was not specified in the typescript definition of nextAsTwin for query.  Added the ? to the parameter  definition.
