### PR TITLE
Update code for createing certificates with PEM

### DIFF
--- a/provisioning/device/samples/readme.md
+++ b/provisioning/device/samples/readme.md
@@ -37,21 +37,29 @@ If you don't have PEM or CER files for your device along with the associated pri
 When creating certificates, it is important that the commonName (CN) field matches the registrationId for the device you are enrolling.  Registration will fail if this field is not set correctly.
 
 ```
-  var registrationId = '[registration id]';
+  var pem = require('pem');
+  var fs = require('fs');
+
+  var registrationId = process.argv[2].toLowerCase();
+
+  // make sure directory exists
+  var certPath = __dirname + "\\cert\\";
+
   var certOptions = {
-    commonName: registrationId;
+    commonName: registrationId,
     selfSigned: true,
     days: 10
   };
 
   pem.createCertificate(certOptions, function (err, result) {
     if (err) {
-      done(err);
+      console.log (err);
     } else {
-      fs.writeFileSync(registrationId + '-cert.pem', result.certificate);
-      fs.writeFileSync(registrationId + '-key.pem', result.clientKey);
+      fs.writeFileSync(certPath + registrationId + '-cert.pem', result.certificate);
+      fs.writeFileSync(certPath + registrationId + '-key.pem', result.clientKey);
     }
   });
+
 ```
 
 2. Alternately, you can use the Azure IoT C sdk, as documented [here][c-sdk-create-individual-enrollment]


### PR DESCRIPTION
With this source code an user is able to create a certificate for a device. Using command line argument, it's easy to create multiple certificates without changing the variable in the code.

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
