### PR TITLE
Authentication providers for the device client

### DIFF
--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -13,7 +13,7 @@ export { Message }
 export { SharedAccessSignature } from './lib/shared_access_signature';
 export { RetryOperation } from './lib/retry_operation';
 export { RetryPolicy, NoRetry, ExponentialBackOffWithJitter } from './lib/retry_policy';
-export { TokenAuthenticationProvider, AuthenticationProvider, AuthenticationType } from './lib/authentication_provider';
+export { AuthenticationProvider, AuthenticationType } from './lib/authentication_provider';
 
 export interface Receiver extends EventEmitter {
     on(type: 'message', func: (msg: Message) => void): this;
@@ -22,5 +22,4 @@ export interface Receiver extends EventEmitter {
     on(type: string, func: Function): this;
 }
 
-export { DeviceCredentials, X509 } from './lib/authorization';
-export { DeviceCredentials as TransportConfig } from './lib/authorization';
+export { TransportConfig, X509 } from './lib/authorization';

--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -13,16 +13,7 @@ export { Message }
 export { SharedAccessSignature } from './lib/shared_access_signature';
 export { RetryOperation } from './lib/retry_operation';
 export { RetryPolicy, NoRetry, ExponentialBackOffWithJitter } from './lib/retry_policy';
-
-// Typescript only, used by other modules in azure-iot-sdk
-export interface X509 {
-    // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
-    cert?: string | string[] | Buffer | Buffer[];
-    key?: string | Buffer;
-    passphrase?: string;
-    certFile?: string;
-    keyFile?: string;
-}
+export { TokenAuthenticationProvider, AuthenticationProvider, AuthenticationType } from './lib/authentication_provider';
 
 export interface Receiver extends EventEmitter {
     on(type: 'message', func: (msg: Message) => void): this;
@@ -31,9 +22,5 @@ export interface Receiver extends EventEmitter {
     on(type: string, func: Function): this;
 }
 
-export interface TransportConfig {
-    host: string;
-    deviceId: string;
-    sharedAccessSignature?: string;
-    x509?: X509;
-}
+export { DeviceCredentials, X509 } from './lib/authorization';
+export { DeviceCredentials as TransportConfig } from './lib/authorization';

--- a/common/core/common.js
+++ b/common/core/common.js
@@ -22,7 +22,6 @@ module.exports = {
   RetryPolicy: require('./lib/retry_policy.js').RetryPolicy,
   NoRetry: require('./lib/retry_policy.js').NoRetry,
   ExponentialBackOffWithJitter: require('./lib/retry_policy.js').ExponentialBackOffWithJitter,
-  TokenAuthenticationProvider: require('./lib/authentication_provider').TokenAuthenticationProvider,
   AuthenticationProvider: require('./lib/authentication_provider').X509AuthenticationProvider,
   AuthenticationType: require('./lib/authentication_provider').AuthenticationType
 };

--- a/common/core/common.js
+++ b/common/core/common.js
@@ -22,4 +22,7 @@ module.exports = {
   RetryPolicy: require('./lib/retry_policy.js').RetryPolicy,
   NoRetry: require('./lib/retry_policy.js').NoRetry,
   ExponentialBackOffWithJitter: require('./lib/retry_policy.js').ExponentialBackOffWithJitter,
+  TokenAuthenticationProvider: require('./lib/authentication_provider').TokenAuthenticationProvider,
+  AuthenticationProvider: require('./lib/authentication_provider').X509AuthenticationProvider,
+  AuthenticationType: require('./lib/authentication_provider').AuthenticationType
 };

--- a/common/core/src/authentication_provider.ts
+++ b/common/core/src/authentication_provider.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventEmitter } from 'events';
+import { DeviceCredentials } from './authorization';
+
+export enum AuthenticationType {
+  X509,
+  Token
+}
+
+export interface AuthenticationProvider {
+  type: AuthenticationType;
+  getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void;
+}
+
+export interface TokenAuthenticationProvider extends AuthenticationProvider, EventEmitter {
+  automaticRenewal: boolean;
+  updateSharedAccessSignature: (sharedAccessSignature: string) => void;
+}

--- a/common/core/src/authentication_provider.ts
+++ b/common/core/src/authentication_provider.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { EventEmitter } from 'events';
-import { DeviceCredentials } from './authorization';
+import { TransportConfig } from './authorization';
 
 export enum AuthenticationType {
   X509,
@@ -11,10 +10,5 @@ export enum AuthenticationType {
 
 export interface AuthenticationProvider {
   type: AuthenticationType;
-  getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void;
-}
-
-export interface TokenAuthenticationProvider extends AuthenticationProvider, EventEmitter {
-  automaticRenewal: boolean;
-  updateSharedAccessSignature: (sharedAccessSignature: string) => void;
+  getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void;
 }

--- a/common/core/src/authorization.ts
+++ b/common/core/src/authorization.ts
@@ -38,3 +38,22 @@ export function hmacHash(password: string, stringToSign: string): string {
   hmac.update(stringToSign);
   return hmac.digest('base64');
 }
+
+
+export interface DeviceCredentials {
+  host: string;
+  deviceId: string;
+  sharedAccessSignature?: string;
+  sharedAccessKeyName?: string;
+  sharedAccessKey?: string;
+  x509?: X509;
+}
+
+export interface X509 {
+  // https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+  cert?: string | string[] | Buffer | Buffer[];
+  key?: string | Buffer;
+  passphrase?: string;
+  certFile?: string;
+  keyFile?: string;
+}

--- a/common/core/src/authorization.ts
+++ b/common/core/src/authorization.ts
@@ -40,7 +40,7 @@ export function hmacHash(password: string, stringToSign: string): string {
 }
 
 
-export interface DeviceCredentials {
+export interface TransportConfig {
   host: string;
   deviceId: string;
   sharedAccessSignature?: string;

--- a/device/core/devdoc/sak_authentication_provider_requirements.md
+++ b/device/core/devdoc/sak_authentication_provider_requirements.md
@@ -15,32 +15,28 @@ sakAuthProvider.getCredentials(function (err, credentials) {
 });
 
 // to monitor for new tokens:
-sakAuthProvider.on('newTokenAvailable', function () {
-  sakAuthProvider.getCredentials(function (err, credentials) {
-    // do something with the credentials
-  });
+sakAuthProvider.on('newTokenAvailable', function (credentials) {
+  // do something with the credentials
 });
 ```
 
 # Public API
 
-# constructor(credentials: DeviceCredentials, tokenValidTimeInSeconds?, tokenRenewalMarginInSeconds?: number)
+# constructor(credentials: TransportConfig, tokenValidTimeInSeconds?, tokenRenewalMarginInSeconds?: number)
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_001: [** The `constructor` shall create the initial token value using the `credentials` parameter. **]**
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_002: [** The `constructor` shall start a timer that will automatically renew the token every (`tokenValidTimeInSeconds` - `tokenRenewalMarginInSeconds`) seconds if specified, or 45 minutes by default. **]**
 
-## getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void
+**SRS_NODE_SAK_AUTH_PROVIDER_16_011: [** The `constructor` shall throw an `ArgumentError` if the `tokenRenewalMarginInSeconds` is less than or equal `tokenValidTimeInSeconds`. **]**
 
-**SRS_NODE_SAK_AUTH_PROVIDER_16_003: [** The `getDeviceCredentials` should call its callback with a `null` first parameter and a `DeviceCredentials` object as a second parameter, containing the latest valid token it generated. **]**
+## getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void
 
-## updateSharedAccessSignature(sharedAccessSignature: string): void
-
-**SRS_NODE_SAK_AUTH_PROVIDER_16_004: [** The `updateSharedAccessSignature` method shall save the `sharedAccessSignature` passed as a parameter and return it when `getDeviceCredentials` is called, until it gets renewed. **]**
+**SRS_NODE_SAK_AUTH_PROVIDER_16_003: [** The `getDeviceCredentials` should call its callback with a `null` first parameter and a `TransportConfig` object as a second parameter, containing the latest valid token it generated. **]**
 
 ## newTokenAvailable event
 
-**SRS_NODE_SAK_AUTH_PROVIDER_16_005: [** Every time a new token is created, the `newTokenAvailable` event shall be fired with no arguments. **]**
+**SRS_NODE_SAK_AUTH_PROVIDER_16_005: [** Every time a new token is created, the `newTokenAvailable` event shall be fired with the updated credentials. **]**
 
 ## fromConnectionString(connectionString: string, tokenValidTimeInSeconds?, tokenRenewalMarginInSeconds?: number): SharedAccessKeyAuthenticationProvider [static]
 

--- a/device/core/devdoc/sas_authentication_provider_requirements.md
+++ b/device/core/devdoc/sas_authentication_provider_requirements.md
@@ -16,20 +16,18 @@ sasAuthProvider.getCredentials(function (err, credentials) {
 sasAuthProvider.updateSharedAccessSignature('<new shared access signature>');
 
 // to monitor for new tokens:
-sasAuthProvider.on('newTokenAvailable', function () {
-  sasAuthProvider.getCredentials(function (err, credentials) {
-    // do something with the credentials
-  });
+sasAuthProvider.on('newTokenAvailable', function (credentials) {
+  // do something with the credentials
 });
 ```
 
 ## Public API
 
-### constructor(credentials: DeviceCredentials)
+### constructor(credentials: TransportConfig)
 
 **SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_001: [** The `constructor` shall store the credentials passed in the `credentials` argument. **]**
 
-### getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void
+### getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void
 
 **SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [** The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials. **]**
 
@@ -37,7 +35,7 @@ sasAuthProvider.on('newTokenAvailable', function () {
 
 **SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_003: [** The `updateSharedAccessSignature` method shall update the stored credentials with the new `sharedAccessSignature` value passed as an argument.**]**
 
-**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [** The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with no arguments. **]**
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [** The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with the updated credentials. **]**
 
 ### static fromSharedAccessSignature(sharedAccessSignature: string): SharedAccessSignatureAuthenticationProvider
 

--- a/device/core/devdoc/sas_authentication_provider_requirements.md
+++ b/device/core/devdoc/sas_authentication_provider_requirements.md
@@ -1,0 +1,46 @@
+# SharedAccessSignatureAuthenticationProvider requirements
+
+## Overview
+
+The `SharedAccessSignatureAuthenticationProvider` class is used when an SDK user wants to control how shared access signatures are generated. A device client created with this authentication provider will be notified every time the user updates the shared access signature and will take appropriate action to stay connected, depending on which transport is used.
+
+## Example usage
+```js
+var sasAuthProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature('<shared access signature>');
+// whenever the token is needed for authentication:
+sasAuthProvider.getCredentials(function (err, credentials) {
+  // do something with the credentials
+});
+
+// to update the credentials
+sasAuthProvider.updateSharedAccessSignature('<new shared access signature>');
+
+// to monitor for new tokens:
+sasAuthProvider.on('newTokenAvailable', function () {
+  sasAuthProvider.getCredentials(function (err, credentials) {
+    // do something with the credentials
+  });
+});
+```
+
+## Public API
+
+### constructor(credentials: DeviceCredentials)
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_001: [** The `constructor` shall store the credentials passed in the `credentials` argument. **]**
+
+### getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [** The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials. **]**
+
+### updateSharedAccessSignature(sharedAccessSignature: string): void
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_003: [** The `updateSharedAccessSignature` method shall update the stored credentials with the new `sharedAccessSignature` value passed as an argument.**]**
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [** The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with no arguments. **]**
+
+### static fromSharedAccessSignature(sharedAccessSignature: string): SharedAccessSignatureAuthenticationProvider
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_005: [** The `fromSharedAccessSignature` method shall throw a `ReferenceError` if the `sharedAccessSignature` argument is falsy. **]**
+
+**SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_006: [** The `fromSharedAccessSignature` shall return a new `SharedAccessSignatureAuthenticationProvider` object initialized with the credentials parsed from the `sharedAccessSignature` argument. **]**

--- a/device/core/devdoc/x509_authentication_provider_requirements.md
+++ b/device/core/devdoc/x509_authentication_provider_requirements.md
@@ -1,0 +1,47 @@
+# X509AuthenticationProvider Requirements
+
+## Overview
+
+The `X509AuthenticationProvider` class can be used to configure a device client to authenticate with an X509 certificate/key pair.
+
+## Example
+
+```js
+var x509AuthProvider = X509AuthenticationProvider.fromX509Options('<device id>', '<host name>', { cert: 'cert', key: 'key' });
+// whenever the token is needed for authentication:
+x509AuthProvider.getCredentials(function (err, credentials) {
+  // do something with the credentials
+});
+
+// to update the credentials
+x509AuthProvider.setX509Options({ cert: 'new cert', key: 'new key' });
+});
+```
+
+## Public API
+
+### constructor(credentials: DeviceCredentials)
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_001: [** The `constructor` shall store the credentials passed as argument. **]**
+
+### getDeviceCredentials(callback: (err: Error, credentials?: DeviceCredentials) => void): void
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_002: [** The `getDeviceCredentials` method shall call its callback with a `null` error object and the stored device credentials as a second argument. **]**
+
+### setX509Options(x509: X509): void
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_003: [** The `setX509Options` method shall store the `X509` object passed as an argument with the existing credentials. **]**
+
+### fromX509Options(deviceId: string, iotHubHostname: string, x509info: X509): X509AuthenticationProvider [static]
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_004: [** The `fromX509Options` method shall throw a `ReferenceError` if `deviceId` is falsy. **]**
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_005: [** The `fromX509Options` method shall throw a `ReferenceError` if `iotHubHostname` is falsy. **]**
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_006: [** The `fromX509Options` method shall throw a `ReferenceError` if `x509info` is falsy. **]**
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_007: [** The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.cert` is falsy. **]**
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_008: [** The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.key` is falsy. **]**
+
+**SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_009: [** The `fromX509Options` method shall create a new instance of `X509AuthenticationProvider` with a credentials object created from the arguments. **]**

--- a/device/core/devdoc/x509_authentication_provider_requirements.md
+++ b/device/core/devdoc/x509_authentication_provider_requirements.md
@@ -20,11 +20,11 @@ x509AuthProvider.setX509Options({ cert: 'new cert', key: 'new key' });
 
 ## Public API
 
-### constructor(credentials: DeviceCredentials)
+### constructor(credentials: TransportConfig)
 
 **SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_001: [** The `constructor` shall store the credentials passed as argument. **]**
 
-### getDeviceCredentials(callback: (err: Error, credentials?: DeviceCredentials) => void): void
+### getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void
 
 **SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_002: [** The `getDeviceCredentials` method shall call its callback with a `null` error object and the stored device credentials as a second argument. **]**
 

--- a/device/core/device.d.ts
+++ b/device/core/device.d.ts
@@ -6,3 +6,6 @@ export import ConnectionString = require('./lib/connection_string');
 export import SharedAccessSignature = require('./lib/shared_access_signature');
 export { Message } from 'azure-iot-common';
 export { DeviceMethodRequest, DeviceMethodResponse } from './lib/device_method';
+export { X509AuthenticationProvider } from './lib/x509_authentication_provider';
+export { SharedAccessSignatureAuthenticationProvider } from './lib/sas_authentication_provider';
+export { SharedAccessKeyAuthenticationProvider } from './lib/sak_authentication_provider';

--- a/device/core/device.js
+++ b/device/core/device.js
@@ -49,5 +49,8 @@ module.exports = {
   Message: common.Message,
   SharedAccessSignature: require('./lib/shared_access_signature.js'),
   DeviceMethodRequest: require('./lib/device_method').DeviceMethodRequest,
-  DeviceMethodResponse: require('./lib/device_method').DeviceMethodResponse
+  DeviceMethodResponse: require('./lib/device_method').DeviceMethodResponse,
+  X509AuthenticationProvider: require('./lib/x509_authentication_provider').X509AuthenticationProvider,
+  SharedAccessSignatureAuthenticationProvider: require('./lib/sas_authentication_provider').SharedAccessSignatureAuthenticationProvider,
+  SharedAccessKeyAuthenticationProvider: require('./lib/sak_authentication_provider').SharedAccessKeyAuthenticationProvider,
 };

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --lines 96 --functions 92"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --lines 96 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/sak_authentication_provider.ts
+++ b/device/core/src/sak_authentication_provider.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import * as dbg from 'debug';
+const debug = dbg('azure-iot-device:SAKTokenAuthenticationProvider');
+
+import { EventEmitter } from 'events';
+import { TokenAuthenticationProvider, AuthenticationType, ConnectionString, SharedAccessSignature, errors, DeviceCredentials, encodeUriComponentStrict } from 'azure-iot-common';
+
+export class SharedAccessKeyAuthenticationProvider extends EventEmitter implements TokenAuthenticationProvider {
+  type: AuthenticationType = AuthenticationType.Token;
+  automaticRenewal: boolean = true;
+
+  private _tokenValidTimeInSeconds: number = 3600;   // 1 hour
+  private _tokenRenewalMarginInSeconds: number = 900; // 15 minutes
+
+  private _currentTokenExpiryTimeInSeconds: number;
+  private _renewalTimeout: NodeJS.Timer;
+
+  private _credentials: DeviceCredentials;
+
+  /**
+   * @private
+   *
+   * Initializes a new instance of the TokenAuthenticationProvider - users should only use the factory methods though.
+   *
+   * @param credentials                    Credentials to be used by the device to connect to the IoT hub.
+   * @param tokenValidTimeInSeconds        [optional] The number of seconds for which a token is supposed to be valid.
+   * @param tokenRenewalMarginInSeconds    [optional] The number of seconds before the end of the validity period during which the `SharedAccessKeyAuthenticationProvider` should renew the token.
+   */
+  constructor(credentials: DeviceCredentials, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number) {
+    super();
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_001: [The `constructor` shall create the initial token value using the `credentials` parameter.]*/
+    this._credentials  = credentials;
+
+    if (tokenValidTimeInSeconds) this._tokenValidTimeInSeconds = tokenValidTimeInSeconds;
+    if (tokenRenewalMarginInSeconds) this._tokenRenewalMarginInSeconds = tokenRenewalMarginInSeconds;
+
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_002: [The `constructor` shall start a timer that will automatically renew the token every (`tokenValidTimeInSeconds` - `tokenRenewalMarginInSeconds`) seconds if specified, or 45 minutes by default.]*/
+    this._renewToken();
+  }
+
+  /**
+   * Gets the current device credentials that are valid and were generated from the connectiom string.
+   *
+   * @param callback function that will be called with either an error or a set of device credentials that can be used to authenticate with the IoT hub.
+   */
+  getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void {
+    if (this._shouldRenewToken()) {
+      this._renewToken();
+    }
+
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_003: [The `getDeviceCredentials` should call its callback with a `null` first parameter and a `DeviceCredentials` object as a second parameter, containing the latest valid token it generated.]*/
+    callback(null, this._credentials);
+  }
+
+  /**
+   * Sets the current security token for the device. Note that it will be overwritten by the timer that is running in the background.
+   * If you're looking for an AuthenticationProvider where you maintain the lifecycle of the token yourself, you should look at the `SharedAccessSignatureAuthorizationProvider` class.
+   *
+   * @param sharedAccessSignature shared access signature that should be stored.
+   */
+  updateSharedAccessSignature(sharedAccessSignature: string): void {
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall save the `sharedAccessSignature` passed as a parameter and return it when `getDeviceCredentials` is called, until it gets renewed.]*/
+    debug('Manually replacing a shared access signature when automatic renewal is active');
+    this._credentials.sharedAccessSignature = sharedAccessSignature;
+  }
+
+  private _shouldRenewToken(): boolean {
+    const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+    return (this._currentTokenExpiryTimeInSeconds - currentTimeInSeconds) < this._tokenRenewalMarginInSeconds;
+  }
+
+  private _renewToken(): void {
+    if (this._renewalTimeout) {
+      clearTimeout(this._renewalTimeout);
+    }
+
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_009: [Every token shall be created with a validity period of `tokenValidTimeInSeconds` if specified when the constructor was called, or 1 hour by default.]*/
+    const newExpiry =  Math.floor(Date.now() / 1000) + this._tokenValidTimeInSeconds;
+
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_010: [Every token shall be created using the `azure-iot-common.SharedAccessSignature.create` method and then serialized as a string, with the arguments to the create methods being:
+    ```
+    resourceUri: <IoT hub host>/devices/<deviceId>
+    keyName: the `SharedAccessKeyName` parameter of the connection string or `null`
+    key: the `SharedAccessKey` parameter of the connection string
+    expiry: the expiration time of the token, which is now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).
+    ```]*/
+    const resourceUri = encodeUriComponentStrict(this._credentials.host + '/devices/' + this._credentials.deviceId);
+    const sas = SharedAccessSignature.create(resourceUri, this._credentials.sharedAccessKeyName, this._credentials.sharedAccessKey, newExpiry);
+    this._credentials.sharedAccessSignature = sas.toString();
+
+    const nextRenewalTimeout = (this._tokenValidTimeInSeconds - this._tokenRenewalMarginInSeconds) * 1000;
+    if (this.automaticRenewal) {
+      this._renewalTimeout = setTimeout(() => this._renewToken(), nextRenewalTimeout);
+    }
+    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_005: [Every time a new token is created, the `newTokenAvailable` event shall be fired with no arguments.]*/
+    this.emit('newTokenAvailable');
+  }
+
+  /**
+   * Creates a new `SharedAccessKeyAuthenticationProvider` from a connection string
+   *
+   * @param connectionString              A device connection string containing the required parameters for authentication with the IoT hub.
+   * @param tokenValidTimeInSeconds       [optional] The number of seconds for which a token is supposed to be valid.
+   * @param tokenRenewalMarginInSeconds   [optional] The number of seconds before the end of the validity period during which the `SharedAccessKeyAuthenticationProvider` should renew the token.
+   */
+  static fromConnectionString(connectionString: string, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number): SharedAccessKeyAuthenticationProvider {
+    if (!connectionString) {
+      /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_006: [The `fromConnectionString` method shall throw a `ReferenceError` if the `connectionString` parameter is falsy.]*/
+      throw new ReferenceError('connectionString cannot be \'' + connectionString + '\'');
+    }
+
+    const cs = ConnectionString.parse(connectionString);
+    if (!cs.SharedAccessKey) {
+      /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_007: [The `fromConnectionString` method shall throw an `errors.ArgumentError` if the `connectionString` does not have a SharedAccessKey parameter.]*/
+      throw new errors.ArgumentError('Connection string is missing a shared access key');
+    }
+
+      /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_008: [The `fromConnectionString` method shall extract the credentials from the `connectionString` argument and create a new `SharedAccessKeyAuthenticationProvider` that uses these credentials to generate security tokens.]*/
+      const credentials: DeviceCredentials = {
+      host: cs.HostName,
+      deviceId: cs.DeviceId,
+      sharedAccessKeyName: cs.SharedAccessKeyName,
+      sharedAccessKey: cs.SharedAccessKey
+    };
+
+    return new SharedAccessKeyAuthenticationProvider(credentials, tokenValidTimeInSeconds, tokenRenewalMarginInSeconds);
+  }
+}

--- a/device/core/src/sas_authentication_provider.ts
+++ b/device/core/src/sas_authentication_provider.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { EventEmitter } from 'events';
-import { TokenAuthenticationProvider, AuthenticationType, SharedAccessSignature, DeviceCredentials } from 'azure-iot-common';
+import { AuthenticationProvider, AuthenticationType, SharedAccessSignature, TransportConfig } from 'azure-iot-common';
 
-export class SharedAccessSignatureAuthenticationProvider extends EventEmitter implements TokenAuthenticationProvider {
+export class SharedAccessSignatureAuthenticationProvider extends EventEmitter implements AuthenticationProvider {
   type: AuthenticationType = AuthenticationType.Token;
-  automaticRenewal: boolean = false;
-  private _credentials: DeviceCredentials;
+  private _credentials: TransportConfig;
 
   /**
    * @private
@@ -17,13 +16,13 @@ export class SharedAccessSignatureAuthenticationProvider extends EventEmitter im
    * @param credentials       Credentials to be used by the device to connect to the IoT hub.
    * @param securityProvider  Object used to sign the tokens that are going to be used during authentication.
    */
-  constructor(credentials: DeviceCredentials) {
+  constructor(credentials: TransportConfig) {
     super();
     /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed in the `credentials` argument.]*/
     this._credentials  = credentials;
   }
 
-  getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void {
+  getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void {
     /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials.]*/
     callback(null, this._credentials);
   }
@@ -31,8 +30,8 @@ export class SharedAccessSignatureAuthenticationProvider extends EventEmitter im
   updateSharedAccessSignature(sharedAccessSignature: string): void {
     /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_003: [The `updateSharedAccessSignature` method shall update the stored credentials with the new `sharedAccessSignature` value passed as an argument.]*/
     this._credentials.sharedAccessSignature = sharedAccessSignature;
-    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with no arguments.]*/
-    this.emit('newTokenAvailable');
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with the updated credentials.]*/
+    this.emit('newTokenAvailable', this._credentials);
   }
 
   static fromSharedAccessSignature(sharedAccessSignature: string): SharedAccessSignatureAuthenticationProvider {
@@ -40,10 +39,10 @@ export class SharedAccessSignatureAuthenticationProvider extends EventEmitter im
       /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_005: [The `fromSharedAccessSignature` method shall throw a `ReferenceError` if the `sharedAccessSignature` argument is falsy.]*/
       throw new ReferenceError('sharedAccessSignature cannot be \'' + sharedAccessSignature + '\'');
     }
-    const sas = SharedAccessSignature.parse(sharedAccessSignature);
+    const sas: SharedAccessSignature = SharedAccessSignature.parse(sharedAccessSignature);
     const decodedUri = decodeURIComponent(sas.sr);
     const uriSegments = decodedUri.split('/');
-    const credentials: DeviceCredentials = {
+    const credentials: TransportConfig = {
       host: uriSegments[0],
       deviceId: uriSegments[uriSegments.length - 1],
       sharedAccessSignature: sharedAccessSignature

--- a/device/core/src/sas_authentication_provider.ts
+++ b/device/core/src/sas_authentication_provider.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { EventEmitter } from 'events';
+import { TokenAuthenticationProvider, AuthenticationType, SharedAccessSignature, DeviceCredentials } from 'azure-iot-common';
+
+export class SharedAccessSignatureAuthenticationProvider extends EventEmitter implements TokenAuthenticationProvider {
+  type: AuthenticationType = AuthenticationType.Token;
+  automaticRenewal: boolean = false;
+  private _credentials: DeviceCredentials;
+
+  /**
+   * @private
+   *
+   * Initializes a new instance of the TokenAuthenticationProvider - users should only use the factory methods though.
+   *
+   * @param credentials       Credentials to be used by the device to connect to the IoT hub.
+   * @param securityProvider  Object used to sign the tokens that are going to be used during authentication.
+   */
+  constructor(credentials: DeviceCredentials) {
+    super();
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed in the `credentials` argument.]*/
+    this._credentials  = credentials;
+  }
+
+  getDeviceCredentials(callback: (err: Error, credentials: DeviceCredentials) => void): void {
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials.]*/
+    callback(null, this._credentials);
+  }
+
+  updateSharedAccessSignature(sharedAccessSignature: string): void {
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_003: [The `updateSharedAccessSignature` method shall update the stored credentials with the new `sharedAccessSignature` value passed as an argument.]*/
+    this._credentials.sharedAccessSignature = sharedAccessSignature;
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with no arguments.]*/
+    this.emit('newTokenAvailable');
+  }
+
+  static fromSharedAccessSignature(sharedAccessSignature: string): SharedAccessSignatureAuthenticationProvider {
+    if (!sharedAccessSignature) {
+      /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_005: [The `fromSharedAccessSignature` method shall throw a `ReferenceError` if the `sharedAccessSignature` argument is falsy.]*/
+      throw new ReferenceError('sharedAccessSignature cannot be \'' + sharedAccessSignature + '\'');
+    }
+    const sas = SharedAccessSignature.parse(sharedAccessSignature);
+    const decodedUri = decodeURIComponent(sas.sr);
+    const uriSegments = decodedUri.split('/');
+    const credentials: DeviceCredentials = {
+      host: uriSegments[0],
+      deviceId: uriSegments[uriSegments.length - 1],
+      sharedAccessSignature: sharedAccessSignature
+    };
+
+    /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_006: [The `fromSharedAccessSignature` shall return a new `SharedAccessSignatureAuthenticationProvider` object initialized with the credentials parsed from the `sharedAccessSignature` argument.]*/
+    return new SharedAccessSignatureAuthenticationProvider(credentials);
+  }
+}

--- a/device/core/src/x509_authentication_provider.ts
+++ b/device/core/src/x509_authentication_provider.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { AuthenticationProvider, AuthenticationType, errors, DeviceCredentials, X509 } from 'azure-iot-common';
+import { AuthenticationProvider, AuthenticationType, errors, TransportConfig, X509 } from 'azure-iot-common';
 
 export class X509AuthenticationProvider implements AuthenticationProvider {
   type: AuthenticationType = AuthenticationType.X509;
-  private _credentials: DeviceCredentials;
+  private _credentials: TransportConfig;
 
-  constructor(credentials: DeviceCredentials) {
+  constructor(credentials: TransportConfig) {
     /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed as argument.]*/
     this._credentials = credentials;
   }
 
-  getDeviceCredentials(callback: (err: Error, credentials?: DeviceCredentials) => void): void {
+  getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void {
     /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error object and the stored device credentials as a second argument.]*/
     callback(null, this._credentials);
   }

--- a/device/core/src/x509_authentication_provider.ts
+++ b/device/core/src/x509_authentication_provider.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { AuthenticationProvider, AuthenticationType, errors, DeviceCredentials, X509 } from 'azure-iot-common';
+
+export class X509AuthenticationProvider implements AuthenticationProvider {
+  type: AuthenticationType = AuthenticationType.X509;
+  private _credentials: DeviceCredentials;
+
+  constructor(credentials: DeviceCredentials) {
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed as argument.]*/
+    this._credentials = credentials;
+  }
+
+  getDeviceCredentials(callback: (err: Error, credentials?: DeviceCredentials) => void): void {
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error object and the stored device credentials as a second argument.]*/
+    callback(null, this._credentials);
+  }
+
+  setX509Options(x509: X509): void {
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_003: [The `setX509Options` method shall store the `X509` object passed as an argument with the existing credentials.]*/
+    this._credentials.x509 = x509;
+  }
+
+  static fromX509Options(deviceId: string, iotHubHostname: string, x509info: X509): X509AuthenticationProvider {
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_004: [The `fromX509Options` method shall throw a `ReferenceError` if `deviceId` is falsy.]*/
+    if (!deviceId) {
+      throw new ReferenceError('deviceId cannot be \'' + deviceId + '\'');
+    }
+
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_005: [The `fromX509Options` method shall throw a `ReferenceError` if `iotHubHostname` is falsy.]*/
+    if (!iotHubHostname) {
+      throw new ReferenceError('iotHubHostname cannot be \'' + iotHubHostname + '\'');
+    }
+
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_006: [The `fromX509Options` method shall throw a `ReferenceError` if `x509info` is falsy.]*/
+    if (!x509info) {
+      throw new ReferenceError('x509info cannot be \'' + x509info + '\'');
+    }
+
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_007: [The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.cert` is falsy.]*/
+    if (!x509info.cert) {
+      throw new errors.ArgumentError('x509info.cert cannot be \'' + x509info.cert + '\'');
+    }
+
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_008: [The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.key` is falsy.]*/
+    if (!x509info.key) {
+      throw new errors.ArgumentError('x509info.key cannot be \'' + x509info.key + '\'');
+    }
+
+    /*Codes_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_009: [The `fromX509Options` method shall create a new instance of `X509AuthenticationProvider` with a credentials object created from the arguments.]*/
+    return new X509AuthenticationProvider({
+      deviceId: deviceId,
+      host: iotHubHostname,
+      x509: x509info
+    });
+  }
+}

--- a/device/core/test/_sak_authentication_provider_test.js
+++ b/device/core/test/_sak_authentication_provider_test.js
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var errors = require('azure-iot-common').errors;
+var SharedAccessSignature = require('azure-iot-common').SharedAccessSignature;
+var SharedAccessKeyAuthenticationProvider = require('../lib/sak_authentication_provider').SharedAccessKeyAuthenticationProvider;
+
+describe('SharedAccessKeyAuthenticationProvider', function () {
+  describe('#constructor', function () {
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_001: [The `constructor` shall create the initial token value using the `credentials` parameter.]*/
+    it('initializes the credentials', function (testCallback) {
+      var fakeCredentials = {
+        deviceId: 'fakeDeviceId',
+        host: 'fake.host.name',
+        sharedAccessKey: 'fakeKey'
+      };
+      var sakAuthProvider = new SharedAccessKeyAuthenticationProvider(fakeCredentials, 10, 1);
+      sakAuthProvider.automaticRenewal = false;
+      sakAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.deviceId, fakeCredentials.deviceId);
+        assert.strictEqual(creds.host, fakeCredentials.host);
+        assert.strictEqual(creds.sharedAccessKey, fakeCredentials.sharedAccessKey);
+        var sasObject = SharedAccessSignature.parse(creds.sharedAccessSignature);
+        /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_010: [Every token shall be created using the `azure-iot-common.SharedAccessSignature.create` method and then serialized as a string, with the arguments to the create methods being:
+        ```
+        resourceUri: <IoT hub host>/devices/<deviceId>
+        keyName: the `SharedAccessKeyName` parameter of the connection string or `null`
+        key: the `SharedAccessKey` parameter of the connection string
+        expiry: the expiration time of the token, which is now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).
+        ```]*/
+        assert.strictEqual(sasObject.sr, encodeURIComponent(fakeCredentials.host + '/devices/' + fakeCredentials.deviceId));
+        assert.notOk(sasObject.skn);
+        assert.isOk(sasObject.sig);
+        assert.isTrue(sasObject.se > Date.now() / 1000);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_002: [The `constructor` shall start a timer that will automatically renew the token every (`tokenValidTimeInSeconds` - `tokenRenewalMarginInSeconds`) seconds if specified, or 45 minutes by default.]*/
+    it('starts a timer to renew the token', function (testCallback) {
+      this.clock = sinon.useFakeTimers();
+      var testClock = this.clock;
+      var fakeCredentials = {
+        deviceId: 'fakeDeviceId',
+        host: 'fake.host.name',
+        sharedAccessKey: 'fakeKey'
+      };
+      var token;
+      var sakAuthProvider = new SharedAccessKeyAuthenticationProvider(fakeCredentials, 10, 1);
+      var eventSpy = sinon.spy();
+      sakAuthProvider.on('newTokenAvailable', eventSpy);
+      /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_003: [The `getDeviceCredentials` should call its callback with a `null` first parameter and a `DeviceCredentials` object as a second parameter, containing the latest valid token it generated.]*/
+      sakAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.isNull(err);
+        token = creds.sharedAccessSignature;
+        testClock.tick(5000); // 5 seconds - token not renewed
+        sakAuthProvider.getDeviceCredentials(function (err, creds) {
+          assert.strictEqual(token, creds.sharedAccessSignature);
+          testClock.tick(5000); // 5 more seconds - token should've been renewed
+          sakAuthProvider.getDeviceCredentials(function (err, creds) {
+            assert.notEqual(token, creds.sharedAccessSignature);
+            /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_005: [Every time a new token is created, the `newTokenAvailable` event shall be fired with no arguments.]*/
+            assert.isTrue(eventSpy.calledOnce);
+            sakAuthProvider.automaticRenewal = false;
+            testClock.restore();
+            testCallback();
+          });
+        });
+      });
+    });
+  });
+
+  describe('fromConnectionString', function () {
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_006: [The `fromConnectionString` method shall throw a `ReferenceError` if the `connectionString` parameter is falsy.]*/
+    [null, undefined, ''].forEach(function (badConnectionString) {
+      it('throws if the connection string is \'' + badConnectionString + '\'', function () {
+        assert.throws(function () {
+          SharedAccessKeyAuthenticationProvider.fromConnectionString(badConnectionString);
+        }, ReferenceError);
+      });
+    });
+
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_007: [The `fromConnectionString` method shall throw an `errors.ArgumentError` if the `connectionString` does not have a SharedAccessKey parameter.]*/
+    it('throws an ArgumentError if the connection string does not contain a shared access key', function () {
+      assert.throws(function () {
+        var fakeConnectionString = 'DeviceId=deviceId;HostName=host;SharedAccessKeyName=foo';
+        return SharedAccessKeyAuthenticationProvider.fromConnectionString(fakeConnectionString, 1, 1);
+      }, errors.ArgumentError);
+    });
+
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_008: [The `fromConnectionString` method shall extract the credentials from the `connectionString` argument and create a new `SharedAccessKeyAuthenticationProvider` that uses these credentials to generate security tokens.]*/
+    it('initializes the credentials from the connection string', function (testCallback) {
+      var fakeCredentials = {
+        deviceId: 'fakeDeviceId',
+        host: 'fake.host.name',
+        sharedAccessKey: 'fakeKey'
+      };
+      var fakeConnectionString = 'DeviceId=' + fakeCredentials.deviceId + ';HostName=' + fakeCredentials.host + ';SharedAccessKey=' + fakeCredentials.sharedAccessKey;
+
+      var sakAuthProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(fakeConnectionString, 1, 1);
+      sakAuthProvider.automaticRenewal = false;
+      sakAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.deviceId, fakeCredentials.deviceId);
+        assert.strictEqual(creds.host, fakeCredentials.host);
+        assert.strictEqual(creds.sharedAccessKey, fakeCredentials.sharedAccessKey);
+        testCallback();
+      });
+    });
+  });
+
+  describe('updateSharedAccessSignature', function () {
+    /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall save the `sharedAccessSignature` passed as a parameter and return it when `getDeviceCredentials` is called, until it gets renewed.]*/
+    it('updates the shared access signature', function (testCallback) {
+      var newSas = 'newSas';
+      var fakeCredentials = {
+        deviceId: 'fakeDeviceId',
+        host: 'fake.host.name',
+        sharedAccessKey: 'fakeKey'
+      };
+      var sakAuthProvider = new SharedAccessKeyAuthenticationProvider(fakeCredentials);
+      sakAuthProvider.automaticRenewal = false;
+      sakAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.notEqual(creds.sharedAccessSignature, newSas);
+        sakAuthProvider.updateSharedAccessSignature(newSas);
+        sakAuthProvider.getDeviceCredentials(function (err, newCreds) {
+          assert.strictEqual(newCreds.sharedAccessSignature, newSas);
+          testCallback();
+        });
+      });
+    });
+  });
+});

--- a/device/core/test/_sas_authentication_provider_test.js
+++ b/device/core/test/_sas_authentication_provider_test.js
@@ -56,9 +56,13 @@ describe('SharedAccessSignatureAuthenticationProvider', function () {
         deviceId: 'deviceId',
         sharedAccessSignature: 'sas'
       };
+      var newSas = 'new shared access signature';
       var sasAuthProvider = new SharedAccessSignatureAuthenticationProvider(fakeCredentials);
-      sasAuthProvider.on('newTokenAvailable', testCallback);
-      sasAuthProvider.updateSharedAccessSignature('newSas');
+      sasAuthProvider.on('newTokenAvailable', function (creds) {
+        assert.strictEqual(creds.sharedAccessSignature, newSas);
+        testCallback();
+      });
+      sasAuthProvider.updateSharedAccessSignature(newSas);
     });
   });
 

--- a/device/core/test/_sas_authentication_provider_test.js
+++ b/device/core/test/_sas_authentication_provider_test.js
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var errors = require('azure-iot-common').errors;
+var SharedAccessSignature = require('azure-iot-common').SharedAccessSignature;
+var SharedAccessSignatureAuthenticationProvider = require('../lib/sas_authentication_provider').SharedAccessSignatureAuthenticationProvider;
+
+
+describe('SharedAccessSignatureAuthenticationProvider', function () {
+  describe('#constructor + #getDeviceCredentials', function () {
+    /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed in the `credentials` argument.]*/
+    it('stores the credentials passed as argument', function (testCallback) {
+      var fakeCredentials = {
+        host: 'host.name',
+        deviceId: 'deviceId',
+        sharedAccessSignature: 'sas'
+      };
+      var sasAuthProvider = new SharedAccessSignatureAuthenticationProvider(fakeCredentials);
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials.]*/
+        assert.strictEqual(creds, fakeCredentials);
+        assert.isNull(err);
+        testCallback();
+      });
+    });
+  });
+
+  describe('#updateSharedAccessSignature', function () {
+    /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_003: [The `updateSharedAccessSignature` method shall update the stored credentials with the new `sharedAccessSignature` value passed as an argument.]*/
+    it('updates the stored credentials', function (testCallback) {
+      var newSas = 'newSas';
+      var fakeCredentials = {
+        host: 'host.name',
+        deviceId: 'deviceId',
+        sharedAccessSignature: 'sas'
+      };
+      var sasAuthProvider = new SharedAccessSignatureAuthenticationProvider(fakeCredentials);
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.sharedAccessSignature, fakeCredentials.sharedAccessSignature);
+        sasAuthProvider.updateSharedAccessSignature(newSas);
+        sasAuthProvider.getDeviceCredentials(function (err, creds) {
+          assert.strictEqual(creds.sharedAccessSignature, newSas);
+          testCallback();
+        });
+      });
+    });
+
+    /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_004: [The `updateSharedAccessSignature` method shall emit a `newTokenAvailable` event with no arguments.]*/
+    it('emits a newTokenAvailable event', function (testCallback) {
+      var fakeCredentials = {
+        host: 'host.name',
+        deviceId: 'deviceId',
+        sharedAccessSignature: 'sas'
+      };
+      var sasAuthProvider = new SharedAccessSignatureAuthenticationProvider(fakeCredentials);
+      sasAuthProvider.on('newTokenAvailable', testCallback);
+      sasAuthProvider.updateSharedAccessSignature('newSas');
+    });
+  });
+
+  describe('#fromSharedAccessSignature', function () {
+    /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_005: [The `fromSharedAccessSignature` method shall throw a `ReferenceError` if the `sharedAccessSignature` argument is falsy.]*/
+    [undefined, null, ''].forEach(function (badSas) {
+      it('throws a ReferenceError if the shared access signature is \'' + badSas + '\'', function () {
+        assert.throws(function () {
+          return SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(badSas);
+        }, ReferenceError);
+      });
+    });
+
+    /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_006: [The `fromSharedAccessSignature` shall return a new `SharedAccessSignatureAuthenticationProvider` object initialized with the credentials parsed from the `sharedAccessSignature` argument.]*/
+    it('creates a SharedAccessSignatureAuthenticationProvider initialized with credentiasl from the shared access signature passed as argument', function (testCallback) {
+      var fakeCredentials = {
+        host: 'host.name',
+        deviceId: 'deviceId',
+        sharedAccessSignature: 'sas'
+      };
+      var fakeSas = SharedAccessSignature.create(encodeURIComponent(fakeCredentials.host + '/devices/' + fakeCredentials.deviceId), null, 'foo', Math.floor(Date.now() / 1000) + 1000).toString();
+
+      var sasAuthProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(fakeSas.toString());
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.host, fakeCredentials.host);
+        assert.strictEqual(creds.deviceId, fakeCredentials.deviceId);
+        assert.isUndefined(creds.sharedAccessKey);
+        assert.strictEqual(creds.sharedAccessSignature, fakeSas);
+        testCallback();
+      });
+    });
+  });
+});

--- a/device/core/test/_x509_authentication_provider_test.js
+++ b/device/core/test/_x509_authentication_provider_test.js
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var errors = require('azure-iot-common').errors;
+var X509AuthenticationProvider = require('../lib/x509_authentication_provider').X509AuthenticationProvider;
+
+describe('X509AuthenticationProvider', function () {
+  describe('#constructor + #getDeviceCredentials', function () {
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_001: [The `constructor` shall store the credentials passed as argument.]*/
+    it('creates an X509AuthenticationProvider with the credentials given as argument', function (testCallback) {
+      var initialCreds = {
+        deviceId: 'deviceId',
+        host: 'host.name',
+        x509: {
+          cert: 'cert',
+          key: 'key'
+        }
+      };
+
+      var x509AuthProvider = new X509AuthenticationProvider(initialCreds);
+      /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error object and the stored device credentials as a second argument.]*/
+      x509AuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.isNull(err);
+        assert.strictEqual(creds.deviceId, initialCreds.deviceId);
+        assert.strictEqual(creds.host, initialCreds.host);
+        assert.strictEqual(creds.x509.cert, initialCreds.x509.cert);
+        assert.strictEqual(creds.x509.key, initialCreds.x509.key);
+        testCallback();
+      });
+    });
+  });
+
+  describe('#setX509Options', function () {
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_003: [The `setX509Options` method shall store the `X509` object passed as an argument with the existing credentials.]*/
+    it('updates the x509 options', function (testCallback) {
+      var initialCreds = {
+        deviceId: 'deviceId',
+        host: 'host.name',
+        x509: {
+          cert: 'cert',
+          key: 'key'
+        }
+      };
+
+      var newX509Options = {
+        cert: 'cert',
+        key: 'key'
+      };
+
+      var x509AuthProvider = new X509AuthenticationProvider(initialCreds);
+      x509AuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.isNull(err);
+        assert.strictEqual(creds.deviceId, initialCreds.deviceId);
+        assert.strictEqual(creds.host, initialCreds.host);
+        assert.strictEqual(creds.x509.cert, initialCreds.x509.cert);
+        assert.strictEqual(creds.x509.key, initialCreds.x509.key);
+        x509AuthProvider.setX509Options(newX509Options);
+        x509AuthProvider.getDeviceCredentials(function (err, creds) {
+          assert.isNull(err);
+          assert.strictEqual(creds.deviceId, initialCreds.deviceId);
+          assert.strictEqual(creds.host, initialCreds.host);
+          assert.strictEqual(creds.x509.cert, newX509Options.cert);
+          assert.strictEqual(creds.x509.key, newX509Options.key);
+          testCallback();
+        });
+      });
+    });
+  });
+
+  describe('#fromX509Options', function () {
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_004: [The `fromX509Options` method shall throw a `ReferenceError` if `deviceId` is falsy.]*/
+    [undefined, null, ''].forEach(function (badDeviceId) {
+      it('throws if deviceId is \'' + badDeviceId + '\'', function () {
+        var fakeX509Options = {
+          cert: 'cert',
+          key: 'key'
+        };
+        assert.throws(function () {
+          return X509AuthenticationProvider.fromX509Options(badDeviceId, 'host', fakeX509Options);
+        }, ReferenceError);
+      });
+    });
+
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_005: [The `fromX509Options` method shall throw a `ReferenceError` if `iotHubHostname` is falsy.]*/
+    [undefined, null, ''].forEach(function (badHost) {
+      it('throws if iotHubHostname is \'' + badHost + '\'', function () {
+        var fakeX509Options = {
+          cert: 'cert',
+          key: 'key'
+        };
+        assert.throws(function () {
+          return X509AuthenticationProvider.fromX509Options('deviceId', badHost, fakeX509Options);
+        }, ReferenceError);
+      });
+    });
+
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_006: [The `fromX509Options` method shall throw a `ReferenceError` if `x509info` is falsy.]*/
+    [undefined, null].forEach(function (badX509Opts) {
+      it('throws if x509Options is \'' + badX509Opts + '\'', function () {
+        assert.throws(function () {
+          return X509AuthenticationProvider.fromX509Options('deviceId', 'host', badX509Opts);
+        }, ReferenceError);
+      });
+    });
+
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_007: [The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.cert` is falsy.]*/
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_008: [The `fromX509Options` method shall throw an `errors.ArgumentError` if `x509info.key` is falsy.]*/
+    [{ cert: 'cert' }, { key: 'key' }, {}].forEach(function (badX509Opts) {
+      it('throws if x509Options is \'' + JSON.stringify(badX509Opts) + '\'', function () {
+        assert.throws(function () {
+          return X509AuthenticationProvider.fromX509Options('deviceId', 'host', badX509Opts);
+        }, errors.ArgumentError);
+      });
+    });
+
+    /*Tests_SRS_NODE_X509_AUTHENTICATION_PROVIDER_16_009: [The `fromX509Options` method shall create a new instance of `X509AuthenticationProvider` with a credentials object created from the arguments.]*/
+    it('creates a new instance of an X509AuthenticationProvider using the arguments provided', function (testCallback) {
+      var fakeX509Options = {
+        cert: 'cert',
+        key: 'key'
+      };
+      var fakeDeviceId = 'deviceId';
+      var fakeHost = 'host.name';
+
+      var x509AuthProvider = X509AuthenticationProvider.fromX509Options(fakeDeviceId, fakeHost, fakeX509Options);
+      x509AuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.isNull(err);
+        assert.strictEqual(creds.deviceId, fakeDeviceId);
+        assert.strictEqual(creds.host, fakeHost);
+        assert.strictEqual(creds.x509.cert, fakeX509Options.cert);
+        assert.strictEqual(creds.x509.key, fakeX509Options.key);
+        testCallback();
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Description of the problem
In preparation for the DPS integration with the IoT Hub device SDK we need to introduce the concept of AuthenticationProvider: a set of classes that obey the same interface and are in charge of acquiring and updating the credentials that the client and transports need to perform

This first PR (out of a series) introduces the interface as well as the first 3 authentication providers that cover legacy authentication methods, using shared access key, shared access signature and x509 certificates. 

The future PRs will include changes to the client and transports to take advantage of these new objects as well as the TPM and X509 authentication providers working with their respective security clients coming from the DPS world.

No breaking changes in here, only new APIs that are currently not used by the client or transports.