### PR TITLE
Device client modifications to support the new AuthenticationProvider object

### DIFF
--- a/device/core/devdoc/blob_upload/blob_upload_client_requirements.md
+++ b/device/core/devdoc/blob_upload/blob_upload_client_requirements.md
@@ -14,11 +14,6 @@ Initializes a new instance of the `BlobUploadClient` class.
 
 **SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_003: [** If specified, `BlobUploadClient` shall use the `blobUploader` passed as a parameter instead of the default one. **]**
 
-## updateSharedAccessSignature(sharedAccessSignature)
-Updates the current value shared access signature.
-
-**SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_011: [** `updateSharedAccessSignature` shall update the value used by the `BlobUploadClient` instance to the value passed as an argument. **]**
-
 ## uploadToBlob(blobName, stream, streamLength, done)
 Uploads the specified stream to the specified blob.
 

--- a/device/core/devdoc/blob_upload/file_upload_endpoint_requirements.md
+++ b/device/core/devdoc/blob_upload/file_upload_endpoint_requirements.md
@@ -6,19 +6,15 @@ The `FileUploadApi` class provide methods to get an Azure Storage blob SAS URI f
 ## Usage
 
 ## Public API
-### FileUploadApi(deviceId, hostname, transport) [constructor]
+### FileUploadApi(authenticationProvider, transport) [constructor]
 
-**SRS_NODE_FILE_UPLOAD_ENDPOINT_16_002: [** `FileUploadApi` shall throw a `ReferenceError` if `deviceId` is falsy. **]**
-
-**SRS_NODE_FILE_UPLOAD_ENDPOINT_16_003: [** `FileUploadApi` shall throw a `ReferenceError` if `hostname` is falsy. **]**
+**SRS_NODE_FILE_UPLOAD_ENDPOINT_16_019: [** `FileUploadApi` shall throw a `ReferenceError` if `authenticationProvider` is falsy. **]**
 
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_018: [** `FileUploadApi` shall instantiate the default `azure-iot-http-base.Http` transport if `transport` is not specified, otherwise it shall use the specified transport. **]**
 
 ### getBlobSharedAccessSignature(blobName, iotHubSas, done)
 
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_004: [** `getBlobSharedAccessSignature` shall throw a `ReferenceError` if `blobName` is falsy. **]**
-
-**SRS_NODE_FILE_UPLOAD_ENDPOINT_16_005: [** `getBlobSharedAccessSignature` shall throw a `ReferenceError` if `auth` is falsy. **]**
 
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_006: [** `getBlobSharedAccessSignature` shall create a `POST` HTTP request to a path formatted as the following:
 `/devices/<deviceId>/files?api-version=<api-version>`
@@ -52,10 +48,8 @@ The `POST` HTTP request shall have the following body:
 }
  **]**
 
-### notifyUploadComplete(correlationId, sharedAccessSignature, uploadResult, done)
+### notifyUploadComplete(correlationId, uploadResult, done)
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_010: [** `notifyUploadComplete` shall throw a `ReferenceError` if `correlationId` is falsy. **]**
-
-**SRS_NODE_FILE_UPLOAD_ENDPOINT_16_011: [** `notifyUploadComplete` shall throw a `ReferenceError` if `auth` is falsy. **]**
 
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_012: [** `notifyUploadComplete` shall throw a `ReferenceError` if `uploadResult` is falsy. **]**
 
@@ -70,7 +64,7 @@ Authorization: <sharedAccessSignature>,
 'Content-Type': 'application/json; charset=utf-8',
 'Content-Length': <content length>,
 'iothub-name': <hub name>
-``` 
+```
 **]**
 
 **SRS_NODE_FILE_UPLOAD_ENDPOINT_16_015: [** The `POST` HTTP request shall have the following body:

--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -31,9 +31,11 @@ client.sendEvent(new Message('hello world'), print);
 #### fromConnectionString
 **SRS_NODE_DEVICE_CLIENT_05_003: [** The `fromConnectionString` method shall throw ReferenceError if the connStr argument is falsy. **]**
 
-**SRS_NODE_DEVICE_CLIENT_05_005: [** `fromConnectionString` shall derive and transform the needed parts from the connection string in order to create a new instance of Transport. **]**
-
 **SRS_NODE_DEVICE_CLIENT_05_006: [** The `fromConnectionString` method shall return a new instance of the `Client` object, as by a call to `new Client(new Transport(...))`. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_087: [** The `fromConnectionString` method shall create a new `SharedAccessKeyAuthorizationProvider` object with the connection string passed as argument if it contains a SharedAccessKey parameter and pass this object to the transport constructor. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_093: [** The `fromConnectionString` method shall create a new `X509AuthorizationProvider` object with the connection string passed as argument if it contains an X509 parameter and pass this object to the transport constructor. **]**
 
 #### fromSharedAccessSignature
 
@@ -41,14 +43,25 @@ client.sendEvent(new Message('hello world'), print);
 
 **SRS_NODE_DEVICE_CLIENT_16_030: [** The `fromSharedAccessSignature` method shall return a new instance of the `Client` object **]**
 
+**SRS_NODE_DEVICE_CLIENT_16_088: [** The `fromSharedAccessSignature` method shall create a new `SharedAccessSignatureAuthorizationProvider` object with the shared access signature passed as argument, and pass this object to the transport constructor. **]**
+
+#### fromAuthenticationProvider
+
+**SRS_NODE_DEVICE_CLIENT_16_089: [** The `fromAuthenticationProvider` method shall throw a `ReferenceError` if the `authenticationProvider` argument is falsy. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_092: [** The `fromAuthenticationProvider` method shall throw a `ReferenceError` if the `transportCtor` argument is falsy. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_090: [** The `fromAuthenticationProvider` method shall pass the `authenticationProvider` object passed as argument to the transport constructor. **]**
+
+**SRS_NODE_DEVICE_CLIENT_16_091: [** The `fromAuthenticationProvider` method shall return a `Client` object configured with a new instance of a transport created using the `transportCtor` argument. **]**
+
+
 ### Constructors
 #### Client(transport, connectionString) constructor
 
 **SRS_NODE_DEVICE_CLIENT_05_001: [** The `Client` constructor shall accept a transport object **]**  , e.g. `azure-iot-device-http.Http`.
 
 **SRS_NODE_DEVICE_CLIENT_16_026: [** The `Client` constructor shall accept a connection string as an optional second argument **]**
-
-**SRS_NODE_DEVICE_CLIENT_16_027: [** If a connection string argument is provided and is using SharedAccessKey authentication, the `Client` shall automatically generate and renew SAS tokens. **]**
 
 ### Public Methods
 
@@ -158,8 +171,6 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 #### updateSharedAccessSignature(sharedAccessSignature, done)
 
 **SRS_NODE_DEVICE_CLIENT_16_031: [** The `updateSharedAccessSignature` method shall throw a `ReferenceError` if the sharedAccessSignature parameter is falsy. **]**
-
-**SRS_NODE_DEVICE_CLIENT_06_002: [** The `updateSharedAccessSignature` method shall throw a `ReferenceError` if the client was created using x509. **]**
 
 **SRS_NODE_DEVICE_CLIENT_16_032: [** The `updateSharedAccessSignature` method shall call the `updateSharedAccessSignature` method of the transport currently in use with the sharedAccessSignature parameter. **]**
 

--- a/device/core/src/blob_upload/blob_upload_client.ts
+++ b/device/core/src/blob_upload/blob_upload_client.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { Stream } from 'stream';
-import { X509, SharedAccessSignature } from 'azure-iot-common';
+import { AuthenticationProvider } from 'azure-iot-common';
 
 import { BlobUploadResult } from './blob_upload_result';
 import { BlobUploader as DefaultBlobUploader } from './blob_uploader';
@@ -27,15 +27,15 @@ export interface UploadParams {
  * @private
  */
 export interface FileUpload {
-    getBlobSharedAccessSignature(blobName: string, auth: X509 | SharedAccessSignature, done: (err: Error, uploadParams?: UploadParams) => void): void;
-    notifyUploadComplete(correlationId: string, auth: X509 | SharedAccessSignature, uploadResult: BlobUploadResult, done: (err?: Error) => void): void;
+  getBlobSharedAccessSignature(blobName: string, done: (err: Error, uploadParams?: UploadParams) => void): void;
+  notifyUploadComplete(correlationId: string, uploadResult: BlobUploadResult, done: (err?: Error) => void): void;
 }
 
 /**
  * @private
  */
 export interface BlobUploader {
-    uploadToBlob(uploadParams: UploadParams, stream: Stream, streamLength: number, done: (err: Error, body?: any, result?: { statusCode: number, body: string }) => void): void;
+  uploadToBlob(uploadParams: UploadParams, stream: Stream, streamLength: number, done: (err: Error, body?: any, result?: { statusCode: number, body: string }) => void): void;
 }
 
 /**
@@ -49,32 +49,25 @@ export interface BlobUpload {
  * @private
  */
 export class BlobUploadClient implements BlobUpload {
-  private _config: any;
+  private _authenticationProvider: AuthenticationProvider;
   private _fileUploadApi: FileUpload;
   private _blobUploader: BlobUploader;
 
-  constructor(config: any, fileUploadApi?: FileUpload, blobUploader?: BlobUploader) {
+  constructor(authenticationProvider: AuthenticationProvider, fileUploadApi?: FileUpload, blobUploader?: BlobUploader) {
     /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_001: [`BlobUploadClient` shall throw a `ReferenceError` if `config` is falsy.]*/
-    if (!config) throw new ReferenceError('config cannot be \'' + config + '\'');
-    this._config = config;
+    if (!authenticationProvider) throw new ReferenceError('authenticationProvider cannot be \'' + authenticationProvider + '\'');
+    this._authenticationProvider = authenticationProvider;
 
     /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_002: [If specified, `BlobUploadClient` shall use the `fileUploadApi` passed as a parameter instead of the default one.]*/
-    this._fileUploadApi = fileUploadApi ? fileUploadApi : new DefaultFileUploadApi(this._config.deviceId, this._config.host);
+    this._fileUploadApi = fileUploadApi ? fileUploadApi : new DefaultFileUploadApi(this._authenticationProvider);
 
     /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_003: [If specified, `BlobUploadClient` shall use the `blobUploader` passed as a parameter instead of the default one.]*/
     this._blobUploader = blobUploader ? blobUploader : new DefaultBlobUploader();
   }
 
-  updateSharedAccessSignature(sharedAccessSignature: string): void {
-    /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_011: [`updateSharedAccessSignature` shall update the value used by the `BlobUploadClient` instance to the value passed as an argument.]*/
-    this._config.sharedAccessSignature = sharedAccessSignature;
-  }
-
   uploadToBlob(blobName: string, stream: Stream, streamLength: number, done: (err?: Error) => void): void {
-    const self = this;
     /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_004: [`uploadToBlob` shall obtain a blob SAS token using the IoT Hub service file upload API endpoint.]*/
-    const auth = self._config.x509 ? self._config.x509 : self._config.sharedAccessSignature;
-    self._fileUploadApi.getBlobSharedAccessSignature(blobName, auth, (err, uploadParams) => {
+    this._fileUploadApi.getBlobSharedAccessSignature(blobName, (err, uploadParams) => {
       if (err) {
         /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_005: [`uploadToBlob` shall call the `done` callback with a `BlobSasError` parameter if retrieving the SAS token fails.]*/
         let error = new errors.BlobSasError('Could not obtain blob shared access signature.');
@@ -82,10 +75,10 @@ export class BlobUploadClient implements BlobUpload {
         done(error);
       } else {
         /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_006: [`uploadToBlob` shall upload the stream to the specified blob using its BlobUploader instance.]*/
-        self._blobUploader.uploadToBlob(uploadParams, stream, streamLength, (err, body, result) => {
+        this._blobUploader.uploadToBlob(uploadParams, stream, streamLength, (err, body, result) => {
           const uploadResult = BlobUploadResult.fromAzureStorageCallbackArgs(err, body, result);
           /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_008: [`uploadToBlob` shall notify the result of a blob upload to the IoT Hub service using the file upload API endpoint.]*/
-          self._fileUploadApi.notifyUploadComplete(uploadParams.correlationId, auth, uploadResult, (err) => {
+          this._fileUploadApi.notifyUploadComplete(uploadParams.correlationId, uploadResult, (err) => {
             if (err) {
               /*Codes_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_009: [`uploadToBlob` shall call the `done` callback with a `BlobUploadNotificationError` if notifying the IoT Hub instance of the transfer outcome fails.]*/
               let error = new errors.BlobUploadNotificationError('Could not notify the IoT Hub of the file upload completion.');

--- a/device/core/src/blob_upload/file_upload_api.ts
+++ b/device/core/src/blob_upload/file_upload_api.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { endpoint, X509, SharedAccessSignature } from 'azure-iot-common';
+import { endpoint, AuthenticationProvider } from 'azure-iot-common';
 import { Http as DefaultHttpTransport } from 'azure-iot-http-base';
 import { UploadParams, FileUpload as FileUploadInterface } from './blob_upload_client';
 import { BlobUploadResult } from './blob_upload_result';
@@ -25,120 +25,119 @@ const packageJson = require('../../package.json');
 /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_002: [`FileUploadApi` shall throw a `ReferenceError` if `deviceId` is falsy.]*/
 /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_003: [`FileUploadApi` shall throw a `ReferenceError` if `hostname` is falsy.]*/
 export class FileUploadApi implements FileUploadInterface {
-    deviceId: string;
-    hostname: string;
+    _authenticationProvider: AuthenticationProvider;
     http: any; // TODO: need interface >_<
 
-    constructor(deviceId: string, hostname: string, httpTransport?: any) {
-        if (!deviceId) throw new ReferenceError('deviceId cannot be \'' + deviceId + '\'');
-        if (!hostname) throw new ReferenceError('hostname cannot be \'' + hostname + '\'');
+    constructor(authenticationProvider: AuthenticationProvider, httpTransport?: any) {
+        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_019: [`FileUploadApi` shall throw a `ReferenceError` if `authenticationProvider` is falsy.]*/
+        if (!authenticationProvider) throw new ReferenceError('authenticationProvider cannot be \'' + authenticationProvider + '\'');
 
-        this.deviceId = deviceId;
-        this.hostname = hostname;
+        this._authenticationProvider = authenticationProvider;
         /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_018: [`FileUploadApi` shall instantiate the default `azure-iot-http-base.Http` transport if `transport` is not specified, otherwise it shall use the specified transport.]*/
         this.http = httpTransport ? httpTransport : new DefaultHttpTransport();
     }
 
-    getBlobSharedAccessSignature(blobName: string, auth: X509 | SharedAccessSignature, done: (err?: Error, uploadParams?: UploadParams) => void): void {
+    getBlobSharedAccessSignature(blobName: string, done: (err?: Error, uploadParams?: UploadParams) => void): void {
         /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_004: [`getBlobSharedAccessSignature` shall throw a `ReferenceError` if `blobName` is falsy.]*/
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_005: [`getBlobSharedAccessSignature` shall throw a `ReferenceError` if `auth` is falsy.]*/
         if (!blobName) throw new ReferenceError('blobName cannot be \'' + blobName + '\'');
-        if (!auth) throw new ReferenceError('auth cannot be \'' + auth + '\'');
 
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_006: [`getBlobSharedAccessSignature` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files?api-version=<api-version>]*/
-        const path = endpoint.devicePath(this.deviceId) + '/files' + endpoint.versionQueryString();
-        const body = JSON.stringify({ blobName: blobName });
+        this._authenticationProvider.getDeviceCredentials((err, deviceCredentials) => {
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_006: [`getBlobSharedAccessSignature` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files?api-version=<api-version>]*/
+            const path = endpoint.devicePath(deviceCredentials.deviceId) + '/files' + endpoint.versionQueryString();
+            const body = JSON.stringify({ blobName: blobName });
 
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_007: [The `POST` HTTP request shall have the following headers:
-        ```
-         Host: <hostname>
-         Authorization: <sharedAccessSignature>,
-         Accept: 'application/json',
-        'Content-Type': 'application/json',
-         Content-Length': body.length,
-        'User-Agent': <sdk name and version>
-        The `POST` HTTP request shall have the following body:
-        {
-          blobName: '<name of the blob for which a SAS URI will be generated>'
-        }
-        ```]*/
-        let headers: any = {
-            Host: this.hostname,
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_007: [The `POST` HTTP request shall have the following headers:
+            ```
+            Host: <hostname>
+            Authorization: <sharedAccessSignature>,
             Accept: 'application/json',
             'Content-Type': 'application/json',
-            'Content-Length': body.length,
-            'User-Agent': packageJson.name + '/' + packageJson.version
-        };
-
-        let x509Opts = null;
-        if (typeof auth === 'string') {
-            headers.Authorization = auth;
-        } else {
-            x509Opts = auth;
-        }
-
-        const req = this.http.buildRequest('POST', path, headers, this.hostname, x509Opts, (err, body, response) => {
-            if (err) {
-                err.responseBody = body;
-                err.response = response;
-                /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_008: [`getBlobSasUri` shall call the `done` callback with an `Error` object if the request fails.]*/
-                done(err);
-            } else {
-                /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_009: [`getBlobSasUri` shall call the `done` callback with a `null` error object and a result object containing a correlation ID and a SAS parameters if the request succeeds]*/
-                const result = JSON.parse(body);
-                done(null, result);
+            Content-Length': body.length,
+            'User-Agent': <sdk name and version>
+            The `POST` HTTP request shall have the following body:
+            {
+            blobName: '<name of the blob for which a SAS URI will be generated>'
             }
+            ```]*/
+            let headers: any = {
+                Host: deviceCredentials.host,
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+                'Content-Length': body.length,
+                'User-Agent': packageJson.name + '/' + packageJson.version
+            };
+
+            let x509Opts = null;
+            if (typeof deviceCredentials.sharedAccessSignature === 'string') {
+                headers.Authorization = deviceCredentials.sharedAccessSignature;
+            } else {
+                x509Opts = deviceCredentials.x509;
+            }
+
+            const req = this.http.buildRequest('POST', path, headers, deviceCredentials.host, x509Opts, (err, body, response) => {
+                if (err) {
+                    err.responseBody = body;
+                    err.response = response;
+                    /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_008: [`getBlobSasUri` shall call the `done` callback with an `Error` object if the request fails.]*/
+                    done(err);
+                } else {
+                    /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_009: [`getBlobSasUri` shall call the `done` callback with a `null` error object and a result object containing a correlation ID and a SAS parameters if the request succeeds]*/
+                    const result = JSON.parse(body);
+                    done(null, result);
+                }
+            });
+            req.write(body);
+            req.end();
         });
-        req.write(body);
-        req.end();
+
     }
 
-    notifyUploadComplete(correlationId: string, auth: X509 | SharedAccessSignature, uploadResult: BlobUploadResult, done?: (err?: Error) => void): void {
+    notifyUploadComplete(correlationId: string, uploadResult: BlobUploadResult, done?: (err?: Error) => void): void {
         /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_010: [`notifyUploadComplete` shall throw a `ReferenceError` if `correlationId` is falsy.]*/
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_011: [`notifyUploadComplete` shall throw a `ReferenceError` if `auth` is falsy.]*/
         /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_012: [`notifyUploadComplete` shall throw a `ReferenceError` if `uploadResult` is falsy.]*/
         if (!correlationId) throw new ReferenceError('correlationId cannot be \'' + correlationId + '\'');
-        if (!auth) throw new ReferenceError('auth cannot be \'' + auth + '\'');
         if (!uploadResult) throw new ReferenceError('uploadResult cannot be \'' + uploadResult + '\'');
 
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_013: [`notifyUploadComplete` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files/<correlationId>?api-version=<api-version>`]*/
-        const path = endpoint.devicePath(this.deviceId) + '/files/notifications/' + encodeURIComponent(correlationId) + endpoint.versionQueryString();
-        const body = JSON.stringify(uploadResult);
+        this._authenticationProvider.getDeviceCredentials((err, deviceCredentials) => {
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_013: [`notifyUploadComplete` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files/<correlationId>?api-version=<api-version>`]*/
+            const path = endpoint.devicePath(deviceCredentials.deviceId) + '/files/notifications/' + encodeURIComponent(correlationId) + endpoint.versionQueryString();
+            const body = JSON.stringify(uploadResult);
 
-        /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_014: [The `POST` HTTP request shall have the following headers:
-        ```
-        Host: <hostname>,
-        Authorization: <sharedAccessSignature>,
-        'User-Agent': <version>,
-        'Content-Type': 'application/json; charset=utf-8',
-        'Content-Length': <content length>,
-        'iothub-name': <hub name>
-        ```]*/
-        let headers: any = {
-            Host: this.hostname,
-            'User-Agent': packageJson.name + '/' + packageJson.version,
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_014: [The `POST` HTTP request shall have the following headers:
+            ```
+            Host: <hostname>,
+            Authorization: <sharedAccessSignature>,
+            'User-Agent': <version>,
             'Content-Type': 'application/json; charset=utf-8',
-            'Content-Length': body.length,
-            'iothub-name': this.hostname.split('.')[0]
-        };
+            'Content-Length': <content length>,
+            'iothub-name': <hub name>
+            ```]*/
+            let headers: any = {
+                Host: deviceCredentials.host,
+                'User-Agent': packageJson.name + '/' + packageJson.version,
+                'Content-Type': 'application/json; charset=utf-8',
+                'Content-Length': body.length,
+                'iothub-name': deviceCredentials.host.split('.')[0]
+            };
 
-        let x509Opts = null;
-        if (typeof auth === 'string') {
-            headers.Authorization = auth;
-        } else {
-            x509Opts = auth;
-        }
-
-        const req = this.http.buildRequest('POST', path, headers, this.hostname, x509Opts, (err) => {
-            if (err) {
-                /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_016: [** `notifyUploadComplete` shall call the `done` callback with an `Error` object if the request fails.]*/
-                done(err);
+            let x509Opts = null;
+            if (typeof deviceCredentials.sharedAccessSignature === 'string') {
+                headers.Authorization = deviceCredentials.sharedAccessSignature;
             } else {
-                /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_017: [** `notifyUploadComplete` shall call the `done` callback with no parameters if the request succeeds.]*/
-                done();
+                x509Opts = deviceCredentials.x509;
             }
+
+            const req = this.http.buildRequest('POST', path, headers, deviceCredentials.host, x509Opts, (err) => {
+                if (err) {
+                    /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_016: [** `notifyUploadComplete` shall call the `done` callback with an `Error` object if the request fails.]*/
+                    done(err);
+                } else {
+                    /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_017: [** `notifyUploadComplete` shall call the `done` callback with no parameters if the request succeeds.]*/
+                    done();
+                }
+            });
+            req.write(body);
+            req.end();
         });
-        req.write(body);
-        req.end();
     }
 }

--- a/device/core/test/_sas_authentication_provider_test.js
+++ b/device/core/test/_sas_authentication_provider_test.js
@@ -73,7 +73,7 @@ describe('SharedAccessSignatureAuthenticationProvider', function () {
     });
 
     /*Tests_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_006: [The `fromSharedAccessSignature` shall return a new `SharedAccessSignatureAuthenticationProvider` object initialized with the credentials parsed from the `sharedAccessSignature` argument.]*/
-    it('creates a SharedAccessSignatureAuthenticationProvider initialized with credentiasl from the shared access signature passed as argument', function (testCallback) {
+    it('creates a SharedAccessSignatureAuthenticationProvider initialized with credentials from the shared access signature passed as argument', function (testCallback) {
       var fakeCredentials = {
         host: 'host.name',
         deviceId: 'deviceId',
@@ -87,6 +87,28 @@ describe('SharedAccessSignatureAuthenticationProvider', function () {
         assert.strictEqual(creds.deviceId, fakeCredentials.deviceId);
         assert.isUndefined(creds.sharedAccessKey);
         assert.strictEqual(creds.sharedAccessSignature, fakeSas);
+        testCallback();
+      });
+    });
+
+    it('create a correct config when sr is not URI-encoded', function (testCallback) {
+      var sharedAccessSignature = '"SharedAccessSignature sr=hubName.azure-devices.net/devices/deviceId&sig=s1gn4tur3&se=1454204843"';
+      var sasAuthProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(sharedAccessSignature);
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.host, 'hubName.azure-devices.net');
+        assert.strictEqual(creds.deviceId, 'deviceId');
+        assert.strictEqual(creds.sharedAccessSignature, sharedAccessSignature);
+        testCallback();
+      });
+    });
+
+    it('create a correct config when sr is URI-encoded', function (testCallback) {
+      var sharedAccessSignature = '"SharedAccessSignature sr=hubName.azure-devices.net%2Fdevices%2FdeviceId&sig=s1gn4tur3&se=1454204843"';
+      var sasAuthProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(sharedAccessSignature);
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.host, 'hubName.azure-devices.net');
+        assert.strictEqual(creds.deviceId, 'deviceId');
+        assert.strictEqual(creds.sharedAccessSignature, sharedAccessSignature);
         testCallback();
       });
     });

--- a/device/core/test/blob_upload/_blob_upload_client_test.js
+++ b/device/core/test/blob_upload/_blob_upload_client_test.js
@@ -24,6 +24,12 @@ var fakeConfig = {
   deviceId: 'deviceId'
 };
 
+var fakeAuthenticationProvider = {
+  getDeviceCredentials: function (callback) {
+    callback(null, fakeConfig);
+  }
+};
+
 describe('BlobUploadClient', function() {
   describe('#constructor', function() {
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_001: [`BlobUploadClient` shall throw a `ReferenceError` if `config` is falsy.]*/
@@ -48,24 +54,6 @@ describe('BlobUploadClient', function() {
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_003: [If specified, `BlobUploadClient` shall use the `blobUploader` passed as a parameter instead of the default one.]*/
   });
 
-  describe('#updateSharedAccessSignature', function() {
-    /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_011: [`updateSharedAccessSignature` shall update the value used by the `BlobUploadClient` instance to the value passed as an argument.]*/
-    it('updates the shared access signature with the new one', function() {
-      var newSas = 'newSas';
-      var fakeStream = new stream.Readable();
-      var fakeFileUpload = new FakeFileUploadApi();
-      var fakeBlobUploader = new FakeBlobUploader();
-      var fakeBlobName = 'blobName';
-
-      var client = new BlobUploadClient(fakeConfig, fakeFileUpload, fakeBlobUploader);
-      client.uploadToBlob(fakeBlobName, fakeStream, 42, function() {});
-      assert(fakeFileUpload.getBlobSharedAccessSignature.calledWith(fakeBlobName, fakeConfig.sharedAccessSignature));
-      client.updateSharedAccessSignature(newSas);
-      client.uploadToBlob(fakeBlobName, fakeStream, 42, function() {});
-      assert(fakeFileUpload.getBlobSharedAccessSignature.calledWith(fakeBlobName, newSas));
-    });
-  });
-
   describe('#uploadToBlob', function() {
     /*Tests_SRS_NODE_DEVICE_BLOB_UPLOAD_CLIENT_16_004: [`uploadToBlob` shall obtain a blob SAS token using the IoT Hub service file upload API endpoint.]*/
     it('gets the Blob SAS token from the File Upload API', function() {
@@ -84,7 +72,7 @@ describe('BlobUploadClient', function() {
       var fakeFileUpload = new FakeFileUploadApi();
       var fakeBlobUploader = new FakeBlobUploader();
       var fakeBlobName = 'blobName';
-      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
+      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, callback) {
         var error = new Error('fake error');
         callback(error);
       };
@@ -111,7 +99,7 @@ describe('BlobUploadClient', function() {
         sasToken: 'sasToken'
       };
 
-      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
+      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, callback) {
         callback(null, fakeBlobInfo);
       };
 
@@ -141,7 +129,7 @@ describe('BlobUploadClient', function() {
         sasToken: 'sasToken'
       };
 
-      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
+      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, callback) {
         callback(null, fakeBlobInfo);
       };
 
@@ -169,11 +157,11 @@ describe('BlobUploadClient', function() {
         sasToken: 'sasToken'
       };
 
-      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
+      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, callback) {
         callback(null, fakeBlobInfo);
       };
 
-      fakeFileUpload.notifyUploadComplete = function(correlationId, result, sharedAccessSignature, callback) {
+      fakeFileUpload.notifyUploadComplete = function(correlationId, result, callback) {
         callback(new Error('could not notify hub'));
       };
 
@@ -203,11 +191,11 @@ describe('BlobUploadClient', function() {
         sasToken: 'sasToken'
       };
 
-      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, sas, callback) {
+      fakeFileUpload.getBlobSharedAccessSignature = function(blobName, callback) {
         callback(null, fakeBlobInfo);
       };
 
-      fakeFileUpload.notifyUploadComplete = function(correlationId, result, sharedAccessSignature, callback) {
+      fakeFileUpload.notifyUploadComplete = function(correlationId, result, callback) {
         callback();
       };
 


### PR DESCRIPTION
The PR follows #179 and implements the required changes in the device client package to support the new AuthenticationProvider classes.

While the unit tests work, changes to the transport packages are required to fully enable the feature so it will be merged with transports PR before it's merged into master.