### PR TITLE
separate disconnect and cancel at the transport level

### DIFF
--- a/provisioning/device/devdoc/polling_state_machine_requirements.md
+++ b/provisioning/device/devdoc/polling_state_machine_requirements.md
@@ -27,6 +27,8 @@ Register round-trips one step of the registration process, not returning until a
 
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_028: [** If `PollingTransport.registrationRequest` succeeds with status==Failed, it shall fail with a `ProvisioningRegistrationFailedError` error **]**
 
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_036: [** If `PollingTransport.registrationRequest` does not call its callback within `ProvisioningDeviceConstants.defaultTimeoutInterval` ms, register shall with with a `TimeoutError` error. **]**
+
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_018: [** When the polling interval elapses, `register` shall call `PollingTransport.queryOperationStatus`. **]**
 
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_019: [** If `PollingTransport.queryOperationStatus` fails, `register` shall fail. **]**
@@ -39,15 +41,31 @@ Register round-trips one step of the registration process, not returning until a
 
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_022: [** If `PollingTransport.queryOperationStatus` succeeds with an unknown status, `register` shall fail with a `SyntaxError` and pass the response body and the protocol-specific result to the `callback`. **]**
 
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_037: [** If `PollingTransport.queryOperationStatus` does not call its callback within `ProvisioningDeviceConstants.defaultTimeoutInterval` ms, register shall with with a `TimeoutError` error. **]**
+
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_024: [** If `register` is called while a different request is in progress, it shall fail with an `InvalidOperationError`. **]**
 
 
 ### cancel(callback: (err: Error) => void): void
-`cancel` is used to end the transport session
+`cancel` is used to cancel the current operation
 
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_025: [** If `cancel` is called while disconnected, it shall immediately call its `callback`. **]**
 
-**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_026: [** `cancel` shall call `PollingTransport.cancel` of it's called while the transport is connected. **]**
-
 **SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_027: [** If a registration is in progress, `cancel` shall cause that registration to fail with an `OperationCancelledError`. **]**
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_030: [** If `cancel` is called while the transport is connected but idle, it shall immediately call its `callback`. **]**
+
+
+### disconnect(callback: (err: Error) => void): void
+`disconnect` is used to end the current transport session
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_031: [** If `disconnect` is called while disconnected, it shall immediately call its `callback`. **]**
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_032: [** If `disconnect` is called while while the transport is connected but idle, it shall call `PollingTransport.disconnect` and call it's `callback` passing the results of the transport operation. **]**
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_033: [** If `disconnect` is called while in the middle of a `registrationRequest` operation, the operation shall be cancelled and the transport shall be disconnected. **]**
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_034: [** If `disconnect` is called while the state machine is waiting to poll, the current operation shall be cancelled and the transport shall be disconnected. **]**
+
+**SRS_NODE_PROVISIONING_TRANSPORT_STATE_MACHINE_18_035: [** If `disconnect` is called while in the middle of a `queryOperationStatus` operation, the operation shall be cancelled and the transport shall be disconnected. **]**
 

--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -24,13 +24,13 @@
   "scripts": {
     "lint": "tslint --project . -c ../../tslint.json",
     "build": "tsc",
-    "unittest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
-    "alltest-min": "istanbul cover --report none node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
+    "unittest-min": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test.js",
+    "alltest-min": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot test/_*_test*.js",
     "unittest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test.js",
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 84 --branches 68 --functions 70 --lines 86"
+    "check-cover": "istanbul check-coverage --statements 85 --branches 64 --functions 72 --lines 86"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/device/src/constants.ts
+++ b/provisioning/device/src/constants.ts
@@ -28,5 +28,5 @@ export class ProvisioningDeviceConstants {
   /**
    * default timeout to use when communicating with the service
    */
-  static defaultTimeoutInterval: number = 4000;
+  static defaultTimeoutInterval: number = 30000;
 }

--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -107,6 +107,7 @@ export interface PollingTransport {
   registrationRequest(request: RegistrationRequest, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void;
   queryOperationStatus(request: RegistrationRequest, operationId: string, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void;
   cancel(callback: (err?: Error) => void): void;
+  disconnect(callback: (err?: Error) => void): void;
 }
 
 /**

--- a/provisioning/device/src/x509_registration.ts
+++ b/provisioning/device/src/x509_registration.ts
@@ -53,7 +53,7 @@ export class X509Registration implements RegistrationClient {
         this._transport.setAuthentication(cert);
         /* Codes_SRS_NODE_DPS_X509_REGISTRATION_18_002: [ `register` shall call `registerX509` on the transport object and call it's callback with the result of the transport operation. ] */
         this._pollingStateMachine.register(request, (err?: Error, result?: DeviceRegistrationResult) => {
-          this._pollingStateMachine.cancel((disconnectErr: Error) => {
+          this._pollingStateMachine.disconnect((disconnectErr: Error) => {
             if (disconnectErr) {
               debug('error disconnecting.  Ignoring.  ' + disconnectErr);
             }

--- a/provisioning/transport/amqp/devdoc/amqp_requirements.md
+++ b/provisioning/transport/amqp/devdoc/amqp_requirements.md
@@ -84,12 +84,34 @@ iotdps-operation-id: <operationId>;
 
 **SRS_NODE_PROVISIONING_AMQP_16_021: [** The `queryOperationStatus` method shall call its callback with an error if the transport fails to send the request message. **]**
 
+## disconnect(callback: (err?: Error) => void): void
+
+**SRS_NODE_PROVISIONING_AMQP_16_022: [** `disconnect` shall call its callback immediately if the AMQP connection is disconnected. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_16_023: [** `disconnect` shall detach the sender and receiver links and disconnect the AMQP connection. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_16_024: [** `disconnect` shall call its callback with no arguments if all detach/disconnect operations were successful. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_16_025: [** `disconnect` shall call its callback with the error passed from the first unsuccessful detach/disconnect operation if one of those fail. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_18_009: [** `disconnect` shall disonnect the AMQP connection and cancel the operation that initiated a connection if called while the connection is in process. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_18_001: [** `disconnect` shall cause a `registrationRequest` operation that is in progress to call its callback passing an `OperationCancelledError` object. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_18_002: [** `disconnect` shall cause a `queryOperationStatus` operation that is in progress to call its callback passing an `OperationCancelledError` object. **]**
+
 ## cancel(callback: (err?: Error) => void): void
 
-**SRS_NODE_PROVISIONING_AMQP_16_022: [** `cancel` shall call its callback immediately if the AMQP connection is disconnected. **]**
+**SRS_NODE_PROVISIONING_AMQP_18_003: [** `cancel` shall call its callback immediately if the AMQP connection is disconnected. **]**
 
-**SRS_NODE_PROVISIONING_AMQP_16_023: [** `cancel` shall detach the sender and receiver links and disconnect the AMQP connection. **]**
+**SRS_NODE_PROVISIONING_AMQP_18_004: [** `cancel` shall call its callback immediately if the AMQP connection is connected but idle. **]**
 
-**SRS_NODE_PROVISIONING_AMQP_16_024: [** `cancel` shall call its callback with no arguments if all detach/disconnect operations were successful. **]**
+**SRS_NODE_PROVISIONING_AMQP_18_005: [** `cancel` shall disconnect the AMQP connection and cancel the operation that initiated a connection if called while the connection is in process. **]**
 
-**SRS_NODE_PROVISIONING_AMQP_16_025: [** `cancel` shall call its callback with the error passed from the first unsuccessful detach/disconnect operation if one of those fail. **]**
+**SRS_NODE_PROVISIONING_AMQP_18_006: [** `cancel` shall cause a `registrationRequest` operation that is in progress to call its callback passing an `OperationCancelledError` object. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_18_007: [** `cancel` shall cause a `queryOperationStatus` operation that is in progress to call its callback passing an `OperationCancelledError` object. **]**
+
+**SRS_NODE_PROVISIONING_AMQP_18_008: [** `cancel` shall not disconnect the AMQP transport. **]**
+
+

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 93 --branches 81 --functions 86 --lines 94"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 81 --functions 88 --lines 95"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/transport/amqp/test/_amqp_test.js
+++ b/provisioning/transport/amqp/test/_amqp_test.js
@@ -7,11 +7,29 @@ var EventEmitter = require('events').EventEmitter;
 var assert = require('chai').assert;
 var sinon = require('sinon');
 var Message = require('azure-iot-common').Message;
+var errors = require('azure-iot-common').errors;
 var ProvisioningDeviceConstants = require('azure-iot-provisioning-device').ProvisioningDeviceConstants;
 var Amqp = require('../lib/amqp.js').Amqp;
 
 describe('Amqp', function () {
-  var fakeSenderLink, fakeReceiverLink, fakeAmqpBase;
+  var fakeSenderLink, fakeReceiverLink, fakeAmqpBase, amqp;
+
+  var fakeRequest = {
+    idScope: 'fakeScope',
+    registrationId: 'fakeRegistrationId',
+    forceRegistration: false
+  };
+  var fakeError = new Error('fake error');
+  var fakeOperationId = 'fakeOpId';
+
+  var registrationRequest = {
+    name: 'registrationRequest',
+    invoke: function(callback) { amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, callback); }
+  };
+  var queryOperationStatus = {
+    name: 'queryOperationStatus',
+    invoke: function(callback) { amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', callback); }
+  };
 
   beforeEach(function () {
     fakeReceiverLink = new EventEmitter();
@@ -39,7 +57,7 @@ describe('Amqp', function () {
       }
 
       process.nextTick(() => {
-        fakeReceiverLink.emit('message', fakeResponse);
+        fakeReceiverLink.emit ('message', fakeResponse);
       })
       callback();
     });
@@ -50,17 +68,25 @@ describe('Amqp', function () {
       attachSenderLink: sinon.stub().callsArgWith(2, null, fakeSenderLink),
       attachReceiverLink: sinon.stub().callsArgWith(2, null, fakeReceiverLink),
     };
+
+    amqp = new Amqp(fakeAmqpBase);
+    amqp.setAuthentication({
+      cert: 'fakeCert',
+      key: 'fakeKey'
+    });
+  });
+
+  afterEach(function() {
+    fakeSenderLink = null;
+    fakeReceiverLink = null;
+    fakeAmqpBase = null;
+    amqp = null;
   });
 
   describe('X509', function () {
     describe('registrationRequest', function () {
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_002: [The `registrationRequest` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method.]*/
-      it('connects the AMQP connection using the X509 certificate', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('connects the AMQP connection using the X509 certificate', function (testCallback) {
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -69,14 +95,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_008: [The `registrationRequest` method shall call its callback with an error if the transport fails to connect.]*/
-      it('calls its callback with an error if it fails to connect', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to connect', function (testCallback) {
         fakeAmqpBase.connect = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -90,12 +110,7 @@ describe('Amqp', function () {
       com.microsoft:api-version: <API_VERSION>
       com.microsoft:client-version: <CLIENT_VERSION>
       ```]*/
-      it('attaches the sender link', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('attaches the sender link', function (testCallback) {
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {
           assert.isTrue(fakeAmqpBase.attachSenderLink.calledOnce);
@@ -104,14 +119,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_009: [The `registrationRequest` method shall call its callback with an error if the transport fails to attach the sender link.]*/
-      it('calls its callback with an error if it fails to attach the sender link', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to attach the sender link', function (testCallback) {
         fakeAmqpBase.attachSenderLink = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -125,17 +134,7 @@ describe('Amqp', function () {
       com.microsoft:api-version: <API_VERSION>
       com.microsoft:client-version: <CLIENT_VERSION>
       ```]*/
-      it('attaches the receiver link', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        var fakeRequest = {
-          idScope: 'fakeScope',
-          registrationId: 'fakeRegistrationId'
-        };
-
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('attaches the receiver link', function (testCallback) {
 
         amqp.registrationRequest(fakeRequest, function () {
           assert.isTrue(fakeAmqpBase.attachReceiverLink.calledOnce);
@@ -150,14 +149,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_010: [The `registrationRequest` method shall call its callback with an error if the transport fails to attach the receiver link.]*/
-      it('calls its callback with an error if it fails to attach the receiver link', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to attach the receiver link', function (testCallback) {
         fakeAmqpBase.attachReceiverLink = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -172,17 +165,7 @@ describe('Amqp', function () {
       iotdps-forceRegistration: <true or false>;
       ```
       ]*/
-      it('sends a properly formatted message', function (testCallback) {
-        var fakeRequest = {
-          idScope: 'fakeScope',
-          registrationId: 'fakeRegistrationId',
-          forceRegistration: false
-        };
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('sends a properly formatted message', function (testCallback) {
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {
           assert.isTrue(fakeSenderLink.send.calledOnce);
@@ -195,19 +178,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_011: [The `registrationRequest` method shall call its callback with an error if the transport fails to send the request message.]*/
-      it('calls its callback with an error if sending the message fails', function (testCallback) {
-        var fakeRequest = {
-          idScope: 'fakeScope',
-          registrationId: 'fakeRegistrationId',
-          forceRegistration: false
-        };
-        var fakeError = new Error('fake');
+      it ('calls its callback with an error if sending the message fails', function (testCallback) {
         fakeSenderLink.send = sinon.stub().callsArgWith(1, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
           assert.isTrue(fakeSenderLink.send.calledOnce);
@@ -218,54 +190,9 @@ describe('Amqp', function () {
     });
 
     describe('queryOperationStatus', function () {
-      var fakeSenderLink, fakeReceiverLink, fakeAmqpBase;
-
-      beforeEach(function () {
-        fakeReceiverLink = new EventEmitter();
-        fakeReceiverLink.forceDetach = sinon.stub();
-        fakeReceiverLink.detach = sinon.stub().callsArg(0);
-
-        fakeSenderLink = new EventEmitter();
-        fakeSenderLink.forceDetach = sinon.stub();
-        fakeSenderLink.detach = sinon.stub().callsArg(0);
-        fakeSenderLink.send = sinon.stub().callsFake((message, callback) => {
-          var fakeResponse;
-          if (message.applicationProperties['iotdps-operation-type'] === 'iotdps-register') {
-            fakeResponse = new Message(JSON.stringify({
-              operationId: 'fakeOpId',
-              status: 'assigning'
-            }));
-            fakeResponse.correlationId = message.properties.correlationId;
-          } else {
-            fakeResponse = new Message(JSON.stringify({
-              operationId: message.applicationProperties['iotdps-operation-id'],
-              status: 'assigned',
-              registrationState: {}
-            }));
-            fakeResponse.correlationId = message.properties.correlationId;
-          }
-
-          process.nextTick(() => {
-            fakeReceiverLink.emit('message', fakeResponse);
-          })
-          callback();
-        });
-
-        fakeAmqpBase = {
-          connect: sinon.stub().callsArg(2),
-          disconnect: sinon.stub().callsArg(0),
-          attachSenderLink: sinon.stub().callsArgWith(2, null, fakeSenderLink),
-          attachReceiverLink: sinon.stub().callsArgWith(2, null, fakeReceiverLink),
-        };
-      });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_012: [The `queryOperationStatus` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method.]*/
-      it('connects the AMQP connection using the X509 certificate', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('connects the AMQP connection using the X509 certificate', function (testCallback) {
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function () {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -274,14 +201,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_018: [The `queryOperationStatus` method shall call its callback with an error if the transport fails to connect.]*/
-      it('calls its callback with an error if it fails to connect', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to connect', function (testCallback) {
         fakeAmqpBase.connect = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -295,12 +216,7 @@ describe('Amqp', function () {
       com.microsoft:api-version: <API_VERSION>
       com.microsoft:client-version: <CLIENT_VERSION>
       ```]*/
-      it('attaches the sender link', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('attaches the sender link', function (testCallback) {
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function () {
           assert.isTrue(fakeAmqpBase.attachSenderLink.calledOnce);
@@ -309,14 +225,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_019: [The `queryOperationStatus` method shall call its callback with an error if the transport fails to attach the sender link.]*/
-      it('calls its callback with an error if it fails to attach the sender link', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to attach the sender link', function (testCallback) {
         fakeAmqpBase.attachSenderLink = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -330,12 +240,7 @@ describe('Amqp', function () {
       com.microsoft:api-version: <API_VERSION>
       com.microsoft:client-version: <CLIENT_VERSION>
       ```]*/
-      it('attaches the receiver link', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('attaches the receiver link', function (testCallback) {
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function () {
           assert.isTrue(fakeAmqpBase.attachReceiverLink.calledOnce);
@@ -344,14 +249,8 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_020: [The `queryOperationStatus` method shall call its callback with an error if the transport fails to attach the receiver link.]*/
-      it('calls its callback with an error if it fails to attach the receiver link', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('calls its callback with an error if it fails to attach the receiver link', function (testCallback) {
         fakeAmqpBase.attachReceiverLink = sinon.stub().callsArgWith(2, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -365,18 +264,7 @@ describe('Amqp', function () {
       iotdps-operation-type: iotdps-get-operationstatus;
       iotdps-operation-id: <operationId>;
       ```]*/
-      it('sends a properly formatted message', function (testCallback) {
-        var fakeRequest = {
-          idScope: 'fakeScope',
-          registrationId: 'fakeRegistrationId',
-          forceRegistration: false
-        };
-        var fakeOperationId = 'fakeOpId';
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      it ('sends a properly formatted message', function (testCallback) {
 
         amqp.queryOperationStatus(fakeRequest, fakeOperationId, function (err) {
           assert.isTrue(fakeSenderLink.send.calledOnce);
@@ -389,39 +277,21 @@ describe('Amqp', function () {
       });
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_021: [The `queryOperationStatus` method shall call its callback with an error if the transport fails to send the request message.]*/
-      it('calls its callback with an error if sending the message fails', function (testCallback) {
-        var fakeRequest = {
-          idScope: 'fakeScope',
-          registrationId: 'fakeRegistrationId',
-          forceRegistration: false
-        };
-        var fakeOperationId = 'fakeOpId';
-        var fakeError = new Error('fake');
+      it ('calls its callback with an error if sending the message fails', function (testCallback) {
         fakeSenderLink.send = sinon.stub().callsArgWith(1, fakeError);
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.queryOperationStatus(fakeRequest, fakeOperationId, function (err) {
           assert.isTrue(fakeSenderLink.send.calledOnce);
           assert.strictEqual(err, fakeError);
           testCallback();
         });
-      })
+      });
     });
 
     describe('amqpError', function () {
-      it('forces link detach and disconnects the connection', function (testCallback) {
-        var fakeError = new Error('fake error');
+      it ('forces link detach and disconnects the connection', function (testCallback) {
         fakeSenderLink.send = sinon.stub().callsFake(function () {
-          fakeSenderLink.emit('error', fakeError);
-        });
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
+          fakeSenderLink.emit ('error', fakeError);
         });
         amqp.on('error', function (err) {
           assert.strictEqual(err, fakeError);
@@ -435,33 +305,23 @@ describe('Amqp', function () {
       });
     });
 
-    describe('cancel', function () {
+    describe('disconnect', function () {
 
-      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_022: [`cancel` shall call its callback immediately if the AMQP connection is disconnected.]*/
-      it('calls its callback immediately if disconnected', function (testCallback) {
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_022: [`disconnect` shall call its callback immediately if the AMQP connection is disconnected.]*/
+      it ('calls its callback immediately if disconnected', function (testCallback) {
 
-        amqp.cancel(function () {
+        amqp.disconnect(function () {
           assert.isTrue(fakeAmqpBase.connect.notCalled);
           testCallback();
         });
       });
 
-      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`cancel` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
-      it('detaches the links if they are attached and disconnects the connection', function (testCallback) {
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`disconnect` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
+      it ('detaches the links if they are attached and disconnects the connection', function (testCallback) {
         fakeSenderLink.send = sinon.stub(); // will block while sending the request
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {});
-        amqp.cancel(function () {
+        amqp.disconnect(function () {
           assert.isTrue(fakeAmqpBase.disconnect.calledOnce);
           assert.isTrue(fakeReceiverLink.detach.calledOnce);
           assert.isTrue(fakeSenderLink.detach.calledOnce);
@@ -470,38 +330,121 @@ describe('Amqp', function () {
         });
       });
 
-      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`cancel` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
-      it('disconnects the connection if called while attaching the receiver link', function (testCallback) {
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`disconnect` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
+      it ('disconnects the connection if called while attaching the receiver link', function (testCallback) {
         fakeAmqpBase.attachReceiverLink = sinon.stub(); // will block while in the 'connecting' state since the callback won't be called.
-        var amqp = new Amqp(fakeAmqpBase);
         amqp.setAuthentication({
           cert: 'fakeCert',
           key: 'fakeKey'
         });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {});
-        amqp.cancel(function () {
+        amqp.disconnect(function () {
           assert.isTrue(fakeAmqpBase.disconnect.calledOnce);
           testCallback();
         });
       });
 
-      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`cancel` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
-      it('detaches the receiver and disconnects the connection if called while attaching the sender link', function (testCallback) {
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_16_023: [`disconnect` shall detach the sender and receiver links and disconnect the AMQP connection.]*/
+      it ('detaches the receiver and disconnects the connection if called while attaching the sender link', function (testCallback) {
         fakeAmqpBase.attachSenderLink = sinon.stub(); // will block while in the 'connecting' state since the callback won't be called.
-        var amqp = new Amqp(fakeAmqpBase);
-        amqp.setAuthentication({
-          cert: 'fakeCert',
-          key: 'fakeKey'
-        });
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {});
-        amqp.cancel(function () {
+        amqp.disconnect(function () {
           assert.isTrue(fakeAmqpBase.disconnect.calledOnce);
           assert.isTrue(fakeReceiverLink.detach.calledOnce);
           testCallback();
         });
       });
+
+      [
+        registrationRequest,
+        queryOperationStatus
+      ].forEach(function(op) {
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_002: [ `disconnect` shall cause a `queryOperationStatus` operation that is in progress to call its callback passing an `OperationCancelledError` object. ] */
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_001: [ `disconnect` shall cause a `registrationRequest` operation that is in progress to call its callback passing an `OperationCancelledError` object. ] */
+        it ('cancels ' + op.name + ' when called', function(testCallback) {
+          fakeSenderLink.send = sinon.stub();
+
+          op.invoke(function (err) {
+            assert.instanceOf(err, errors.OperationCancelledError);
+            assert.isTrue(fakeAmqpBase.disconnect.called);
+            testCallback();
+          });
+          amqp.disconnect(function() {});
+        });
+
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_009: [ `disconnect` shall disonnect the AMQP connection and cancel the operation that initiated a connection if called while the connection is in process. ] */
+        it ( 'disconnects and cancels ' + op.name + ' operation if called while connecting', function(testCallback) {
+          fakeAmqpBase.attachSenderLink = sinon.stub();
+
+          op.invoke(function (err) {
+            assert.instanceOf(err, errors.OperationCancelledError);
+            testCallback();
+          });
+          amqp.disconnect(function() {});
+        });
+      });
+
+
     });
+
+    describe('cancel', function () {
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_18_003: [ `cancel` shall call its callback immediately if the AMQP connection is disconnected. ] */
+      it ('calls its callback immediately if disconnected', function (testCallback) {
+
+        amqp.cancel(function () {
+          assert.isTrue(fakeAmqpBase.connect.notCalled);
+          testCallback();
+        });
+      });
+
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_18_004: [ `cancel` shall call its callback immediately if the AMQP connection is connected but idle. ] */
+      it ( 'calls its callback immediately if idle', function(testCallback) {
+
+        amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
+          assert.isNotOk(err);
+          assert.isTrue(fakeAmqpBase.connect.calledOnce);
+          assert.isFalse(fakeAmqpBase.disconnect.called);
+
+          amqp.cancel(function(err) {
+            assert.isNotOk(err);
+            testCallback();
+          });
+        });
+      });
+
+      [
+        registrationRequest,
+        queryOperationStatus
+      ].forEach(function(op) {
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_005: [ `cancel` shall disconnect the AMQP connection and cancel the operation that initiated a connection if called while the connection is in process. ] */
+        it ( 'disconnects and cancels ' + op.name + ' operation if called while connecting', function(testCallback) {
+          fakeAmqpBase.attachSenderLink = sinon.stub();
+
+          op.invoke(function (err) {
+            assert.instanceOf(err, errors.OperationCancelledError);
+            testCallback();
+          });
+          amqp.cancel(function() {});
+        });
+
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_007: [ `cancel` shall cause a `queryOperationStatus` operation that is in progress to call its callback passing an `OperationCancelledError` object. ] */
+        /*Tests_SRS_NODE_PROVISIONING_AMQP_18_006: [ `cancel` shall cause a `registrationRequest` operation that is in progress to call its callback passing an `OperationCancelledError` object. ] */
+        it ('cancels ' + op.name + ' when called', function(testCallback) {
+          fakeSenderLink.send = sinon.stub();
+
+          op.invoke(function (err) {
+            assert.instanceOf(err, errors.OperationCancelledError);
+            /*Tests_SRS_NODE_PROVISIONING_AMQP_18_008: [ `cancel` shall not disconnect the AMQP transport. ] */
+            assert.isFalse(fakeAmqpBase.disconnect.called);
+            testCallback();
+          });
+          amqp.cancel(function() {});
+        });
+      });
+    });
+
   });
 });
+

--- a/provisioning/transport/http/devdoc/http_requirements.md
+++ b/provisioning/transport/http/devdoc/http_requirements.md
@@ -10,81 +10,64 @@ This module provides HTTP protocol support to communicate with the Azure device 
 
 ## Public Interface
 
-### constructor(idScope: number, httpBase?: Base)
+### constructor(httpBase?: Base)
 The `constructor` creates an Http transport object used to communicate with the Azure device provisioning service
 
 **SRS_NODE_PROVISIONING_HTTP_18_001: [** The `Http` constructor shall accept the following properties:
-  - `idScope` - the ID Scope value for the provisioning service
   - `httpBase` - an optional test implementation of azure-iot-http-base **]**
 
 
-### register(auth: string | X509, forceRegistration: boolean, body: any, callback: DeviceProvisioningTransport.ResponseCallback): void;
-`register` calls into the service to register the given device with the provisioning service.
+### registrationRequest(request: RegistrationRequest, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void;
 
-**SRS_NODE_PROVISIONING_HTTP_18_036: [** `register` shall call the `callback` with an `InvalidOperationError` if it is called while a previous registration is in progress. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_005: [** `registrationRequest` shall include the current `api-version` as a URL query string value named 'api-version'. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_005: [** The registration request shall include the current `api-version` as a URL query string value named 'api-version'. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_006: [** The registration request shall specify the following in the Http header:
+**SRS_NODE_PROVISIONING_HTTP_18_006: [** `registrationRequest` shall specify the following in the Http header:
   Accept: application/json
   Content-Type: application/json; charset=utf-8 **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_007: [** If an `auth` string is specifed, it shall be URL encoded and included in the Http Authorization header. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_007: [** If an X509 cert if provided, `registrationRequest` shall include it in the Http authorization header. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_008: [** If `forceRegistration` is specified, the registration request shall include this as a query string value named 'forceRegistration' **]**
+**SRS_NODE_PROVISIONING_HTTP_18_008: [** If `forceRegistration` is specified, `registrationRequest` shall include this as a query string value named 'forceRegistration' **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_009: [** `register` shall PUT the registration request to 'https://global.azure-devices-provisioning.net/{idScope}/registrations/{registrationId}/register' **]**
+**SRS_NODE_PROVISIONING_HTTP_18_009: [** `registrationRequest` shall PUT the registration request to 'https://{provisioningHost}/{idScope}/registrations/{registrationId}/register' **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_011: [** If the registration request times out, `register` shall call the `callback` with with the lower level error **]**
+**SRS_NODE_PROVISIONING_HTTP_18_014: [** If the Http response has a failed status code, `registrationRequest` shall use `translateError` to translate this to a common error object **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_012: [** If the registration response contains a body, `register` shall deserialize this into an object. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_044: [** If the Http request fails for any reason, `registrationRequest` shall call `callback`, passing the error along with the `result` and `response` objects. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_013: [** If registration response body fails to deserialize, `register` will throw an `InternalServerError` error. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_045: [** If the Http request succeeds, `registrationRequest` shall call `callback`, passing a `null` error along with the `result` and `response` objects. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_014: [** If the registration response has a failed status code, `register` shall use `translateError` to translate this to a common error object and pass this into the `callback` function along with the deserialized body of the response. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_043: [** If `cancel` is called while the registration request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_015: [** If the registration response has a success code with a 'status' of 'Assigned', `register` call the `callback` with `err` == `null` and result `containing` the deserialized body **]**
+### queryOperationStatus(request: RegistrationRequest, operationId: string, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void;
 
-**SRS_NODE_PROVISIONING_HTTP_18_016: [** If the registration response has a success code with a 'status' of 'Assigning', `register` shall fire an `operationStatus` event with the deserialized body **]**
+**SRS_NODE_PROVISIONING_HTTP_18_037: [** `queryOperationStatus` shall include the current `api-version` as a URL query string value named 'api-version'. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_017: [** If the registration response has a success code with a 'status' of 'Assigning', `register` shall start polling for operation updates **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_029: [** If the registration response has a success code with a 'status' that is any other value', `register` shall call the callback with a `SyntaxError` error. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_018: [** `register` shall poll for operation status every `operationStatusPollingInterval` milliseconds **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_037: [** The operation status request shall include the current `api-version` as a URL query string value named 'api-version'. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_020: [** The operation status request shall have the following in the Http header:
+**SRS_NODE_PROVISIONING_HTTP_18_020: [** `queryOperationStatus` shall specify the following in the Http header:
   Accept: application/json
   Content-Type: application/json; charset=utf-8 **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_021: [** If an `auth` string is specifed, it shall be URL encoded and included in the Http Authorization header of the operation status request. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_021: [** If an X509 cert if provided, `queryOperationStatus` shall include it in the Http authorization header. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_022: [** operation status request polling shall be a GET operation sent to 'https://global.azure-devices-provisioning.net/{idScope}/registrations/{registrationId}/operations/{operationId}' **]**
+**SRS_NODE_PROVISIONING_HTTP_18_022: [** `queryOperationStatus` shall send a GET operation sent to 'https://{provisioningHost}/{idScope}/registrations/{registrationId}/operations/{operationId}' **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_023: [** If the operation status request times out, `register` shall stop polling and call the `callback` with with the lower level error **]**
+**SRS_NODE_PROVISIONING_HTTP_18_026: [** If the Http response has a failed status code, `queryOperationStatus` shall use `translateError` to translate this to a common error object **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_024: [** `register` shall deserialize the body of the operation status response into an object. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_038: [** If the Http request fails for any reason, `queryOperationStatus` shall call `callback`, passing the error along with the `result` and `response` objects. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_025: [** If the body of the operation status response fails to deserialize, `register` will throw a `SyntaxError` error. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_039: [** If the Http request succeeds, `queryOperationStatus` shall call `callback`, passing a `null` error along with the `result` and `response` objects. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_026: [** If the operation status response contains a failure status code, `register` shall stop polling and call the `callback` with an error created using `translateError`. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_027: [** If the operation status response contains a success status code with a 'status' of 'Assigned', `register` shall stop polling and call the `callback` with `err` == null and the body containing the deserialized body. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_028: [** If the operation status response contains a success status code with a 'status' that is 'Assigning', `register` shall fire an `operationStatus` event with the deserialized body and continue polling. **]**
-
-**SRS_NODE_PROVISIONING_HTTP_18_030: [** If the operation status response has a success code with a 'status' that is any other value, `register` shall call the callback with a `SyntaxError` error and stop polling. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_042: [** If `cancel` is called while the operation status request is in progress, `queryOperationStatus` shall call the `callback` with an `OperationCancelledError` error. **]**
 
 
-### disconnect(callback: (err?: Error) => void): void;}
+### disconnect(callback: (err?: Error) => void): void;
 
-**SRS_NODE_PROVISIONING_HTTP_18_035: [** disconnect will cause polling to cease **]**
+**SRS_NODE_PROVISIONING_HTTP_18_040: [** `disconnect` shall immediately call `callback` passing null. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_031: [** If `disconnect` is called while the registration request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. **]**
 
-**SRS_NODE_PROVISIONING_HTTP_18_032: [** If `disconnect` is called while the operation status request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. **]**
+### cancel(callback: (err?: Error) => void): void;
 
-**SRS_NODE_PROVISIONING_HTTP_18_033: [** If `disconnect` is called while the register is waiting between polls, `register` shall call the `callback` with an `OperationCancelledError` error. **]**
+**SRS_NODE_PROVISIONING_HTTP_18_041: [** `cancel` shall immediately call `callback` passing null. **]**
+
+
 

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -32,7 +32,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 91 --branches 66 --functions 86 --lines 94 "
+    "check-cover": "istanbul check-coverage --statements 90 --branches 58 --functions 81 --lines 92"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/transport/http/src/http.ts
+++ b/provisioning/transport/http/src/http.ts
@@ -31,13 +31,11 @@ export class Http extends EventEmitter implements X509ProvisioningTransport {
    * @private
    */
   /* Codes_SRS_NODE_PROVISIONING_HTTP_18_001: [ The `Http` constructor shall accept the following properties:
-  - `idScope` - the ID Scope value for the provisioning service
   - `httpBase` - an optional test implementation of azure-iot-http-base ] */
   constructor(httpBase?: Base) {
     super();
     this._httpBase = httpBase || new Base();
     this._config.pollingInterval = ProvisioningDeviceConstants.defaultPollingInterval;
-    this._config.timeoutInterval = ProvisioningDeviceConstants.defaultTimeoutInterval;
   }
 
   setAuthentication(auth: X509): void {
@@ -50,8 +48,7 @@ export class Http extends EventEmitter implements X509ProvisioningTransport {
    */
   setTransportOptions(options: ProvisioningTransportOptions): void {
     [
-      'pollingInterval',
-      'timeoutInterval'
+      'pollingInterval'
     ].forEach((optionName) => {
       if (options.hasOwnProperty(optionName)) {
         this._config[optionName] = options[optionName];
@@ -63,7 +60,13 @@ export class Http extends EventEmitter implements X509ProvisioningTransport {
    * private
    */
   cancel(callback: (err?: Error) => void): void {
-    // Nothing to do.
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_041: [ `cancel` shall immediately call `callback` passing null. ] */
+    callback();
+  }
+
+  disconnect(callback: (err?: Error) => void): void {
+    // nothing to do
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_040: [ `disconnect` shall immediately call `callback` passing null. ] */
     callback();
   }
 
@@ -72,41 +75,43 @@ export class Http extends EventEmitter implements X509ProvisioningTransport {
    */
   registrationRequest(request: RegistrationRequest, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void {
 
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_007: [ If an X509 cert if provided, `registrationRequest` shall include it in the Http authorization header. ] */
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_021: [ If an X509 cert if provided, `queryOperationStatus` shall include it in the Http authorization header. ] */
     this._restApiClient = new RestApiClient({ 'host' : request.provisioningHost , 'x509' : this._auth}, ProvisioningDeviceConstants.userAgent, this._httpBase);
 
     let requestBody: any = { registrationId : request.registrationId };
 
-    /* update Codes_SRS_NODE_PROVISIONING_HTTP_18_009: [ `register` shall PUT the registration request to 'https://global.azure-devices-provisioning.net/{idScope}/registrations/{registrationId}/register' ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_005: [ The registration request shall include the current `api-version` as a URL query string value named 'api-version'. ] */
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_005: [ `registrationRequest` shall include the current `api-version` as a URL query string value named 'api-version'. ] */
     let path: string = '/' + request.idScope + '/registrations/' + request.registrationId + '/register?api-version=' + ProvisioningDeviceConstants.apiVersion;
 
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_008: [ If `forceRegistration` is specified, the registration request shall include this as a query string value named 'forceRegistration' ] */
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_008: [ If `forceRegistration` is specified, `registrationRequest` shall include this as a query string value named 'forceRegistration' ] */
     if (request.forceRegistration) {
       path += '&forceRegistration=true';
     }
 
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_006: [ The registration request shall specify the following in the Http header:
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_006: [ `registrationRequest` shall specify the following in the Http header:
       Accept: application/json
       Content-Type: application/json; charset=utf-8 ] */
     let httpHeaders = JSON.parse(JSON.stringify(_defaultHeaders));
 
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_007: [ If an `auth` string is specifed, it shall be URL encoded and included in the Http Authorization header. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_011: [ If the registration request times out, `register` shall call the `callback` with the lower level error] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_012: [ If the registration response contains a body, `register` shall deserialize this into an object. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_013: [ If registration response body fails to deserialize, `register` will throw an `SyntaxError` error. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_014: [ If the registration response has a failed status code, `register` shall use `translateError` to translate this to a common error object and pass this into the `callback` function along with the deserialized body of the response. ] */
     debug('submitting PUT for ' + request.registrationId + ' to ' + path);
     debug(JSON.stringify(requestBody));
-    this._restApiClient.executeApiCall('PUT', path, httpHeaders, requestBody, this._config.timeoutInterval, (err: Error, result?: any, response?: any) => {
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_009: [ `registrationRequest` shall PUT the registration request to 'https://{provisioningHost}/{idScope}/registrations/{registrationId}/register' ] */
+    this._restApiClient.executeApiCall('PUT', path, httpHeaders, requestBody, (err: Error, result?: any, response?: any) => {
       if (err) {
+        /* Codes_SRS_NODE_PROVISIONING_HTTP_18_044: [ If the Http request fails for any reason, `registrationRequest` shall call `callback`, passing the error along with the `result` and `response` objects. ] */
+        /* Codes_SRS_NODE_PROVISIONING_HTTP_18_043: [ If `cancel` is called while the registration request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. ] */
         debug('error executing PUT: ' + err.toString());
         callback(err, result, response);
       } else {
         debug('PUT response received:');
         debug(JSON.stringify(result));
         if (response.statusCode < 300) {
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_045: [ If the Http request succeeds, `registrationRequest` shall call `callback`, passing a `null` error along with the `result` and `response` objects. ] */
           callback(null, result, response, this._config.pollingInterval);
         } else {
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_014: [ If the Http response has a failed status code, `registrationRequest` shall use `translateError` to translate this to a common error object ] */
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_044: [ If the Http request fails for any reason, `registrationRequest` shall call `callback`, passing the error along with the `result` and `response` objects. ] */
           callback(translateError('PUT operation returned failure', response.statusCode, result, response));
         }
       }
@@ -117,52 +122,35 @@ export class Http extends EventEmitter implements X509ProvisioningTransport {
    * private
    */
   queryOperationStatus(request: RegistrationRequest, operationId: string, callback: (err?: Error, result?: DeviceRegistrationResult, response?: any, pollingInterval?: number) => void): void {
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_022: [ operation status request polling shall be a GET operation sent to 'https://global.azure-devices-provisioning.net/{idScope}/registrations/{registrationId}/operations/{operationId}' ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_037: [ The operation status request shall include the current `api-version` as a URL query string value named 'api-version'. ] */
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_037: [ `queryOperationStatus` shall include the current `api-version` as a URL query string value named 'api-version'. ] */
     let path: string = '/' + request.idScope + '/registrations/' + request.registrationId + '/operations/' + operationId + '?api-version=' + ProvisioningDeviceConstants.apiVersion;
 
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_020: [ The operation status request shall have the following in the Http header:
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_020: [ `queryOperationStatus` shall specify the following in the Http header:
       Accept: application/json
       Content-Type: application/json; charset=utf-8 ] */
     let httpHeaders = JSON.parse(JSON.stringify(_defaultHeaders));
 
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_021: [ If an `auth` string is specifed, it shall be URL encoded and included in the Http Authorization header of the operation status request. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_023: [ If the operation status request times out, `register` shall stop polling and call the `callback` with with the lower level error ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_024: [ `register` shall deserialize the body of the operation status response into an object. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_025: [ If the body of the operation status response fails to deserialize, `register` will throw a `SyntaxError` error. ] */
-    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_026: [ If the operation status response contains a failure status code, `register` shall stop polling and call the `callback` with an error created using `translateError`. ] */
+    /* Codes_SRS_NODE_PROVISIONING_HTTP_18_022: [ `queryOperationStatus` shall send a GET operation sent to 'https://{provisioningHost}/{idScope}/registrations/{registrationId}/operations/{operationId}'  ] */
     debug('submitting status GET for ' + request.registrationId + ' to ' + path);
-    this._restApiClient.executeApiCall('GET', path, httpHeaders, {}, this._config.timeoutInterval, (err: Error, result?: any, response?: any) => {
+    this._restApiClient.executeApiCall('GET', path, httpHeaders, {}, (err: Error, result?: any, response?: any) => {
       if (err) {
+        /* Codes_SRS_NODE_PROVISIONING_HTTP_18_038: [ If the Http request fails for any reason, `queryOperationStatus` shall call `callback`, passing the error along with the `result` and `response` objects. ] */
+        /* Codes_SRS_NODE_PROVISIONING_HTTP_18_042: [ If `cancel` is called while the operation status request is in progress, `queryOperationStatus` shall call the `callback` with an `OperationCancelledError` error. ] */
         debug('error executing GET: ' + err.toString());
         callback(err, result, response);
       } else {
         debug('GET response received:');
         debug(JSON.stringify(result));
         if (response.statusCode < 300) {
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_039: [ If the Http request succeeds, `queryOperationStatus` shall call `callback`, passing a `null` error along with the `result` and `response` objects. ] */
           callback(null, result, response, this._config.pollingInterval);
         } else {
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_026: [ If the Http response has a failed status code, `queryOperationStatus` shall use `translateError` to translate this to a common error object ] */
+          /* Codes_SRS_NODE_PROVISIONING_HTTP_18_038: [ If the Http request fails for any reason, `queryOperationStatus` shall call `callback`, passing the error along with the `result` and `response` objects. ] */
           callback(translateError('GET operation returned failure', response.statusCode, result, response));
         }
       }
     });
   }
 }
-// The following are legacy requirements.  The used to be handled by http.ts, but they've been moved into transport_state_machine.ts.
-// We're keeping these here mostly for the Http tests, which now overlap with the TransportStateMachine tests, but we're keeping
-// the tests here for the extra test coverage.
 
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_016: [ If the registration response has a success code with a 'status' of 'Assigning', `register` shall fire an `operationStatus` event with the deserialized body ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_017: [ If the registration response has a success code with a 'status' of 'Assigning', `register` shall start polling for operation updates ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_015: [ If the registration response has a success code with a 'status' of 'Assigned', `register` call the `callback` with `err` == `null` and result `containing` the deserialized body ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_029: [ If the registration response has a success code with a 'status' that is any other value', `register` shall call the callback with a `SyntaxError` error. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_036: [ `register` shall call the `callback` with an `InvalidOperationError` if it is called while a previous registration is in progress. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_018: [ `register` shall poll for operation status every `operationStatusPollingInterval` milliseconds ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_036: [ `register` shall call the `callback` with an `InvalidOperationError` if it is called while a previous registration is in progress. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_028: [ If the operation status response contains a success status code with a 'status' that is 'Assigning', `register` shall fire an `operationStatus` event with the deserialized body and continue polling. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_027: [ If the operation status response contains a success status code with a 'status' of 'Assigned', `register` shall stop polling and call the `callback` with `err` == null and the body containing the deserialized body. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_030: [ If the operation status response has a success code with a 'status' that is any other value, `register` shall call the callback with a `SyntaxError` error and stop polling. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_036: [ `register` shall call the `callback` with an `InvalidOperationError` if it is called while a previous registration is in progress. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_035: [ disconnect will cause polling to cease ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_031: [ If `disconnect` is called while the registration request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. ] */
-/* Codes_SRS_NODE_PROVISIONING_HTTP_18_033: [ If `disconnect` is called while the register is waiting between polls, `register` shall call the `callback` with an `OperationCancelledError` error. ] */

--- a/provisioning/transport/http/test/_http_test.js
+++ b/provisioning/transport/http/test/_http_test.js
@@ -285,7 +285,7 @@ describe('Http', function () {
 
     });
 
-    /* Tests_SRS_NODE_PROVISIONING_HTTP_18_032: [ If `disconnect` is called while the operation status request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. ] */
+   /* Tests_SRS_NODE_PROVISIONING_HTTP_18_032: [ If `disconnect` is called while the operation status request is in progress, `register` shall call the `callback` with an `OperationCancelledError` error. ] */
     it('fails with cancel during operation status request', function(testCallback) {
       var fakeBase = {};
       var callbackCount = 0;
@@ -528,16 +528,6 @@ describe('Http', function () {
       var http = makeNewTransport(fakeBase);
       http.registerX509(fakeRegRequest, fakeAuth, function(err, result) {
         assert.instanceOf(err, SyntaxError);
-        testCallback();
-      });
-    });
-  });
-
-  describe('disconnect', function() {
-    it('does nothing if disconnect is called while disconnected', function(testCallback) {
-      var http = new Http(null);
-      http.cancel(function(err) {
-        assert.isTrue(!err);
         testCallback();
       });
     });

--- a/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
@@ -18,23 +18,11 @@ These methods are used by the other objects of the SDK but are not public API fo
 
 **SRS_NODE_PROVISIONING_MQTT_18_004: [** If the publish fails, `registrationRequest` shall call `callback` passing in the error. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_005: [** If the publish fails, `registrationRequest` shall disconnect the transport. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_006: [** `registrationRequest` shall wait for a response with a matching rid. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_007: [** `registrationRequest` shall wait for a response for `timeoutInterval` milliseconds.  After that shall be considered a timeout. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_008: [** When `registrationRequest` times out, it shall disconnect the transport. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_009: [** When `registrationRequest` times out, it shall call `callback` passing in a TimeoutError. **]**
-
 **SRS_NODE_PROVISIONING_MQTT_18_010: [** When waiting for responses, `registrationRequest` shall watch for messages with a topic named $dps/registrations/res/<status>/?$rid=<rid>. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_012: [** If `registrationRequest` receives a response with status >= 300, it shall consider the request failed and create an error using `translateError`. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_013: [** When `registrationRequest` receives a successful response from the service, it shall call `callback` passing in null and the response. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_014: [** When `registrationRequest` receives an error from the service, it shall disconnect the transport. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_015: [** When `registrationRequest` receives an error from the service, it shall call `callback` passing in the error. **]**
 
@@ -47,38 +35,39 @@ These methods are used by the other objects of the SDK but are not public API fo
 
 **SRS_NODE_PROVISIONING_MQTT_18_018: [** If the publish fails, `queryOperationStatus` shall call `callback` passing the error. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_019: [** If the publish fails, `queryOperationStatus` shall disconnect the transport. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_020: [** `queryOperationStatus` shall wait for a response with a matching rid. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_021: [** `queryOperationStatus` shall wait for a response for `timeoutInterval` milliseconds.  After that shall be considered a timeout. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_022: [** When `queryOperationStatus` times out, it shall disconnect the transport. **]**
-
-**SRS_NODE_PROVISIONING_MQTT_18_023: [** When `queryOperationStatus` times out, it shall call `callback` passing in a TimeoutError. **]**
-
 **SRS_NODE_PROVISIONING_MQTT_18_024: [** When waiting for responses, `queryOperationStatus` shall watch for messages with a topic named $dps/registrations/res/<status>/?$rid=<rid>. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_026: [** If `queryOperationStatus` receives a response with status >= 300, it shall consider the query failed and create an error using `translateError`. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_027: [** When `queryOperationStatus` receives a successful response from the service, it shall call `callback` passing in null and the response. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_028: [** When `queryOperationStatus` receives an error from the service, it shall disconnect the transport. **]**
-
 **SRS_NODE_PROVISIONING_MQTT_18_029: [** When `queryOperationStatus` receives an error from the service, it shall call `callback` passing in the error. **]**
 
 
 ## cancel(callback: (err?: Error) => void): void
 
-**SRS_NODE_PROVISIONING_MQTT_18_030: [** If `cancel` is called while the transport is disconnected, `mqtt` will call `callback` immediately. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_030: [** If `cancel` is called while the transport is disconnected, it will call `callback` immediately. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_031: [** If `cancel` is called while the transport is in the process of connecting, it shall wait until the connection is complete and then disconnect the transport. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_062: [** If `cancel` is called while the transport is in the process of connecting, it shell disconnect transport and cancel the operation that initiated the connection. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_032: [** If `cancel` is called while the transport is connected and idle, it will disconnect the transport. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_032: [** If `cancel` is called while the transport is connected and idle, it will call `callback` immediately. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_033: [** If `cancel` is called while the transport is in the middle of a `registrationRequest` operation, it will disconnect the transport and indirectly cause `registrationRequest` call it's `callback` passing an error. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_033: [** If `cancel` is called while the transport is in the middle of a `registrationRequest` operation, it will stop listening for a response and cause `registrationRequest` call it's `callback` passing an `OperationCancelledError` error. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_034: [** If `cancel` is called while the transport is in the middle of a `queryOperationStatus` operation, it will disconnect the transport and indirectly cause `registrationRequest` call it's `callback` passing an error. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_034: [** If `cancel` is called while the transport is in the middle of a `queryOperationStatus` operation, it will stop listening for a response and cause `registrationRequest` call it's `callback` passing an `OperationCancelledError` error. **]**
+
+
+## disconnect(callback: (err?: Error) => void): void
+
+**SRS_NODE_PROVISIONING_MQTT_18_052: [** If `disconnect` is called while the transport is disconnected, it will call `callback` immediately. **]**
+
+**SRS_NODE_PROVISIONING_MQTT_18_061: [** If `disconnect` is called while the transport is in the process of connecting, it shell disconnect connection and cancel the operation that initiated the connection. **]**
+
+**SRS_NODE_PROVISIONING_MQTT_18_054: [** If `disconnect` is called while the transport is connected and idle, it shall disconnect. **]**
+
+**SRS_NODE_PROVISIONING_MQTT_18_055: [** If `disconnect` is called while the transport is in the middle of a `registrationRequest` operation, it shall cancel the `registrationRequest` operation and disconnect the transport. **]**
+
+**SRS_NODE_PROVISIONING_MQTT_18_056: [** If `disconnect` is called while the transport is in the middle of a `queryOperationStatus` operation, it shall cancel the `queryOperationStatus` operation and disconnect the transport. **]**
 
 
 ## transport connection
@@ -114,6 +103,9 @@ These requirements apply whenever the transport is disonnected.
 
 **SRS_NODE_PROVISIONING_MQTT_18_048: [** If either `_mqttBase.unsubscribe` or `_mqttBase.disconnect` fails, `Mqtt` shall call the disconnect `callback` with the failing error, giving preference to the disconnect error. **]**
 
+**SRS_NODE_PROVISIONING_MQTT_18_051: [** If either `_mqttBase.connect` or `_mqttBase.subscribe` fails, `mqtt` will disconnect the transport. **]**
+
 ## Websockets operation
 
 **SRS_NODE_PROVISIONING_MQTT_18_049: [** When connecting using websockets, `Mqtt`Ws shall set the uri passed into the transport to 'wss://<host>:443/$iothub/websocket'. **]**
+

--- a/provisioning/transport/mqtt/package.json
+++ b/provisioning/transport/mqtt/package.json
@@ -33,7 +33,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 91 --branches 76 --functions 83 --lines 93"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 74 --functions 89 --lines 94"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
This is preparing to implement a proper timeout mechanism that behaves the same way regardless of transport.  This will also lay some groundwork for retry.

This PR has the following:
1. Timeout handling was removed from HTTP and MQTT transports.  HTTP was relying on lower-layer objects to do timeout, so I removed this.  MQTT had specific timeout code that needed to be removed.
1. I added an abort function to azure-iot-http-base.  This may not be strictly necessary, and I am re-thinking about this and may remove it.  This was necessary to support the cancel operation.  (other protocols just stop listening for responses on cancel, so HTTP could maybe do the same)
1. In the transports, I made cancel and disconnect into 2 different operations.  Cancel cancels the current operation but leaves the transport connected.  Disconnect disconnects the transport.
1. I updated transports so failures don't automatically disconnect the transport.  Deciding when to disconnect should be done at higher layers.
1. I updated the polling state machine to handle distinct cancel and disconnect operations.
1. In order to handle the cancel functions in the transports, I leverage the this._operations lookup.  In order for this to work, I needed to allocate the correlationId or rid at the very beginning of the operation.  This is necessary so we can properly cancel an operation while the transport is still connecting.  (This also allowed me to move the _deferredCancelInQueue lookahead in mqtt.ts, which makes me happy.)
1. I changed MQTT disconnect-while-connecting behavior to match AMQP.  If you try to disconnect or cancel while connecting, MQTT will now immediately cancel the connection.  (it used to wait for the connection to complete before disconnecting, which doesn't help us if the connection is _never_ going to complete.)
1. I updated the HTTP requirements to more closely match what the transport does.  They were previously written from a POV above the polling state machine.  Now they're written from the POV above the transport.  Tests still need to be updated to match these new requirements.
1. I added requirements and tests for all of the above.
