### PR TITLE
Fix #193: optional credentials argument in getDeviceCredentials callback

### DIFF
--- a/common/core/src/authentication_provider.ts
+++ b/common/core/src/authentication_provider.ts
@@ -23,5 +23,5 @@ export enum AuthenticationType {
  */
 export interface AuthenticationProvider {
   type: AuthenticationType;
-  getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void;
+  getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void;
 }

--- a/device/core/src/sak_authentication_provider.ts
+++ b/device/core/src/sak_authentication_provider.ts
@@ -53,7 +53,7 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
    *
    * @param callback function that will be called with either an error or a set of device credentials that can be used to authenticate with the IoT hub.
    */
-  getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void {
+  getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void {
     if (this._shouldRenewToken()) {
       this._renewToken();
     }

--- a/device/core/src/sas_authentication_provider.ts
+++ b/device/core/src/sas_authentication_provider.ts
@@ -35,7 +35,7 @@ export class SharedAccessSignatureAuthenticationProvider extends EventEmitter im
    *
    * @param callback function that will be called with either an error or a set of device credentials that can be used to authenticate with the IoT hub.
    */
-  getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void {
+  getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void {
     /*Codes_SRS_NODE_SAS_AUTHENTICATION_PROVIDER_16_002: [The `getDeviceCredentials` method shall call its callback with a `null` error parameter and the stored `credentials` object containing the current device credentials.]*/
     callback(null, this._credentials);
   }


### PR DESCRIPTION
# Description of the problem
credentials was declared as an optional argument in the implementation of the `X509AuthenticationProvider` but not in the `AuthenticationProvider` interface itself

# Description of the solution
Make the `credentials` argument optional everywhere (in case of error, no credentials are provided)
