### PR TITLE
Fix spelling and don't stringify errors

### DIFF
--- a/device/transport/amqp/src/amqp_twin_client.ts
+++ b/device/transport/amqp/src/amqp_twin_client.ts
@@ -89,7 +89,7 @@ export class AmqpTwinClient extends EventEmitter {
             this._fsm.transition('attaching');
           },
           handleErrorEmit: (err: Error) => {
-            debug('_handleError: error is: ' + JSON.stringify(err));
+            debug('_handleError: error is: ' + err);
             this.emit(AmqpTwinClient.errorEvent, translateError('received an error from the amqp transport: ', err));
           },
           handleLinkDetach: (detachObject: any) => {

--- a/provisioning/device/samples/register_x509.js
+++ b/provisioning/device/samples/register_x509.js
@@ -30,7 +30,7 @@ var deviceClient = ProvisioningDeviceClient.create(provisioningHost, idScope, tr
 // Register the device.  Do not force a re-registration.
 deviceClient.register(function(err, result) {
   if (err) {
-    console.log("error registering device: " + JSON.stringify(err));
+    console.log("error registering device: " + err);
   } else {
     console.log('registration succeeded');
     console.log('assigned hub=' + result.assignedHub);

--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -40,7 +40,7 @@ export interface RegistrationRequest {
   idScope: string;
 
   /**
-   * true to foce re-registration
+   * true to force re-registration
    */
   forceRegistration?: boolean;
 }
@@ -131,7 +131,7 @@ export interface X509SecurityClient {
   /**
    * retrieve the X509 certificate chain
    *
-   * @param callback called when the operation is copmlete
+   * @param callback called when the operation is complete
    */
   getCertificateChain(callback: (err?: Error, cert?: string) => void): void;
 

--- a/provisioning/service/readme.md
+++ b/provisioning/service/readme.md
@@ -42,7 +42,7 @@ var enrollment = {
 
 serviceClient.createOrUpdateIndividualEnrollment(enrollment, function(err, enrollmentResponse) {
   if (err) {
-    console.log('error creating the enrollment: ' + JSON.stringify(err));
+    console.log('error creating the enrollment: ' + err);
   } else {
     console.log("enrollment record returned: " + JSON.stringify(enrollmentResponse, null, 2))
   }


### PR DESCRIPTION
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
A couple of spelling errors were found.  In addition, I found a couple of stringify calls on error objects.  This can actually cause a circular reference fault from the json package.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Fixed the spelling and removed the call to stringify.