### PR TITLE
create new cert for each run of service E2E tests

### DIFF
--- a/provisioning/e2e/_provisioning_e2e.js
+++ b/provisioning/e2e/_provisioning_e2e.js
@@ -4,7 +4,6 @@
 'use strict';
 
 var async = require('async');
-var pem = require('pem');
 var uuid = require('uuid');
 var assert = require('chai').assert;
 var debug = require('debug')('azure-iot-provisioning-device-e2e');
@@ -17,6 +16,7 @@ var ProvisioningDeviceClient = require('azure-iot-provisioning-device').Provisio
 var ProvisioningServiceClient = require('azure-iot-provisioning-service').ProvisioningServiceClient;
 var X509Security = require('azure-iot-security-x509').X509Security;
 var Registry = require('azure-iothub').Registry;
+var certHelper = require('./cert_helper');
 
 var idScope = process.env.IOT_PROVISIONING_DEVICE_IDSCOPE;
 var provisioningConnectionString = process.env.IOT_PROVISIONING_SERVICE_CONNECTION_STRING;
@@ -28,86 +28,6 @@ var registry = Registry.fromConnectionString(registryConnectionString);
 
 var X509IndividualTransports = [ Http, Amqp, AmqpWs, Mqtt, MqttWs ];
 var X509GroupTransports = [ Http, Amqp, AmqpWs, Mqtt, MqttWs ];
-
-var createSelfSignedCert = function(registrationId, callback) {
-  var certOptions = {
-    commonName: registrationId,
-    selfSigned: true,
-    days: 10
-  };
-  pem.createCertificate(certOptions, function (err, result) {
-    if (err) {
-      callback(err);
-    } else {
-      var x509 = {
-        cert: result.certificate,
-        key: result.clientKey
-      };
-      callback(null, x509);
-    }
-  });
-};
-
-var createIntermediateCaCert = function(authorityName, parentCert, callback) {
-  var certOptions = {
-    commonName: authorityName,
-    serviceKey: parentCert.key,
-    serviceCertificate: parentCert.cert,
-    serial: Math.floor(Math.random() * 1000000000),
-    days: 1,
-    config: [
-      '[req]',
-      'req_extensions = v3_req',
-      'distinguished_name = req_distinguished_name',
-      'x509_extensions = v3_ca',
-      '[req_distinguished_name]',
-      'commonName = ' + authorityName,
-      '[v3_req]',
-      'basicConstraints = critical, CA:true'
-    ].join('\n')
-  };
-  pem.createCertificate(certOptions, function(err, cert) {
-    if (err) {
-      callback(err);
-    } else {
-      var x509 = {
-        key: cert.clientKey,
-        cert: cert.certificate
-      };
-      callback(null, x509);
-    }
-  });
-};
-
-var createDeviceCert = function(registrationId, parentCert, callback) {
-  var deviceCertOptions = {
-    commonName: registrationId,
-    serviceKey: parentCert.key,
-    serviceCertificate: parentCert.cert,
-    serial: Math.floor(Math.random() * 1000000000),
-    days: 1,
-    config: [
-      '[req]',
-      'req_extensions = v3_req',
-      'distinguished_name = req_distinguished_name',
-      '[req_distinguished_name]',
-      'commonName = ' + registrationId,
-      '[v3_req]',
-      'extendedKeyUsage = critical,clientAuth'
-    ].join('\n')
-  };
-  pem.createCertificate(deviceCertOptions, function(err, cert) {
-    if (err) {
-      callback(err);
-    } else {
-      var x509 = {
-        key: cert.clientKey,
-        cert: cert.certificate
-      };
-      callback(null, x509);
-    }
-  });
-};
 
 var X509Individual = function() {
 
@@ -121,7 +41,7 @@ var X509Individual = function() {
 
   this.initialize = function (callback) {
     debug('creating x509 cert');
-    createSelfSignedCert(this._registrationId, function(err, cert) {
+    certHelper.createSelfSignedCert(this._registrationId, function(err, cert) {
       if (err) {
         callback(err);
       } else {
@@ -197,7 +117,7 @@ var createCertWithoutChain = function(registrationId, callback) {
     key: new Buffer(process.env.IOT_PROVISIONING_ROOT_CERT_KEY,"base64").toString('ascii'),
   };
   debug('creating device cert');
-  createDeviceCert(registrationId, rootCert, function(err, cert) {
+  certHelper.createDeviceCert(registrationId, rootCert, function(err, cert) {
     callback(err, rootCert, cert);
   });
 };
@@ -208,17 +128,17 @@ var createCertWithChain = function(registrationId, callback) {
     key: new Buffer(process.env.IOT_PROVISIONING_ROOT_CERT_KEY,"base64").toString('ascii'),
   };
   debug('creating intermediate CA cert #1');
-  createIntermediateCaCert('Intermediate CA 1', rootCert, function(err, intermediateCert1) {
+  certHelper.createIntermediateCaCert('Intermediate CA 1', rootCert, function(err, intermediateCert1) {
     if (err) {
       callback(err);
     } else {
       debug('creating intermediate CA cert #2');
-      createIntermediateCaCert('Intermediate CA 2', intermediateCert1, function(err, intermediateCert2) {
+      certHelper.createIntermediateCaCert('Intermediate CA 2', intermediateCert1, function(err, intermediateCert2) {
         if (err) {
           callback(err);
         } else {
           debug('creating device cert');
-          createDeviceCert(registrationId, intermediateCert2, function(err, cert) {
+          certHelper.createDeviceCert(registrationId, intermediateCert2, function(err, cert) {
             if (err) {
               callback(err);
             } else {

--- a/provisioning/e2e/cert_helper.js
+++ b/provisioning/e2e/cert_helper.js
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var pem = require('pem');
+
+module.exports.createSelfSignedCert = function(registrationId, callback) {
+  var certOptions = {
+    commonName: registrationId,
+    selfSigned: true,
+    days: 10
+  };
+  pem.createCertificate(certOptions, function (err, result) {
+    if (err) {
+      callback(err);
+    } else {
+      var x509 = {
+        cert: result.certificate,
+        key: result.clientKey
+      };
+      callback(null, x509);
+    }
+  });
+};
+
+module.exports.createIntermediateCaCert = function(authorityName, parentCert, callback) {
+  var certOptions = {
+    commonName: authorityName,
+    serial: Math.floor(Math.random() * 1000000000),
+    days: 1,
+    config: [
+      '[req]',
+      'req_extensions = v3_req',
+      'distinguished_name = req_distinguished_name',
+      'x509_extensions = v3_ca',
+      '[req_distinguished_name]',
+      'commonName = ' + authorityName,
+      '[v3_req]',
+      'basicConstraints = critical, CA:true'
+    ].join('\n')
+  };
+  if (parentCert) {
+    certOptions.serviceKey = parentCert.key;
+    certOptions.serviceCertificate = parentCert.cert;
+  }
+  pem.createCertificate(certOptions, function(err, cert) {
+    if (err) {
+      callback(err);
+    } else {
+      var x509 = {
+        key: cert.clientKey,
+        cert: cert.certificate
+      };
+      callback(null, x509);
+    }
+  });
+};
+
+module.exports.createDeviceCert = function(registrationId, parentCert, callback) {
+  var deviceCertOptions = {
+    commonName: registrationId,
+    serviceKey: parentCert.key,
+    serviceCertificate: parentCert.cert,
+    serial: Math.floor(Math.random() * 1000000000),
+    days: 1,
+    config: [
+      '[req]',
+      'req_extensions = v3_req',
+      'distinguished_name = req_distinguished_name',
+      '[req_distinguished_name]',
+      'commonName = ' + registrationId,
+      '[v3_req]',
+      'extendedKeyUsage = critical,clientAuth'
+    ].join('\n')
+  };
+  pem.createCertificate(deviceCertOptions, function(err, cert) {
+    if (err) {
+      callback(err);
+    } else {
+      var x509 = {
+        key: cert.clientKey,
+        cert: cert.certificate
+      };
+      callback(null, x509);
+    }
+  });
+};
+

--- a/provisioning/transport/amqp/src/amqp.ts
+++ b/provisioning/transport/amqp/src/amqp.ts
@@ -8,7 +8,7 @@ import * as machina from 'machina';
 import * as dbg from 'debug';
 import * as uuid from 'uuid';
 import * as async from 'async';
-const debug = dbg('azure-device-provisioning-amqp:Amqp');
+const debug = dbg('azure-iot-provisioning-device-amqp:Amqp');
 
 import { X509, errors } from 'azure-iot-common';
 import { ProvisioningTransportOptions, X509ProvisioningTransport, RegistrationRequest, RegistrationResult, ProvisioningDeviceConstants } from 'azure-iot-provisioning-device';


### PR DESCRIPTION
I've hit some cases where the _service_create_delete.js tests would fail because a previous run left a group alive and there can't be 2 groups that use the same cert.  My fix is to create a new cert for each run. 