### PR TITLE
Sample takes parameters from the commandline now.

### DIFF
--- a/provisioning/device/samples/register_x509.js
+++ b/provisioning/device/samples/register_x509.js
@@ -1,26 +1,70 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-
 'use strict';
-
-var fs = require('fs');
-var Transport = require('azure-iot-provisioning-device-http').Http;
-
-// Feel free to change the preceding using statement to anyone of the following if you would like to try another protocol.
-// var Transport = require('azure-iot-provisioning-device-amqp').Amqp;
-// var Transport = require('azure-iot-provisioning-device-amqp').AmqpWs;
-// var Transport = require('azure-iot-provisioning-device-mqtt').Mqtt;
-// var Transport = require('azure-iot-provisioning-device-mqtt').MqttWs;
-
 var X509Security = require('azure-iot-security-x509').X509Security;
 var ProvisioningDeviceClient = require('azure-iot-provisioning-device').ProvisioningDeviceClient;
 
-var provisioningHost = '[provisioning host]';
-var idScope = '[id scope]';
-var registrationId = '[registration id]';
+var fs = require('fs');
+var argv = require('yargs')
+  .usage('Usage: $0  --idscope <ID SCOPE> --registrationid <REGISTRATION ID> --certificate <COMMONNAME> --protocol <PROTOCOL>')
+  .option('idscope', {
+    alias: 'i',
+    describe: 'The ID scope is assigned to a Device Provisioning Service',
+    type: 'string',
+    demandOption: true
+  })
+  .option('registrationid', {
+    alias: 'r',
+    describe: 'Used to uniquely identify a device in the Device Provisioning Servic',
+    type: 'string',
+    demandOption: true
+  })
+  .option('certificate', {
+    alias: 'c',
+    describe: 'Commonname of the certificate without extension. Expected filenames: commonName_cert.pem and commonName_key.pem ',
+    type: 'string',
+    demandOption: true
+  })
+  .option('protocol', {
+    alias: 'p',
+    describe: 'Transport protocol to be used.',
+    type: 'string',
+    choices: ['mqtt', 'mqttws', 'amqp', 'amqpws', 'http'],
+    demandOption: false
+  })
+  .argv;
+
+var idScope = argv.idscope;
+var registrationId = argv.registrationid;
+var protocol = argv.protocol;
+var provisioningHost = 'global.azure-devices-provisioning.net';
+var cert = argv.certificate + '_cert.pem'
+var key = argv.certificate + '_key.pem'
+
+switch (protocol) {
+  case 'amqp':
+    var Transport = require('azure-iot-provisioning-device-amqp').Amqp;
+    break;
+  case 'amqpws':
+    var Transport = require('azure-iot-provisioning-device-amqp').AmqpWs;
+    break;
+  case 'mqtt':
+    var Transport = require('azure-iot-provisioning-device-mqtt').Mqtt;
+    break;
+  case 'mqttws':
+    var Transport = require('azure-iot-provisioning-device-mqtt').MqttWs;
+    break;
+  case 'http':
+    var Transport = require('azure-iot-provisioning-device-http').Http;
+    break;
+  default:
+    var Transport = require('azure-iot-provisioning-device-http').Http;
+    protocol = 'http';
+}
+
 var deviceCert = {
-  cert: fs.readFileSync('[cert filename]').toString(),
-  key: fs.readFileSync('[key filename]').toString()
+  cert: fs.readFileSync(cert).toString(),
+  key: fs.readFileSync(key).toString()
 };
 
 var transport = new Transport();
@@ -28,7 +72,7 @@ var securityClient = new X509Security(registrationId, deviceCert);
 var deviceClient = ProvisioningDeviceClient.create(provisioningHost, idScope, transport, securityClient);
 
 // Register the device.  Do not force a re-registration.
-deviceClient.register(function(err, result) {
+deviceClient.register(function (err, result) {
   if (err) {
     console.log("error registering device: " + err);
   } else {
@@ -37,4 +81,3 @@ deviceClient.register(function(err, result) {
     console.log('deviceId=' + result.deviceId);
   }
 });
-


### PR DESCRIPTION
I've modified the device sample to take parameters from the commandline, instead of editing the file. 
A user doesn't need to edit register_x509.js to run the example. 

Second, the default protocol is http, but it's possible to change this from the commandline via the --protocol switch.

Thirds; I've made global.azure-devices-provisioning.net as the default provisioning host.

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
