### PR TITLE
prep work for TPM over AMQP

### DIFF
--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -30,7 +30,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 85 --branches 64 --functions 72 --lines 86"
+    "check-cover": "istanbul check-coverage --statements 84 --branches 63 --functions 73 --lines 85"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -173,8 +173,8 @@ export interface TpmRegistrationResult extends RegistrationResult {
  */
 export interface TpmProvisioningTransport extends PollingTransport {
   setTpmInformation(endorsementKey: Buffer, storageRootKey: Buffer): void;
-  setSasToken(sasToken: string): void;
   getAuthenticationChallenge(request: RegistrationRequest, callback: (err: Error, tpmChallenge?: Buffer) => void): void;
+  respondToAuthenticationChallenge(request: RegistrationRequest, sasToken: string, callback: (err?: Error) => void): void;
 }
 
 /**

--- a/provisioning/device/test/_tpm_registration_test.js
+++ b/provisioning/device/test/_tpm_registration_test.js
@@ -49,7 +49,7 @@ describe('TpmRegistration', function () {
       fakeProvisioningTransport = {
         getAuthenticationChallenge: sinon.stub().callsArgWith(1, null, fakeTpmChallenge),
         setTpmInformation: sinon.stub(),
-        setSasToken: sinon.stub(),
+        respondToAuthenticationChallenge: sinon.stub().callsArgWith(2, null),
         cancel: sinon.stub().callsArg(0)
       };
 
@@ -113,7 +113,7 @@ describe('TpmRegistration', function () {
         assert.strictEqual(authArg.registrationId, fakeRegistrationId);
 
         // TODO: SAS token format test could be improved (see SRS_NODE_DPS_TPM_REGISTRATION_16_005 and SRS_NODE_DPS_TPM_REGISTRATION_16_006)
-        assert.isString(fakeProvisioningTransport.setSasToken.firstCall.args[0]);
+        assert.isString(fakeProvisioningTransport.respondToAuthenticationChallenge.firstCall.args[1]);
         testCallback();
       });
     });
@@ -164,7 +164,8 @@ describe('TpmRegistration', function () {
     });
 
     [
-      { methodName: 'getAuthenticationChallenge', stub: sinon.stub().callsArgWith(1, new Error('failed')) }
+      { methodName: 'getAuthenticationChallenge', stub: sinon.stub().callsArgWith(1, new Error('failed')) },
+      { methodName: 'respondToAuthenticationChallenge', stub: sinon.stub().callsArgWith(2, new Error('failed')) }
    ].forEach(function (testConfig) {
      it('calls the register callback with an error if TpmProvisioningTransport.' + testConfig.methodName + ' fails', function (testCallback) {
        fakeProvisioningTransport[testConfig.methodName] = testConfig.stub;

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 94 --branches 81 --functions 88 --lines 95"
+    "check-cover": "istanbul check-coverage --statements 92 --branches 81 --functions 84 --lines 93"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/transport/http/src/http.ts
+++ b/provisioning/transport/http/src/http.ts
@@ -48,8 +48,9 @@ export class Http extends EventEmitter implements X509ProvisioningTransport, Tpm
    * @private
    *
    */
-  setSasToken(sasToken: string): void {
-    this._sasToken = sasToken;
+  respondToAuthenticationChallenge(request: RegistrationRequest, sasToken: string, callback: (err?: Error) => void): void {
+      this._sasToken = sasToken;
+      callback();
   }
 
   /**

--- a/provisioning/transport/http/test/_http_test.js
+++ b/provisioning/transport/http/test/_http_test.js
@@ -308,22 +308,24 @@ describe('Http', function() {
 
   describe('use sas token in request', function() {
     it('registrationRequest', function(callback) {
-      http.setSasToken('a fake SasToken');
-      http.registrationRequest(fakeRequest, function() {
-        var headers = fakeBase.buildRequest.firstCall.args[2];
-        assert.strictEqual(headers.Authorization, 'a fake SasToken', 'Invalid SasToken Used');
-        callback();
+      http.respondToAuthenticationChallenge(fakeRequest, 'a fake SasToken', function() {
+        http.registrationRequest(fakeRequest, function() {
+          var headers = fakeBase.buildRequest.firstCall.args[2];
+          assert.strictEqual(headers.Authorization, 'a fake SasToken', 'Invalid SasToken Used');
+          callback();
+        });
+        respond_tpm(null, fakeAssignedResponse, 200);
       });
-      respond_tpm(null, fakeAssignedResponse, 200);
     });
     it('queryOperationStatus', function(callback) {
-      http.setSasToken('a fake SasToken');
-      http.queryOperationStatus(fakeRequest, 'fakeOperationId', function() {
-        var headers = fakeBase.buildRequest.firstCall.args[2];
-        assert.strictEqual(headers.Authorization, 'a fake SasToken', 'Invalid SasToken Used');
-        callback();
+      http.respondToAuthenticationChallenge(fakeRequest, 'a fake SasToken', function() {
+        http.queryOperationStatus(fakeRequest, 'fakeOperationId', function() {
+          var headers = fakeBase.buildRequest.firstCall.args[2];
+          assert.strictEqual(headers.Authorization, 'a fake SasToken', 'Invalid SasToken Used');
+          callback();
+        });
+        respond_tpm(null, fakeAssignedResponse, 200);
       });
-      respond_tpm(null, fakeAssignedResponse, 200);
     });
   });
 


### PR DESCRIPTION
In the interest of smaller commits sooner, here is some prep work for TPM over AMQP:
1. I updated the TpmProvisioningTransport to more closely match the version that Tony has in his branch.
2. I changed setSasToken to respondToAuthenticationChallenge because this is a much more weighty operation in AMQP.  Responding to the auth challenge completes the connection, so it deserves it's own state and a callback.
3. I updated the TpmRegistration client to add a new state for responding to the auth challenge.
4. I updated the AMQP provisioning transport to separate connection from establishing links.  This is necessary because TPM uses a different connection flow, but the same link registration.  

My intention is to commit these to master ASAP.  Nothing is broken with these changes.