### PR TITLE
Update amqp10 version and disable auto-reestablishing  the session

### DIFF
--- a/common/transport/amqp/devdoc/amqp_requirements.md
+++ b/common/transport/amqp/devdoc/amqp_requirements.md
@@ -46,6 +46,11 @@ A Boolean indicating whether the client should automatically settle messages:
 - False if the caller intends to manually settle messages
 A string containing the version of the SDK used for telemetry purposes**]**
 
+**SRS_NODE_COMMON_AMQP_16_042: [** The Amqp constructor shall create a new `amqp10.Client` instance and configure it to:
+- not reconnect on failure
+- not reattach sender and receiver links on failure
+- not reestablish sessions on failure **]**
+
 ### connect(done)
 Establishes a connection using the AMQP protocol with the IoT Hub instance.
 

--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -8,7 +8,7 @@
   "typings": "index.d.ts",
   "dependencies": {
     "azure-iot-common": "1.3.0",
-    "amqp10": "3.5.3",
+    "amqp10": "^3.6.0",
     "amqp10-transport-ws": "^0.0.5",
     "async": "^2.5.0",
     "bluebird": "^3.5.0",

--- a/common/transport/amqp/src/amqp.ts
+++ b/common/transport/amqp/src/amqp.ts
@@ -48,7 +48,18 @@ export class Amqp {
     const autoSettleMode = autoSettleMessages ? amqp10.Constants.receiverSettleMode.autoSettle : amqp10.Constants.receiverSettleMode.settleOnDisposition;
     // node-amqp10 has an automatic reconnection/link re-attach feature that is enabled by default.
     // In our case we want to control the reconnection flow ourselves, so we need to disable it.
+
+    /*Codes_SRS_NODE_COMMON_AMQP_16_042: [The Amqp constructor shall create a new `amqp10.Client` instance and configure it to:
+    - not reconnect on failure
+    - not reattach sender and receiver links on failure
+    - not reestablish sessions on failure]*/
     this._amqp = new amqp10.Client(amqp10.Policy.merge(<any>{
+      session: {
+        reestablish: {
+          retries: 0,
+          forever: false
+        }
+      },
       senderLink: {
         attach: {
           properties: {

--- a/common/transport/amqp/test/_amqp_test.js
+++ b/common/transport/amqp/test/_amqp_test.js
@@ -14,11 +14,50 @@ var errors = require('azure-iot-common').errors;
 var Message = require('azure-iot-common').Message;
 var EventEmitter = require('events').EventEmitter;
 var uuid = require('uuid');
+var amqp10 = require('amqp10');
 
 var cbsReceiveEndpoint = '$cbs';
 var cbsSendEndpoint = '$cbs';
 
 describe('Amqp', function () {
+  /*Tests_SRS_NODE_COMMON_AMQP_16_042: [The Amqp constructor shall create a new `amqp10.Client` instance and configure it to:
+  - not reconnect on failure
+  - not reattach sender and receiver links on failure
+  - not reestablish sessions on failure]*/
+  describe('#policies', function () {
+    before(function () {
+      sinon.spy(amqp10, 'Client');
+    });
+
+    it('sets the session policy to not reestablish on failure', function () {
+      var amqp = new Amqp();
+      assert.isFalse(amqp10.Client.firstCall.args[0].session.reestablish.forever);
+      assert.strictEqual(amqp10.Client.firstCall.args[0].session.reestablish.retries, 0);
+    });
+
+    it('sets the sender link to not reattach on failure', function () {
+      var amqp = new Amqp();
+      assert.isFalse(amqp10.Client.firstCall.args[0].senderLink.reattach.forever);
+      assert.strictEqual(amqp10.Client.firstCall.args[0].senderLink.reattach.retries, 0);
+    });
+
+    it('sets the receiver link to not reattach on failure', function () {
+      var amqp = new Amqp();
+      assert.isFalse(amqp10.Client.firstCall.args[0].receiverLink.reattach.forever);
+      assert.strictEqual(amqp10.Client.firstCall.args[0].receiverLink.reattach.retries, 0);
+    });
+
+    it('sets the connection to not reconnect on failure', function () {
+      var amqp = new Amqp();
+      assert.isFalse(amqp10.Client.firstCall.args[0].reconnect.forever);
+      assert.strictEqual(amqp10.Client.firstCall.args[0].reconnect.retries, 0);
+    });
+
+    after(function () {
+      amqp10.Client.restore();
+    });
+  });
+
   describe('#connect', function () {
     /* Tests_SRS_NODE_COMMON_AMQP_06_002: [The connect method shall throw a ReferenceError if the uri parameter has not been supplied.] */
     [undefined, null, ''].forEach(function (badUri){


### PR DESCRIPTION
# Description of the problem
In order to support custom SASL we need to update to the new version of the amqp10 library.

# Description of the solution
- Update to amqp10 v3.6.0
- Disable the new feature that automatically reestablishes the session