### PR TITLE
Update SaslTpm object based on code review feedback

### DIFF
--- a/provisioning/transport/amqp/devdoc/sasl_tpm_requirements.md
+++ b/provisioning/transport/amqp/devdoc/sasl_tpm_requirements.md
@@ -6,13 +6,14 @@ The `SaslTpm` class provides TPM sasl functionality for the AMQP transport.
 
 These methods are used by the other objects of the SDK but are not public API for the SDK user to call.
 
-## constructor(hostName: string, init: Buffer, firstResponse: Buffer, getResponseFromChallenge: GetResponseFromChallenge);
+## constructor(idScope: string, registrationId: string, endorsementKey: Buffer, storageRootKey: Buffer, getSasToken: GetSasToken);
 
 **SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_001: [** The `SaslTpm` constructor shall accept the following parameters:
-  `hostName` - The hostName value to be returned when getInitFrame is called
-  `init` - The initial frame contents to be returned when getInitFrame is called
-  `firstResponse` - The response to return on the first call to getResponseFrame
-  `getResponseFromChallenge` - The callback to call when the challenge has been completed and the caller needs to formulate the response. **]**
+  `idScope` - the idScope for the provisioning service instance
+  `registrationId` - the registrationId for the device being registered
+  `endorsementKey` - the endorsement key which was acquired from the TPM
+  `storageRootKey` - the storage root key which was acquired from the TPM
+  `getSasToken` - The callback to call when the challenge has been completed and the caller needs to formulate the response. **]**
 
 
 ## getInitFrame(): Promise<any>;
@@ -23,7 +24,7 @@ These methods are used by the other objects of the SDK but are not public API fo
   `hostname` - the hostName **]**
 
 
-## getResponseFrame(challenge: any): Promise<Buffer>;
+## getResponseFrame(challenge: any): Promise<SaslResponseFrame>;
 
 **SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_003: [** If `getResponseFrame` is called with a 1 byte challenge, it shall resolve with the the initial response that was passed into the constructor. **]**
 

--- a/provisioning/transport/amqp/src/sasl_tpm.ts
+++ b/provisioning/transport/amqp/src/sasl_tpm.ts
@@ -8,8 +8,8 @@ import * as Promise from 'bluebird';
 import * as dbg from 'debug';
 const debug = dbg('azure-iot-provisioning-device-amqp:SaslTpm');
 
-export type ChallengeResponseCallback = (err: Error, response?: Buffer) => void;
-export type GetResponseFromChallenge = (challenge: Buffer, callback: ChallengeResponseCallback) => void;
+export type GetSasTokenCallback = (err: Error, sasToken?: string) => void;
+export type GetSasToken = (challenge: Buffer, callback: GetSasTokenCallback) => void;
 export type SaslResponseFrame = {
   response: Buffer
 };
@@ -17,24 +17,26 @@ export type SaslResponseFrame = {
 export class SaslTpm {
   public name: string = 'TPM';
 
-  private _init: Buffer;
-  private _firstResponse: Buffer;
-  private _getResponseFromChallenge: GetResponseFromChallenge;
+  private _getSasToken: GetSasToken;
   private _challengeKey: Builder;
-  private _hostname: string;
+  private _idScope: string;
+  private _registrationId: string;
+  private _endorsementKey: Buffer;
+  private _storageRootKey: Buffer;
 
   /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_001: [ The `SaslTpm` constructor shall accept the following parameters:
-    `hostName` - The hostName value to be returned when getInitFrame is called
-    `init` - The initial frame contents to be returned when getInitFrame is called
-    `firstResponse` - The response to return on the first call to getResponseFrame
-    `getResponseFromChallenge` - The callback to call when the challenge has been completed and the caller needs to formulate the response. ] */
-  constructor(hostName: string, init: Buffer, firstResponse: Buffer, getResponseFromChallenge: GetResponseFromChallenge) {
-    this._hostname = hostName;
-    this._init = init;
-    this._firstResponse = firstResponse;
-    this._getResponseFromChallenge = getResponseFromChallenge;
+    `idScope` - the idScope for the provisioning service instance
+    `registrationId` - the registrationId for the device being registered
+    `endorsementKey` - the endorsement key which was acquired from the TPM
+    `storageRootKey` - the storage root key which was acquired from the TPM
+    `getSasToken` - The callback to call when the challenge has been completed and the caller needs to formulate the response. ] */
+  constructor(idScope: string, registrationId: string, endorsementKey: Buffer, storageRootKey: Buffer, getSasToken: GetSasToken) {
+    this._idScope = idScope;
+    this._registrationId = registrationId;
+    this._endorsementKey = endorsementKey;
+    this._storageRootKey = storageRootKey;
+    this._getSasToken = getSasToken;
     this._challengeKey = new Builder();
-    this._hostname = hostName;
   }
 
   /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_002: [ `getInitFrame` shall return a promise that resolves to an object with the following members:
@@ -42,11 +44,20 @@ export class SaslTpm {
     `initialResponse` - The inital frame contents
     `hostname` - the hostName ] */
   getInitFrame(): Promise<any> {
+    let init: Buffer = new Builder()
+        .appendUInt8(0)
+        .appendString(this._idScope)
+        .appendUInt8(0)
+        .appendString(this._registrationId)
+        .appendUInt8(0)
+        .appendBuffer(this._endorsementKey)
+        .get();
+
     return new Promise((resolve: any) => {
       resolve({
         mechanism: this.name,
-        initialResponse: this._init,
-        hostname: this._hostname
+        initialResponse: init,
+        hostname: this._idScope + '/registrations/' + this._registrationId
       });
     });
   }
@@ -55,10 +66,15 @@ export class SaslTpm {
     // depends on the stage of the flow - needs a state machine
     return new Promise((resolve, reject) => {
       if (challenge[0].value.length === 1) {
+        let firstResponse: Buffer = new Builder()
+          .appendUInt8(0)
+          .appendBuffer(this._storageRootKey)
+          .get();
+
         /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_003: [ If `getResponseFrame` is called with a 1 byte challenge, it shall resolve with the the initial response that was passed into the constructor. ] */
         // initial challenge, reply with the srk
         debug('initial response');
-        resolve({response: this._firstResponse});
+        resolve({response: firstResponse});
       } else {
         debug('length = ' + challenge[0].value.length + ' control byte = ' + challenge[0].value[0]);
         if ((challenge[0].value[0] & 0xC0) === 192) {
@@ -66,13 +82,18 @@ export class SaslTpm {
           this._challengeKey.appendBuffer(challenge[0].value.slice(1));
           let keyBuffer: Buffer = this._challengeKey.get();
           /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_005: [ If `getResponseFrame` is called with a first byte that has 11 in the most significant bits, it shall call the challenge callback with the full challenge buffer ] */
-          this._getResponseFromChallenge(keyBuffer, (err, buffer) => {
+          this._getSasToken(keyBuffer, (err, sasToken) => {
             if (err) {
               /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_007: [ If `ChallengeResponseCallback` is called with an error, the final `getResponseFrame` promise shall be rejected. ] */
               reject(err);
             } else {
+              let responseBuffer: Buffer = new Builder()
+                .appendUInt8(0)
+                .appendString(sasToken)
+                .get();
+
               /*Codes_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_006: [ If `ChallengeResponseCallback` is called without passing an error, the final `getResponseFrame` promise shall be resolved. ] */
-              resolve({response: buffer});
+              resolve({response: responseBuffer});
             }
           });
         } else if ((challenge[0].value[0] & 0x80) === 128) {

--- a/provisioning/transport/amqp/test/_sasl_tpm_test.js
+++ b/provisioning/transport/amqp/test/_sasl_tpm_test.js
@@ -5,18 +5,33 @@
 
 var SaslTpm = require('../lib/sasl_tpm').SaslTpm;
 var assert = require('chai').assert;
+var Builder = require('buffer-builder');
 
 describe( 'SaslTpm', function () {
   this.timeout(100);
-  var fakeHostname = '__FAKE_HOST_NAME__';
-  var fakeInit = new Buffer('__FAKE_INIT_BUFFER');
-  var fakeFirstResponse = new Buffer('__FAKE_FIRST_RESPONSE__');
   var fakeBuffer1 = new Buffer('__FAKE_BUFFER_NUMBER_1__');
   var fakeBuffer2 = new Buffer('__FAKE_BUFFER_NUMBER_2_WITH_EXTRA_STUFF__');
   var fakeBuffer3 = new Buffer('__FAKE_BUFFER_NUMBER_3_WITH_EVEN_MORE_EXTRA_STUFF__');
+  var fakeIdScope = '__IDSCOPE__';
+  var fakeRegistrationId = '__REQUEST_ID__';
+  var fakeEndorsementKey = new Buffer('__FAKE_ENDORSEMENT_KEY__');
+  var fakeStorageRootKey = new Buffer('__FAKE_STORAGE_ROOT_KEY__');
   var emptyChallengeResponse = Buffer.from([0]);
-  var fakeFinalResponse = new Buffer('__FAKE_FINAL_RESPONSE_AKA_KEY_AKA_CHALLENGE_STRING__');
   var fakeError = new Error('__FAKE_ERROR_TEXT__');
+  var fakeSasToken = '__FAKE_SAS_TOKEN__';
+
+  var fakeInit = new Builder()
+    .appendUInt8(0)
+    .appendString(fakeIdScope)
+    .appendUInt8(0)
+    .appendString(fakeRegistrationId)
+    .appendUInt8(0)
+    .appendBuffer(fakeEndorsementKey)
+    .get();
+  var fakeFirstResponse = new Builder()
+    .appendUInt8(0)
+    .appendBuffer(fakeStorageRootKey)
+    .get();
 
   var challengeFromBuffer = function(firstByte, buffer) {
     return [
@@ -29,11 +44,12 @@ describe( 'SaslTpm', function () {
   describe('#getInitFrame', function() {
   it ('returns a promise that resolves to the intialization object', function(callback) {
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_001: [ The `SaslTpm` constructor shall accept the following parameters:
-      `hostName` - The hostName value to be returned when getInitFrame is called
-      `init` - The initial frame contents to be returned when getInitFrame is called
-      `firstResponse` - The response to return on the first call to getResponseFrame
-      `getResponseFromChallenge` - The callback to call when the challenge has been completed and the caller needs to formulate the response. ] */
-    var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function() {});
+      `idScope` - the idScope for the provisioning service instance
+      `registrationId` - the registrationId for the device being registered
+      `endorsementKey` - the endorsement key which was acquired from the TPM
+      `storageRootKey` - the storage root key which was acquired from the TPM
+      `getSasToken` - The callback to call when the challenge has been completed and the caller needs to formulate the response. ] */
+    var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey, function() {});
 
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_002: [ `getInitFrame` shall return a promise that resolves to an object with the following members:
       `mechanism` - Must be 'TPM'
@@ -41,8 +57,8 @@ describe( 'SaslTpm', function () {
       `hostname` - the hostName ] */
     sasl.getInitFrame().then(function(contents) {
         assert.strictEqual(contents.mechanism, 'TPM');
-        assert.strictEqual(contents.initialResponse, fakeInit);
-        assert.strictEqual(contents.hostname, fakeHostname);
+        assert.deepEqual(contents.initialResponse, fakeInit);
+        assert.strictEqual(contents.hostname, fakeIdScope + '/registrations/' + fakeRegistrationId);
         callback();
       });
     });
@@ -51,19 +67,19 @@ describe( 'SaslTpm', function () {
   describe('#getResponseFrame', function() {
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_003: [ If `getResponseFrame` is called with a 1 byte challenge, it shall resolve with the the initial response that was passed into the constructor. ] */
     it ('resolves to the initial response on first call', function(callback) {
-      var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function() {});
+      var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey, function() {});
       sasl.getResponseFrame(challengeFromBuffer(1, new Buffer('')))
         .then(function(response) {
           assert.deepEqual(response, {response: fakeFirstResponse});
           callback();
-        })
+        });
     });
 
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_004: [ If `getResponseFrame` is called with a first byte that has 1 in the most significant bit, it shall append the challenge to the full challenge buffer ] */
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_005: [ If `getResponseFrame` is called with a first byte that has 11 in the most significant bits, it shall call the challenge callback with the full challenge buffer ] */
     it ('appends to the challenge buffer, and calls the challenge callback when the 2 high bits are 11', function(callback) {
-      var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function(challenge) {
-        assert.deepEqual(challenge, fakeBuffer1);
+      var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey, function(challenge) {
+      assert.deepEqual(challenge, fakeBuffer1);
         callback();
       });
 
@@ -72,7 +88,7 @@ describe( 'SaslTpm', function () {
 
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_004: [ If `getResponseFrame` is called with a first byte that has 1 in the most significant bit, it shall append the challenge to the full challenge buffer ] */
     it ('appends to the challenge buffer and resolves to an empty buffer when the 2 high bits are 10', function(callback) {
-      var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function(challenge) {
+      var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey,  function(challenge) {
         assert.deepEqual(challenge, Buffer.concat([fakeBuffer1, fakeBuffer2, fakeBuffer3]));
         callback();
       });
@@ -91,21 +107,26 @@ describe( 'SaslTpm', function () {
 
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_006: [ If `ChallengeResponseCallback` is called without passing an error, the final `getResponseFrame` promise shall be resolved. ] */
     it ('resolves the final getResponseFrame promise when the ChallengeResponseCallback callback is called without error', function(callback) {
-      var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function(challenge, challengeResponseCallback) {
-        challengeResponseCallback(null, fakeFinalResponse);
+      var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey,  function(challenge, getSasTokenCallback) {
+        getSasTokenCallback(null, fakeSasToken);
       });
+
+      var sasTokenResponse = new Builder()
+        .appendUInt8(0)
+        .appendString(fakeSasToken)
+        .get();
 
       sasl.getResponseFrame(challengeFromBuffer(0xc0, fakeBuffer1))
         .then(function(response) {
-          assert.deepEqual(response, {response: fakeFinalResponse});
+          assert.deepEqual(response.response, sasTokenResponse);
           callback();
         });
     });
 
     /*Tests_SRS_NODE_PROVISIONING_AMQP_SASL_TPM_18_007: [ If `ChallengeResponseCallback` is called with an error, the final `getResponseFrame` promise shall be rejected. ] */
     it ('rejects the final getResponseFrame promise when the ChallengeResponseCallback callback is called with an error', function(callback) {
-      var sasl = new SaslTpm(fakeHostname, fakeInit, fakeFirstResponse, function(challenge, challengeResponseCallback) {
-        challengeResponseCallback(fakeError);
+      var sasl = new SaslTpm(fakeIdScope, fakeRegistrationId, fakeEndorsementKey, fakeStorageRootKey, function(challenge, getSasTokenCallback) {
+        getSasTokenCallback(fakeError);
       });
 
       sasl.getResponseFrame(challengeFromBuffer(0xc0, fakeBuffer1))


### PR DESCRIPTION
Changing SaslTpm implementation so the SaslTpm object knows how to construct its own buffers based off of information passed in by the Amqp transport object.