### PR TITLE
fix(e2etests): properly detach Event Hubs receivers in e2e tests

### DIFF
--- a/e2etests/test/d2c_disconnect.js
+++ b/e2etests/test/d2c_disconnect.js
@@ -108,8 +108,7 @@ var protocolAndTermination = [
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/eventhub clients - disconnect d2c', function () {
     this.timeout(20000);
-    var deviceClient, ehClient, senderInterval;
-    var provisionedDevice;
+    var deviceClient, ehClient, senderInterval, provisionedDevice, ehReceivers;
 
     before(function (beforeCallback) {
       DeviceIdentityHelper.createDeviceWithSas(function (err, testDeviceInfo) {
@@ -127,11 +126,12 @@ protocolAndTermination.forEach( function (testConfiguration) {
       ehClient = eventHubClient.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       senderInterval = null;
+      ehReceivers = [];
     });
 
     afterEach(function (testCallback) {
       this.timeout(20000);
-      closeDeviceEventHubClients(deviceClient, ehClient, testCallback);
+      closeDeviceEventHubClients(deviceClient, ehClient, ehReceivers, testCallback);
       if (sendMessageTimeout !== null) clearTimeout(sendMessageTimeout);
     });
 
@@ -156,6 +156,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
               .then(function (partitionIds) {
                 return partitionIds.map(function (partitionId) {
                   return ehClient.createReceiver('$Default', partitionId, { 'startAfterTime' : Date.now() }).then(function (receiver) {
+                    ehReceivers.push(receiver);
                     receiver.on('errorReceived', function(err) {
                       testCallback(err);
                     });
@@ -242,6 +243,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
               .then(function (partitionIds) {
                 return partitionIds.map(function (partitionId) {
                   return ehClient.createReceiver('$Default', partitionId, { 'startAfterTime' : Date.now() }).then(function (receiver) {
+                    ehReceivers.push(receiver);
                     receiver.on('errorReceived', function(err) {
                       testCallback(err);
                     });

--- a/e2etests/test/device_service.js
+++ b/e2etests/test/device_service.js
@@ -163,8 +163,7 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
   describe('Over ' + deviceTransport.name + ' using device/eventhub clients - messaging', function () {
     this.timeout(20000);
 
-    var deviceClient, ehClient;
-    var provisionedDevice;
+    var deviceClient, ehClient, ehReceivers, provisionedDevice;
 
     before(function (beforeCallback) {
       createDeviceMethod(function (err, testDeviceInfo) {
@@ -181,11 +180,12 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
       this.timeout(20000);
       ehClient = eventHubClient.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(deviceTransport, provisionedDevice);
+      ehReceivers = [];
     });
 
     afterEach(function (done) {
       this.timeout(20000);
-      closeDeviceEventHubClients(deviceClient, ehClient, done);
+      closeDeviceEventHubClients(deviceClient, ehClient, ehReceivers, done);
     });
 
     it('Device sends a message of maximum size and it is received by the service', function (done) {
@@ -219,6 +219,7 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
               .then(function (partitionIds) {
                 return partitionIds.map(function (partitionId) {
                   return ehClient.createReceiver('$Default', partitionId,{ 'startAfterTime' : Date.now()}).then(function(receiver) {
+                    ehReceivers.push(receiver);
                     receiver.on('errorReceived', function(err) {
                       done(err);
                     });


### PR DESCRIPTION
# Description of the problem
Some tests are unstable because the event hubs client does not automatically detach links before it disconnects.

# Description of the solution
Keep a list of open receivers and detach them before closing the client.
