### PR TITLE
fix(amqp-twin): Remove unnecessary link-detach handlers in Twin Client (fix #221 part deux)

### DIFF
--- a/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
+++ b/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
@@ -85,10 +85,6 @@ The endpoints and link options are as for the response event.
 
 **SRS_NODE_DEVICE_AMQP_TWIN_06_022: [** If an error occurs on establishing the upstream or downstream link then the `error` event shall be emitted. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_06_023: [** If a detach with error occurs on the upstream or the downstream link then the `error` event shall be emitted. **]**
-
-**SRS_NODE_DEVICE_AMQP_TWIN_06_024: [** If any detach occurs the other link will also be detached by the twin receiver. **]**
-
 **SRS_NODE_DEVICE_AMQP_TWIN_06_025: [** When the `error` event is emitted, the first parameter shall be an error object obtained via the amqp `translateError` module. **]**
 
 ### attach(callback)

--- a/device/transport/amqp/test/_amqp_receiver_test.js
+++ b/device/transport/amqp/test/_amqp_receiver_test.js
@@ -20,6 +20,12 @@ describe('AmqpReceiver', function () {
 
   var fakeMethodClient;
   var fakeAuthenticationProvider;
+  var fakeAmqpBaseClient = {
+    connect: sinon.stub().callsArg(2),
+    setDisconnectHandler: sinon.stub(),
+    initializeCBS: sinon.stub().callsArg(0),
+    putToken: sinon.stub().callsArg(2)
+  };
 
   beforeEach(function() {
     fakeMethodClient = {
@@ -52,9 +58,8 @@ describe('AmqpReceiver', function () {
     });
 
     it('forwards the errorReceived event if an error is received from a device method link', function(testCallback) {
-      this.timeout(10000);
       var fakeMethodClient = new EventEmitter();
-      var recv = new AmqpReceiver(fakeAuthenticationProvider);
+      var recv = new AmqpReceiver(fakeAuthenticationProvider, fakeAmqpBaseClient);
       var fakeError = new Error('fake error');
       var fakeCallback = function(err) {
         assert.strictEqual(err.innerError, fakeError);
@@ -170,10 +175,9 @@ describe('AmqpReceiver', function () {
     });
 
     it('emits an error event with the error if the links fail to connect initially', function (testCallback) {
-      this.timeout(10000);
       var fakeMethodClient = new EventEmitter();
       var fakeError = new Error('fake error');
-      var recv = new AmqpReceiver(fakeAuthenticationProvider);
+      var recv = new AmqpReceiver(fakeAuthenticationProvider, fakeAmqpBaseClient);
 
       var errorCallback = function (err) {
         assert.strictEqual(err.innerError, fakeError);

--- a/device/transport/amqp/test/_amqp_twin_client_test.js
+++ b/device/transport/amqp/test/_amqp_twin_client_test.js
@@ -459,36 +459,6 @@ describe('AmqpTwinClient', function () {
         newTwinReceiver.removeListener('response', dummyResponseHandler)
       });
     });
-
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_024: [If any detach occurs the other link will also be detached by the twin receiver.] */
-    /* Tests_SRS_NODE_DEVICE_AMQP_TWIN_06_023: [If a detach with error occurs on the upstream or the downstream link then the `error` event shall be emitted.] */
-    [
-      'fakeSenderLink',
-      'fakeReceiverLink'
-    ].forEach(function (whichLink) {
-      it('twin receiver detaches all links when a detach is emitted on ' + whichLink, function(testDone) {
-        var amqpClient = new AmqpProvider();
-        var detachSender = sinon.spy(amqpClient, 'detachSenderLink');
-        var detachReceiver = sinon.spy(amqpClient, 'detachReceiverLink');
-        var newTwinReceiver = new AmqpTwinClient(fakeAuthenticationProvider, amqpClient);
-        newTwinReceiver.on('subscribed', function(event) {
-          if (event.eventName === 'response') {
-            var linkError = new Error();
-            linkError.condition = 'amqp:internal-error';
-            var detachError = {closed: false, error: linkError};
-            amqpClient[whichLink].emit('detached', detachError);
-            var newDeleteResult = new Message();
-          }
-        });
-        newTwinReceiver.on('error', function(err) {
-          assert(detachSender.calledOnce);
-          assert(detachReceiver.calledOnce);
-          assert.equal(err.constructor.name, 'InternalServerError');
-          testDone();
-        });
-        newTwinReceiver.on('response', function() {});
-      });
-    });
   });
 
   describe('sendTwinRequest', function () {


### PR DESCRIPTION
# Related issue
#221

# Description of the problem
When a connection is lost the link are forceDetached which makes the amqp10 library emit a `detached` event on the link. The `AmqpTwinClient` class used to listen for these events (even though the link lifecycle is managed by the `Amqp` base class) and try to trigger a proper `detach` operation, which tried to write on a socket that is already disconnected, leading to a second (unnecessary) error.

# Description of the solution
Remove the link detached handlers. errors are still handled and bubbled up with other events so it seems these were left erroneously after some refactoring in the Amqp codebase.

Also using this PR to fix a couple of tests and reactivate the disconnection tests for AMQP (the retry tests will come next with more refactoring of the Twin stack)
