### PR TITLE
Update API version to 2018-01-16

### DIFF
--- a/common/core/src/endpoint.ts
+++ b/common/core/src/endpoint.ts
@@ -4,7 +4,7 @@
 
 'use strict';
 
-export const apiVersion = '2017-06-30';
+export const apiVersion = '2018-01-16';
 
 export function devicePath(id: string): string {
   return '/devices/' + id;


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#64 
#157 

# Description of the problem
Service updates now include status and lastActivityTime in the twin

# Description of the solution
Update to the latest REST API version.
