### PR TITLE
Update dependency versions for machina, lodash, debug, uuid and azure-storage

### DIFF
--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -13,7 +13,7 @@
     "async": "^2.5.0",
     "bluebird": "^3.5.0",
     "debug": "^3.0.1",
-    "machina": "^2.0.0",
+    "machina": "^2.0.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/common/transport/http/package.json
+++ b/common/transport/http/package.json
@@ -8,8 +8,8 @@
   "typings": "index.d.ts",
   "dependencies": {
     "azure-iot-common": "1.4.0",
-    "debug": "^2.2.0",
-    "uuid": "^2.0.1"
+    "debug": "^3.1.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -9,8 +9,8 @@
   "dependencies": {
     "azure-iot-common": "1.4.0",
     "debug": "^3.1.0",
-    "machina": "^2.0.0",
-    "mqtt": "^2.15.1"
+    "machina": "^2.0.1",
+    "mqtt": "^2.15.2"
   },
   "devDependencies": {
     "@types/node": "^8.0.28",

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -9,10 +9,10 @@
   "dependencies": {
     "azure-iot-common": "1.4.0",
     "azure-iot-http-base": "1.3.1",
-    "azure-storage": "^2.6.0",
+    "azure-storage": "^2.8.0",
     "debug": "^3.1.0",
-    "lodash": "^4.17.4",
-    "machina": "^2.0.0",
+    "lodash": "^4.17.5",
+    "machina": "^2.0.1",
     "traverse": "^0.6.6"
   },
   "devDependencies": {

--- a/device/samples/package.json
+++ b/device/samples/package.json
@@ -11,7 +11,7 @@
     "azure-iot-device-http": "1.3.1",
     "azure-iot-device-mqtt": "1.3.1",
     "es5-shim": "^4.5.9",
-    "lodash": "^4.15.0"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "jshint": "^2.9.2"

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -12,7 +12,7 @@
     "azure-iot-common": "1.4.0",
     "azure-iot-device": "1.3.1",
     "debug": "^3.0.1",
-    "machina": "^2.0.0",
+    "machina": "^2.0.1",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -11,7 +11,7 @@
     "azure-iot-device": "1.3.1",
     "azure-iot-mqtt-base": "1.3.1",
     "debug": "^3.0.1",
-    "machina": "^2.0.0"
+    "machina": "^2.0.1"
   },
   "devDependencies": {
     "@types/mqtt": "0.0.34",

--- a/e2etests/package.json
+++ b/e2etests/package.json
@@ -15,13 +15,13 @@
     "azure-iot-device-http": "1.3.1",
     "azure-iot-device-mqtt": "1.3.1",
     "azure-iothub": "1.2.4",
-    "azure-storage": "^1.2.0",
+    "azure-storage": "^2.8.0",
     "bluebird": "^3.3.0",
-    "debug": "^2.2.0",
-    "lodash": "^4.15.0",
+    "debug": "^3.1.0",
+    "lodash": "^4.17.5",
     "npm-run-all": "^4.1.1",
     "pem": "^1.8.3",
-    "uuid": "^2.0.1",
+    "uuid": "^3.2.1",
     "yargs": "^4.7.1"
   },
   "devDependencies": {

--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "azure-iot-common": "1.4.0",
     "debug": "^3.0.1",
-    "machina": "^2.0.0"
+    "machina": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/provisioning/service/package.json
+++ b/provisioning/service/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "azure-iot-common": "1.4.0",
     "azure-iot-http-base": "1.3.1",
-    "debug": "^2.6.3"
+    "debug": "^3.1.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -14,7 +14,7 @@
     "bluebird": "^3.5.0",
     "buffer-builder": "^0.2.0",
     "debug": "^3.0.1",
-    "machina": "^2.0.0",
+    "machina": "^2.0.1",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -11,7 +11,7 @@
     "azure-iot-common": "1.4.0",
     "azure-iot-provisioning-device": "1.1.0",
     "debug": "^3.0.1",
-    "machina": "^2.0.0"
+    "machina": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/provisioning/transport/mqtt/package.json
+++ b/provisioning/transport/mqtt/package.json
@@ -11,7 +11,7 @@
     "azure-iot-mqtt-base": "1.3.1",
     "azure-iot-provisioning-device": "1.1.0",
     "debug": "^3.0.1",
-    "machina": "^2.0.0",
+    "machina": "^2.0.1",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/security/tpm/package.json
+++ b/security/tpm/package.json
@@ -10,7 +10,7 @@
     "azure-iot-common": "1.4.0",
     "debug": "^3.0.1",
     "base32-encode": "^1.0.0",
-    "machina": "^2.0.0",
+    "machina": "^2.0.1",
     "tss.js": "^0.0.2",
     "array-equal": "^1.0.0"
   },

--- a/service/package.json
+++ b/service/package.json
@@ -11,9 +11,9 @@
     "azure-iot-amqp-base": "1.4.0",
     "azure-iot-common": "1.4.0",
     "azure-iot-http-base": "1.3.1",
-    "debug": "^2.6.3",
-    "lodash": "^4.15.0",
-    "machina": "^2.0.0"
+    "debug": "^3.1.0",
+    "lodash": "^4.17.5",
+    "machina": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -26,7 +26,7 @@
     "typescript": "2.2.2",
     "@types/node": "^7.0.5",
     "@types/debug": "0.0.29",
-    "uuid": "^2.0.1"
+    "uuid": "^3.2.1"
   },
   "scripts": {
     "lint": "tslint --exclude ./samples --project . -c ../tslint.json",

--- a/service/samples/package.json
+++ b/service/samples/package.json
@@ -7,6 +7,6 @@
   "license": "MIT",
   "dependencies": {
     "azure-iothub": "1.2.4",
-    "azure-storage": "^1.2.0"
+    "azure-storage": "^2.8.0"
   }
 }


### PR DESCRIPTION
# Description of the problem
Need to keep up with dependencies.
Also, update past lodash package vulnerability (https://hackerone.com/reports/310443)
(vuln still present in dependencies - classified as low risk though).

# Description of the solution
updates:
- lodash@4.15.5
- machina@2.0.1
- uuid@3.2.1
- debug@3.1.0
- azure-storage@2.8.0
- mqtt@2.15.2
