### PR TITLE
CR feedback and unit tests for MQTT modules.

### DIFF
--- a/common/transport/mqtt/devdoc/mqtt_base_requirements.md
+++ b/common/transport/mqtt/devdoc/mqtt_base_requirements.md
@@ -38,7 +38,7 @@ The `Mqtt` constructor receives the configuration parameters to configure the MQ
 
 ### MqttBase.connect(config, done)
 The `connect` method establishes a connection with the server using the config object passed in the arguments.
-**SRS_NODE_COMMON_MQTT_BASE_16_006: [** The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: deviceId, host, and one of sharedAccessSignature or x509.cert and x509.key. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_006: [** The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: uri, clientId, username, and one of sharedAccessSignature or x509.cert and x509.key. **]**
 
 **SRS_NODE_COMMON_MQTT_BASE_16_002: [** The `connect` method shall use the authentication parameters contained in the `config` argument to connect to the server. **]**
 

--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -141,7 +141,7 @@ export class MqttBase extends EventEmitter {
   }
 
   connect(config: MqttBaseTransportConfig, done: (err?: Error, result?: any) => void): void {
-    /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_006: [The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: deviceId, host, and one of sharedAccessSignature or x509.cert and x509.key.]*/
+    /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_006: [The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: uri, clientId, username, and one of sharedAccessSignature or x509.cert and x509.key.]*/
     if ((!config) ||
       (!config.uri) ||
       (!config.clientId) ||
@@ -206,7 +206,7 @@ export class MqttBase extends EventEmitter {
       protocolVersion: 4,
       clean: this._config.clean || false,
       clientId: this._config.clientId,
-      rejectUnauthorized: false,
+      rejectUnauthorized: true,
       username: this._config.username,
       reconnectPeriod: 0,  // Client will handle reconnection at the higher level.
       /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_016: [The `connect` method shall configure the `keepalive` ping interval to 3 minutes by default since the Azure Load Balancer TCP Idle timeout default is 4 minutes.]*/

--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -248,7 +248,24 @@ interface DeviceMethodEventHandler {
 
 **SRS_NODE_DEVICE_CLIENT_16_085: [** The `setRetryPolicy` method shall throw an `ArgumentError` if the policy object doesn't have a `nextRetryTimeout` method. **]**
 
-**SRS_NODE_DEVICE_CLIENT_16_086: [** Any operation (such as `sendEvent` or `onDeviceMethod`) happening after a `setRetryPolicy` call should use the policy set during that call. **]**
+**SRS_NODE_DEVICE_CLIENT_16_086: [** Any operation (such as `sendEvent` or `onDeviceMethod`) happening after a `setRetryPolicy` call should use the policy set during that call. **]*
+
+#### sendOutputEvent(outputName: string, message: Message, callback: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_CLIENT_18_010: [** The `sendOutputEvent` method shall send the event indicated by the `message` argument via the transport associated with the Client instance. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_018: [** When the `sendOutputEvent` method completes, the `callback` function shall be invoked with the same arguments as the underlying transport method's callback. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_019: [** The `sendOutputEvent` method shall not throw if the `callback` is not passed. **]**
+
+#### sendOutputEventBatch(outputName: string, messages: Message[], callback: (err?: Error, result?: results.MessageEnqueued) => void): void
+
+**SRS_NODE_DEVICE_CLIENT_18_011: [** The `sendOutputEventBatch` method shall send the list of events (indicated by the `messages` argument) via the transport associated with the Client instance. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_021: [** When the `sendOutputEventBatch` method completes the `callback` function shall be invoked with the same arguments as the underlying transport method's callback. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_022: [** The `sendOutputEventBatch` method shall not throw if the `callback` is not passed. **]**
+
 
 ### Events
 #### message
@@ -265,6 +282,20 @@ interface DeviceMethodEventHandler {
 
 **SRS_NODE_DEVICE_CLIENT_16_066: [** The client shall emit an error if connecting the transport fails while subscribing to message events **]**
 
+#### inputMessage
+
+**SRS_NODE_DEVICE_CLIENT_18_012: [** The `inputMessage` event shall be emitted when an inputMessage is received from the IoT Hub service. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_013: [** The `inputMessage` event parameters shall be the inputName for the message and a `Message` object. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_014: [** The client shall start listening for messages from the service whenever there is a listener subscribed to the `inputMessage` event. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_015: [** The client shall stop listening for messages from the service whenever the last listener unsubscribes from the `inputMessage` event. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_016: [** The client shall connect the transport if needed in order to receive inputMessages. **]**
+
+**SRS_NODE_DEVICE_CLIENT_18_017: [** The client shall emit an `error` if connecting the transport fails while subscribing to `inputMessage` events. **]**
+
 #### error
 
 **SRS_NODE_DEVICE_CLIENT_16_006: [** The `error` event shall be emitted when an error occurred within the client code. **]**
@@ -272,3 +303,4 @@ interface DeviceMethodEventHandler {
 #### disconnect
 
 **SRS_NODE_DEVICE_CLIENT_16_019: [** The `disconnect` event shall be emitted when the client is disconnected from the server. **]**
+

--- a/device/core/devdoc/modules_events_and_messages_design.md
+++ b/device/core/devdoc/modules_events_and_messages_design.md
@@ -1,17 +1,17 @@
-# node modules API
+# Azure IoT Modules API
 
 ## Concepts
 There are two types of clients: device and module. A client instance is defined by a connection string.  It can be either device or module but not both.
 * A device client has a `deviceId`, but no `moduleId`.
 * A module client has a `deviceId` and a `moduleId`.
 
-There are two kinds of upstream events: `sendEvent` and `sendOutputEvent`
-* `sendEvent` is an upstream event without an `outputName`.  This is traditionally called "telemetry"
-* `sendOutputEvent` is an upstream event with an `outputName`.  These are being called "outputEvents"
+There are two kinds of outgoing events that can be sent by an IoT device: `sendEvent` and `sendOutputEvent`
+* `sendEvent` is an outgoing event without an `outputName`.  This is traditionally called "telemetry"
+* `sendOutputEvent` is an outgoing event with an `outputName`.  These are being called "outputEvents"
 
-There are two kinds of downstream messages: Messages and inputMessages
-* Messages are downstream messages without an `inputName`.  These are traditionally called C2D.
-* inputMessages are downstream messages with an `inputName`.  These are being called "inputMessages"
+There are two kinds of incoming messages that can be received by an IoT device: Messages and inputMessages
+* Messages are incoming messages without an `inputName`.  These are traditionally called "C2D" or "commands"
+* inputMessages are incoming messages with an `inputName`.  These are being called "inputMessages"
 
 The following table shows which clients support which events & messages:
 
@@ -21,23 +21,15 @@ The following table shows which clients support which events & messages:
 | module | yes | yes | no | yes|
 
 ## Design principles
-1. The concept of "module" is completely orthogonal to the concepts of `inputName` and `outputName`.  The `moduleId` defines how you connect upstream.  The `inputName` and `outputName` define how a message travels.  This orthogonality is very important.
+1. The concept of "module" is completely orthogonal to the concepts of `inputName` and `outputName`.  The `moduleId` is one of the properties of the service connection.  The `inputName` and `outputName` define how a message travels.  This orthogonality is very important.
 2. The concepts of `inputName` and `outputName` are not properties of a `Message`.  They define the route that a `Message` takes, but the `Message` is completely independent of the route that it takes.  As a result, inputName and outputName are always _parameters_ and not _properties_.
 3. As a side-effect of #2, `Client` and transport object do not modify any `Message` objects that are passed in by the caller.
 4. Instead of overloading, we're adding explicit functions and events for inputMessages and outputEvents.
 5. No explicit `enableInputMessages` and `disableInputMessages` functions were added to the `Client` API.  This mirrors the existing design for other features.  The caller enables this functionality by adding eventHandlers.
-6. Since an instance can't support both Messages and inputMessages, the transport can combine this functionality.  For example, the MQTT transport has a single topic subscription for downstream messages.
-
-## Open issues
-1. transport API has functions called enableC2D and disableC2D.  Because of transport internals, this can be used for both Messages and inputMessages.  Do we want to add enableInputMessages and disableInputMessages?  Do we want to rename this to enableDownstreamMessages?
 
 ## Addition to `Client` API:
 
 ```
-// Input messages
-onInputMessage(inputName: string, func: (msg: Message) => void): this;
-removeInputMessageListener(inputName: string, func: (msg: Message) => void): this;
-
 // Output events
 sendOutputEvent(outputName: string, message: Message, callback: (err?: Error, result?: results.MessageEnqueued) => void): void;
 sendOutputEventBatch(outputName: string, messages: Message[], callback: (err?: Error, result?: results.MessageEnqueued) => void): void;
@@ -54,8 +46,8 @@ sendOutputEventBatch(outputName: string, messages: Message[], callback: (err?: E
 
 ```
 // Input messages
-onInputMessage(inputName: string, func: (msg: Message) => void): this;
-removeInputMessageListener(inputName: string, func: (msg: Message) => void): this;
+enableInputMessages(callback: (err?: Error) => void): void;
+disableInputMessages(callback: (err?: Error) => void): void;
 
 // Output events
 sendOutputEvent(outputName: string, message: Message, callback: (err?: Error, result?: results.MessageEnqueued) => void): void;
@@ -65,10 +57,10 @@ sendOutputEventBatch(outputName: string, messages: Message[], callback: (err?: E
 ## Responsibilities of the transport
 1. The transport builds appropriate topic names based on the presence of the moduleId.
 2. The transport builds the URI and userName based on deviceId, moduleId, and gatewayHostName.
-3. The transport subscribes to the inputMessage topics when the client calls the `enableC2D` function.
+3. The transport subscribes to the inputMessage topics when the client calls the `enableInputMessages` function.
 3. The transport inserts the outputName into the outgoing topic name.
 4. The transport extracts the inputName from the incoming topic name.
-5. The transport fires the "InputMessage_\<inputName\>" events when they come in, effectively using the EventEmitter object as an InputMessage dispatcher.
+5. The transport fires the "InputMessage_\<inputName\>" events when they come in.
 
 ## Changes to MqttBase transport config
 

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --lines 96 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 83 --lines 95 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/test/_client_common_testrun.js
+++ b/device/core/test/_client_common_testrun.js
@@ -63,13 +63,13 @@ function badConfigTests(opName, Transport, requestFn) {
   });
 }
 
-function sendEventTests(Transport, registry) {
-  describe('Client', function () {
+function singleMessageTests(Transport, registry, testName, requestFn) {
+  describe(testName, function () {
     badConfigTests('send an event', Transport, function (client, done) {
-      client.sendEvent(new Message(''), done);
+      requestFn(client, done);
     });
 
-    describe('#sendEvent with a SharedAccessKey', function () {
+    describe('#' + testName + ' with a SharedAccessKey', function () {
       var sakConnectionString;
       before(function(done) {
         registry.create({ deviceId: deviceId, status: "enabled" }, function(err, device) {
@@ -85,6 +85,7 @@ function sendEventTests(Transport, registry) {
       /*Tests_SRS_NODE_DEVICE_CLIENT_05_017: [With the exception of receive, when a Client method completes successfully, the callback function (indicated by the done argument) shall be invoked with the following arguments:
       err - null
       response - a transport-specific response object]*/
+      /*Tests_SRS_NODE_DEVICE_CLIENT_18_010: [The `sendOutputEvent` method shall send the event indicated by the `message` argument via the transport associated with the Client instance. ]*/
       it('sends the event when the client is opened', function (done) {
         var client = Client.fromConnectionString(sakConnectionString, Transport);
 
@@ -93,8 +94,7 @@ function sendEventTests(Transport, registry) {
             done(err);
           } else {
             assert.equal(res.constructor.name, 'Connected', 'Type of the result object of the client.open method is wrong');
-            var message = new Message('hello');
-            client.sendEvent(message, function (err, res) {
+            requestFn(client, function (err, res) {
               if (err) {
                 done(err);
               } else {
@@ -111,8 +111,7 @@ function sendEventTests(Transport, registry) {
       /*Tests_SRS_NODE_DEVICE_CLIENT_16_048: [The `sendEvent` method shall automatically connect the transport if necessary.]*/
       it('sends the event and automatically opens the client if necessary', function(done) {
         var client = Client.fromConnectionString(sakConnectionString, Transport);
-        var message = new Message('hello');
-        client.sendEvent(message, function(err, res) {
+        requestFn(client, function (err, res) {
           if (err) {
             done(err);
           } else {
@@ -125,11 +124,12 @@ function sendEventTests(Transport, registry) {
       });
     });
 
-    describe('#sendEvent with an x509 certificate', function () {
+    describe('#' + testName + ' with an x509 certificate', function () {
       /*Tests_SRS_NODE_DEVICE_CLIENT_05_007: [The sendEvent method shall send the event indicated by the message argument via the transport associated with the Client instance.]*/
       /*Tests_SRS_NODE_DEVICE_CLIENT_05_017: [With the exception of receive, when a Client method completes successfully, the callback function (indicated by the done argument) shall be invoked with the following arguments:
       err - null
       response - a transport-specific response object]*/
+      /*Tests_SRS_NODE_DEVICE_CLIENT_18_010: [The `sendOutputEvent` method shall send the event indicated by the `message` argument via the transport associated with the Client instance. ]*/
       it('sends the event', function (done) {
         var client = Client.fromConnectionString(x509ConnectionString, Transport);
         client.setOptions({
@@ -143,8 +143,7 @@ function sendEventTests(Transport, registry) {
             done(err);
           } else {
             assert.equal(res.constructor.name, 'Connected', 'Type of the result object of the client.open method is wrong');
-            var message = new Message('hello');
-            client.sendEvent(message, function (err, res) {
+            requestFn(client, function (err, res) {
               if (err) {
                 done(err);
               } else {
@@ -161,13 +160,12 @@ function sendEventTests(Transport, registry) {
       /*Tests_SRS_NODE_DEVICE_CLIENT_16_048: [The `sendEvent` method shall automatically connect the transport if necessary.]*/
       it('sends the event and automatically opens the client if necessary', function(done) {
         var client = Client.fromConnectionString(x509ConnectionString, Transport);
-        var message = new Message('hello');
         client.setOptions({
           cert: x509Certificate,
           key: x509Key,
           passphrase: x509Passphrase
         });
-        client.sendEvent(message, function(err, res) {
+        requestFn(client, function (err, res) {
           if (err) {
             done(err);
           } else {
@@ -182,17 +180,13 @@ function sendEventTests(Transport, registry) {
   });
 }
 
-function sendEventBatchTests(Transport, registry) {
-  describe('Client', function () {
+function batchMessageTests(Transport, registry, testName, requestFn) {
+  describe(testName, function () {
     badConfigTests('send an event batch', Transport, function (client, done) {
-      var messages = [];
-      for (var i = 0; i < 5; i++) {
-        messages[i] = new Message('Event Msg ' + i);
-      }
-      client.sendEventBatch(messages, done);
+      requestFn(client, done);
     });
 
-    describe('#sendEvent with a Shared Access Key', function() {
+    describe('#' + testName + ' with a Shared Access Key', function() {
       var sakConnectionString;
       before(function(done) {
         registry.create({ deviceId: deviceId, status: "enabled" }, function(err, device) {
@@ -209,15 +203,11 @@ function sendEventBatchTests(Transport, registry) {
       /*Tests_SRS_NODE_DEVICE_CLIENT_05_017: [With the exception of receive, when a Client method completes successfully, the callback function (indicated by the done argument) shall be invoked with the following arguments:
       err - null
       response - a transport-specific response object]*/
+      /*Tests_SRS_NODE_DEVICE_CLIENT_18_011: [The `sendOutputEventBatch` method shall send the list of events (indicated by the `messages` argument) via the transport associated with the Client instance. ]*/
       it('sends the event batch message', function (done) {
         var client = Client.fromConnectionString(sakConnectionString, Transport);
 
-        var messages = [];
-        for (var i = 0; i < 5; i++) {
-          messages[i] = new Message('Event Msg ' + i);
-        }
-
-        client.sendEventBatch(messages, function (err, res) {
+        requestFn(client, function (err, res) {
           if (err) {
             done(err);
           } else {
@@ -233,6 +223,7 @@ function sendEventBatchTests(Transport, registry) {
       /*Tests_SRS_NODE_DEVICE_CLIENT_05_017: [With the exception of receive, when a Client method completes successfully, the callback function (indicated by the done argument) shall be invoked with the following arguments:
       err - null
       response - a transport-specific response object]*/
+      /*Tests_SRS_NODE_DEVICE_CLIENT_18_011: [The `sendOutputEventBatch` method shall send the list of events (indicated by the `messages` argument) via the transport associated with the Client instance. ]*/
       it('sends the event batch message', function (done) {
         var client = Client.fromConnectionString(x509ConnectionString, Transport);
         client.setOptions({
@@ -241,12 +232,7 @@ function sendEventBatchTests(Transport, registry) {
           passphrase: x509Passphrase
         });
 
-        var messages = [];
-        for (var i = 0; i < 5; i++) {
-          messages[i] = new Message('Event Msg ' + i);
-        }
-
-        client.sendEventBatch(messages, function (err, res) {
+        requestFn(client, function (err, res) {
           if (err) {
             done(err);
           } else {
@@ -259,7 +245,45 @@ function sendEventBatchTests(Transport, registry) {
   });
 }
 
+var sendEventTests = function(Transport, registry) {
+  var message = new Message('hello');
+  singleMessageTests(Transport, registry, 'Client.sendEvent', function (client, done) {
+    client.sendEvent(message, done);
+  });
+}
+
+var sendOutputEventTests = function(Transport, registry) {
+  var message = new Message('hello');
+  singleMessageTests(Transport, registry, 'Client.sendOutputEvent', function (client, done) {
+    client.sendOutputEvent('outputName', message, done);
+  });
+}
+
+var sendEventBatchTests = function(Transport, registry) {
+  var messages = [];
+  for (var i = 0; i < 5; i++) {
+    messages[i] = new Message('Event Msg ' + i);
+  }
+  batchMessageTests(Transport, registry, 'client.sendEventBatch', function (client, done) {
+    client.sendEventBatch(messages, done);
+  });
+}
+
+var sendOutputEventBatchTests = function(Transport, registry) {
+  var messages = [];
+  for (var i = 0; i < 5; i++) {
+    messages[i] = new Message('Event Msg ' + i);
+  }
+  batchMessageTests(Transport, registry, 'client.sendOutputEventBatch', function (client, done) {
+    client.sendOutputEventBatch('outputName', messages, done);
+  });
+}
+
+
 module.exports = {
   sendEventTests: sendEventTests,
-  sendEventBatchTests: sendEventBatchTests
+  sendEventBatchTests: sendEventBatchTests,
+  sendOutputEventTests: sendOutputEventTests,
+  sendOutputEventBatchTests: sendOutputEventBatchTests
 };
+

--- a/device/core/test/_sak_authentication_provider_test.js
+++ b/device/core/test/_sak_authentication_provider_test.js
@@ -104,22 +104,36 @@ describe('SharedAccessKeyAuthenticationProvider', function () {
     });
 
     /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_008: [The `fromConnectionString` method shall extract the credentials from the `connectionString` argument and create a new `SharedAccessKeyAuthenticationProvider` that uses these credentials to generate security tokens.]*/
-    it('initializes the credentials from the connection string', function (testCallback) {
-      var fakeCredentials = {
-        deviceId: 'fakeDeviceId',
-        moduleId: 'fakeModuleId',
-        host: 'fake.host.name',
-        sharedAccessKey: 'fakeKey'
-      };
-      var fakeConnectionString = 'DeviceId=' + fakeCredentials.deviceId + ';ModuleId=' + fakeCredentials.moduleId + ';HostName=' + fakeCredentials.host + ';SharedAccessKey=' + fakeCredentials.sharedAccessKey;
-
-      var sakAuthProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(fakeConnectionString, 2, 1);
-      sakAuthProvider.getDeviceCredentials(function (err, creds) {
-        assert.strictEqual(creds.deviceId, fakeCredentials.deviceId);
-        assert.strictEqual(creds.moduleId, fakeCredentials.moduleId);
-        assert.strictEqual(creds.host, fakeCredentials.host);
-        assert.strictEqual(creds.sharedAccessKey, fakeCredentials.sharedAccessKey);
-        testCallback();
+    [
+      {
+        name: 'without moduleId',
+        connectionString: 'DeviceId=fakeDeviceId;HostName=fake.host.name;SharedAccessKey=fakeKey',
+        credentials: {
+          deviceId: 'fakeDeviceId',
+          host: 'fake.host.name',
+          sharedAccessKey: 'fakeKey'
+        }
+      },
+      {
+        name: 'with moduleId',
+        connectionString: 'DeviceId=fakeDeviceId;ModuleId=fakeModuleId;HostName=fake.host.name;SharedAccessKey=fakeKey',
+        credentials: {
+          deviceId: 'fakeDeviceId',
+          moduleId: 'fakeModuleId',
+          host: 'fake.host.name',
+          sharedAccessKey: 'fakeKey'
+        }
+      }
+    ].forEach(function(testConfig) {
+      it('initializes the credentials from the connection string ' + testConfig.name, function (testCallback) {
+        var sakAuthProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(testConfig.connectionString, 2, 1);
+        sakAuthProvider.getDeviceCredentials(function (err, creds) {
+          assert.strictEqual(creds.deviceId, testConfig.credentials.deviceId);
+          assert.strictEqual(creds.moduleId, testConfig.credentials.moduleId);
+          assert.strictEqual(creds.host, testConfig.credentials.host);
+          assert.strictEqual(creds.sharedAccessKey, testConfig.credentials.sharedAccessKey);
+          testCallback();
+        });
       });
     });
   });

--- a/device/core/test/fake_transport.js
+++ b/device/core/test/fake_transport.js
@@ -25,6 +25,14 @@ function FakeTransport() {
     callback(null, new results.MessageEnqueued());
   };
 
+  this.sendOutputEvent = function (outputName, msg, callback) {
+    callback(null, new results.MessageEnqueued());
+  };
+
+  this.sendOutputEventBatch = function (outputName, msg, callback) {
+    callback(null, new results.MessageEnqueued());
+  };
+
   this.complete = function (msg, callback) {
     callback(null, new results.MessageCompleted());
   };
@@ -50,6 +58,14 @@ function FakeTransport() {
   };
 
   this.disableC2D = function (callback) {
+    callback();
+  };
+
+  this.enableInputMessages = function (callback) {
+    callback();
+  };
+
+  this.disableInputMessages = function (callback) {
     callback();
   };
 }

--- a/device/core/test/http_simulated.js
+++ b/device/core/test/http_simulated.js
@@ -77,6 +77,18 @@ SimulatedHttp.prototype.sendEventBatch = function (message, done) {
   });
 };
 
+SimulatedHttp.prototype.sendOutputEvent = function (outputName, message, done) {
+  this.handleRequest(function (err, response) {
+    done(err, response);
+  });
+};
+
+SimulatedHttp.prototype.sendOutputEventBatch = function (outputName, message, done) {
+  this.handleRequest(function (err, response) {
+    done(err, response);
+  });
+};
+
 SimulatedHttp.prototype.receive = function (done) {
   this.handleRequest(function (err, response) {
     done(err, err ? null : new Message(''), response);

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -266,3 +266,21 @@ An new Amqp message shall be instantiated.
 **SRS_NODE_DEVICE_AMQP_16_050: [** The `disableTwin` method shall call its `callback` with an `Error` if it fails to detach the twin links. **]**
 
 **SRS_NODE_DEVICE_AMQP_16_051: [** The `disableTwin` method shall call its `callback` immediately if the transport is already disconnected. **]**
+
+###   enableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_18_001: [** `enableInputMessages` shall throw a `NotImplementedError`. **]**
+
+###   disableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_18_002: [** `disableInputMessages` shall throw a `NotImplementedError`. **]**
+
+### sendOutputEvent(outputName: string, message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_18_003: [** `sendOutputEvent` shall throw a `NotImplementedError`. **]**
+
+### sendOutputEventBatch(outputName: string, messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_AMQP_18_004: [** `sendOutputEventBatch` shall throw a `NotImplementedError`. **]**
+
+

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 94 --branches 84  --lines 95 --functions 93"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 84  --lines 95 --functions 94"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -647,14 +647,6 @@ export class Amqp extends EventEmitter implements Client.Transport {
 
   /**
    * @private
-   */
-  onInputMessage(inputName: string, callback: (msg: Message) => void): this {
-    throw new errors.NotImplementedError('Module events are not implemented over AMQP.');
-  }
-
-
-  /**
-   * @private
    * The `sendMethodResponse` method sends a direct method response to the IoT Hub
    * @param {Object}     methodResponse   Object describing the device method response.
    * @param {Function}   callback         The callback to be invoked when
@@ -750,6 +742,38 @@ export class Amqp extends EventEmitter implements Client.Transport {
    */
   disableTwin(callback: (err?: Error) => void): void {
     this._fsm.handle('disableTwin', callback);
+  }
+
+  /**
+   * @private
+   */
+  enableInputMessages(callback: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_AMQP_18_001: [`enableInputMessages` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Input messages are not implemented over AMQP.');
+  }
+
+  /**
+   * @private
+   */
+  disableInputMessages(callback: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_AMQP_18_002: [`disableInputMessages` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Input messages are not implemented over AMQP.');
+  }
+
+  /**
+   * @private
+   */
+  sendOutputEvent(outputName: string, message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void {
+    /*Codes_SRS_NODE_DEVICE_AMQP_18_003: [`sendOutputEvent` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Output events are not implemented over AMQP.');
+  }
+
+  /**
+   * @private
+   */
+  sendOutputEventBatch(outputName: string, messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void {
+    /*Codes_SRS_NODE_DEVICE_AMQP_18_004: [`sendOutputEventBatch` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Output events are not implemented over AMQP.');
   }
 
   protected _getConnectionUri(host: string): string {

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -940,15 +940,6 @@ describe('Amqp', function () {
         });
       });
     });
-
-    describe('#sendEventBatch', function () {
-      /*Tests_SRS_NODE_DEVICE_AMQP_16_052: [The `sendEventBatch` method shall throw a `NotImplementedError`.]*/
-      it('throws an NotImplementedError', function () {
-        assert.throws(function () {
-          transport.sendEventBatch([], function() {});
-        }, errors.NotImplementedError);
-      });
-    });
   });
 
   describe('C2D', function () {
@@ -1511,6 +1502,27 @@ describe('Amqp', function () {
           });
         });
       });
+    });
+  });
+
+  /*Tests_SRS_NODE_DEVICE_AMQP_16_052: [The `sendEventBatch` method shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_AMQP_18_001: [`enableInputMessages` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_AMQP_18_002: [`disableInputMessages` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_AMQP_18_003: [`sendOutputEvent` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_AMQP_18_004: [`sendOutputEventBatch` shall throw a `NotImplementedError`.]*/
+  [
+    'sendEventBatch',
+    'enableInputMessages',
+    'disableInputMessages',
+    'sendOutputEvent',
+    'sendOutputEventBatch'
+  ].forEach(function (methodName) {
+    describe('#' + methodName, function () {
+      it('throws a NotImplementedError', function () {
+        assert.throws(function () {
+          transport[methodName]();
+        }, errors.NotImplementedError);
+      })
     });
   });
 });

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -253,7 +253,7 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_16_032: [** All HTTP requests shall obtain the credentials necessary to execute the request by calling `getDeviceCredentials` on the `AuthenticationProvider` object passed to the `Http` constructor. **]**
 
- **SRS_NODE_DEVICE_HTTP_16_033: [** if the `getDeviceCredentials` fails with an error, the Http request shall call its callback with that error **]**
+**SRS_NODE_DEVICE_HTTP_16_033: [** if the `getDeviceCredentials` fails with an error, the Http request shall call its callback with that error **]**
 
 **SRS_NODE_DEVICE_HTTP_05_008: [**If any Http method encounters an error before it can send the request, it shall invoke the `done` callback function and pass the standard JavaScript Error object with a text description of the error (err.message).**]**
 
@@ -272,3 +272,19 @@ Authorization: <config.sharedAccessSignature>
 **]**
 
 **SRS_NODE_DEVICE_HTTP_16_013: [** If using x509 authentication the `Authorization` header shall not be set and the x509 parameters shall instead be passed to the underlying transpoort. **]**
+
+### enableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_HTTP_18_001: [** `enableInputMessages` shall throw a `NotImplementedError`. **]**
+
+### disableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_HTTP_18_002: [** `disableInputMessages` shall throw a `NotImplementedError`. **]**
+
+### sendOutputEvent(outputName: string, message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_HTTP_18_003: [** `sendOutputEvent` shall throw a `NotImplementedError`. **]**
+
+### sendOutputEventBatch(outputName: string, messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_HTTP_18_004: [** `sendOutputEventBatch` shall throw a `NotImplementedError`. **]**

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -33,7 +33,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 92 --branches 83 --lines 93 --functions 89"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 83 --lines 94 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -549,14 +549,6 @@ export class Http extends EventEmitter implements Client.Transport {
   /**
    * @private
    */
-  onInputMessage(inputName: string, callback: (msg: Message) => void): this {
-    throw new errors.NotImplementedError('Module events are not implemented over HTTP.');
-  }
-
-
-  /**
-   * @private
-   */
   enableMethods(callback: (err?: Error) => void): void {
     /*Codes_SRS_NODE_DEVICE_HTTP_16_026: [`enableMethods` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Direct methods are not implemented over HTTP.');
@@ -569,6 +561,40 @@ export class Http extends EventEmitter implements Client.Transport {
     /*Codes_SRS_NODE_DEVICE_HTTP_16_027: [`disableMethods` shall throw a `NotImplementedError`.]*/
     throw new errors.NotImplementedError('Direct methods are not implemented over HTTP.');
   }
+
+  /**
+   * @private
+   */
+  enableInputMessages(callback: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_18_001: [`enableInputMessages` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Input messages are not implemented over HTTP.');
+  }
+
+  /**
+   * @private
+   */
+  disableInputMessages(callback: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_18_002: [`disableInputMessages` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Input messages are not implemented over HTTP.');
+  }
+
+  /**
+   * @private
+   */
+  sendOutputEvent(outputName: string, message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_18_003: [`sendOutputEvent` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Output events are not implemented over HTTP.');
+  }
+
+  /**
+   * @private
+   */
+  sendOutputEventBatch(outputName: string, messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void {
+    /*Codes_SRS_NODE_DEVICE_HTTP_18_004: [`sendOutputEventBatch` shall throw a `NotImplementedError`.]*/
+    throw new errors.NotImplementedError('Output events are not implemented over HTTP.');
+  }
+
+
 
   private _insertAuthHeaderIfNecessary(headers: { [key: string]: string }, credentials: TransportConfig): void {
     if (this._authenticationProvider.type === AuthenticationType.Token) {

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -787,6 +787,10 @@ describe('HttpReceiver', function () {
   /*Tests_SRS_NODE_DEVICE_HTTP_16_025: [`onDeviceMethod` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_026: [`enableMethods` shall throw a `NotImplementedError`.]*/
   /*Tests_SRS_NODE_DEVICE_HTTP_16_027: [`disableMethods` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_18_001: [`enableInputMessages` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_18_002: [`disableInputMessages` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_18_003: [`sendOutputEvent` shall throw a `NotImplementedError`.]*/
+  /*Tests_SRS_NODE_DEVICE_HTTP_18_004: [`sendOutputEventBatch` shall throw a `NotImplementedError`.]*/
   [
     'getTwinReceiver',
     'sendTwinRequest',
@@ -795,7 +799,11 @@ describe('HttpReceiver', function () {
     'sendMethodResponse',
     'onDeviceMethod',
     'enableMethods',
-    'disableMethods'
+    'disableMethods',
+    'enableInputMessages',
+    'disableInputMessages',
+    'sendOutputEvent',
+    'sendOutputEventBatch'
   ].forEach(function (methodName) {
     describe('#' + methodName, function () {
       it('throws a NotImplementedError', function () {

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -18,7 +18,15 @@ The `Mqtt` and `MqttWs` constructors initialize a new instance of the MQTT trans
 
 **SRS_NODE_DEVICE_MQTT_12_003: [** The constructor shall create an MqttBase object and store it in a member variable.**]**
 
-**SRS_NODE_DEVICE_MQTT_16_016: [** The `Mqtt` constructor shall initialize the `uri` property of the `config` object to `mqtts://<host>`. **]**
+**SRS_NODE_DEVICE_MQTT_16_016: [** If the connection string does not specify a `gatewayHostName` value, the `Mqtt` constructor shall initialize the `uri` property of the `config` object to `mqtts://<host>`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_054: [** If a `gatewayHostName` is specified in the connection string, the Mqtt constructor shall initialize the `uri` property of the `config` object to `mqtts://<gatewayhostname>`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_052: [** If a `moduleId` is specified in the connection string, the Mqtt constructor shall initialize the `clientId` property of the `config` object to '<deviceId>/<moduleId>'. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_053: [** If a `moduleId` is not specified in the connection string, the Mqtt constructor shall initialize the `clientId` property of the `config` object to '<deviceId>'. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_055: [** The Mqtt constructor shall initialize the `username` property of the `config` object to '<host>/<clientId>/api-version=<version>&DeviceClientType=<agentString>'. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_017: [** The `MqttWs` constructor shall initialize the `uri` property of the `config` object to `wss://<host>:443/$iothub/websocket`. **]**
 
@@ -66,9 +74,9 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_DEVICE_MQTT_12_005: [** The `sendEvent` method shall call the publish method on `MqttBase`. **]**
 
-**SRS_NODE_COMMON_MQTT_BASE_16_008: [** If a moduleId was not specified in the transport connection, the `sendEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/messages/events/`. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_008: [** The `sendEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/messages/events/`. **]**
 
-**SRS_NODE_DEVICE_MQTT_18_027: [** If a moduleId was specified in the transport connection, the `sendEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/modules/<moduleId>/messages/events/`. **]**
+**SRS_NODE_DEVICE_MQTT_18_034: [** If the connection string specifies a `moduleId` value, the `sendEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/<moduleId>/messages/events/` **]**
 
 **SRS_NODE_COMMON_MQTT_BASE_16_009: [** If the message has properties, the property keys and values shall be uri-encoded, then serialized and appended at the end of the topic with the following convention: `<key>=<value>&<key2>=<value2>&<key3>=<value3>(...)`. **]**
 
@@ -99,6 +107,45 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 ### sendEventBatch(messages, done)
 **SRS_NODE_DEVICE_MQTT_16_056: [** The `sendEventBatch` method shall throw a `NotImplementedError` **]**
 
+### sendOutputEvent(outputName: string, message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void;
+
+**SRS_NODE_DEVICE_MQTT_18_035: [** The `sendOutputEvent` method shall call the publish method on `MqttBase`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_036: [** If a `moduleId` was not specified in the transport connection, the `sendOutputEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/messages/events/`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_037: [** If a `moduleId` was specified in the transport connection, the `sendOutputEvent` method shall use a topic formatted using the following convention: `devices/<deviceId>/<moduleId>/messages/events/`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_038: [** If the outputEvent message has properties, the property keys and values shall be uri-encoded, then serialized and appended at the end of the topic with the following convention: `<key>=<value>&<key2>=<value2>&<key3>=<value3>(...)`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_039: [** The `sendOutputEvent` method shall use QoS level of 1. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_040: [** The `sendOutputEvent` method shall serialize the `messageId` property of the message as a key-value pair on the topic with the key `$.mid`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_041: [** The `sendOutputEvent` method shall serialize the `correlationId` property of the message as a key-value pair on the topic with the key `$.cid`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_042: [** The `sendOutputEvent` method shall serialize the `userId` property of the message as a key-value pair on the topic with the key `$.uid`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_043: [** The `sendOutputEvent` method shall serialize the `to` property of the message as a key-value pair on the topic with the key `$.to`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_044: [** The `sendOutputEvent` method shall serialize the `expiryTimeUtc` property of the message as a key-value pair on the topic with the key `$.exp`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_045: [** The `sendOutputEvent` method shall connect the Mqtt connection if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_046: [** The `sendOutputEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to establish a connection. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_047: [** If `sendOutputEvent` is called while `MqttBase` is establishing the connection, it shall wait until the connection is established and then send the event. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_048: [** If `sendOutputEvent` is called while `MqttBase` is establishing the connection, and `MqttBase` fails to establish the connection, then sendEvent shall fail. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_049: [** If `sendOutputEvent` is called while `MqttBase` is disconnecting, it shall wait until the disconnection is complete and then try to connect again and send the event. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_050: [** The `sendOutputEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to publish the message. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_068: [** The `sendOutputEvent` method shall serialize the `outputName` property of the message as a key-value pair on the topic with the key `$.on`. **]**
+
+### sendOutputEventBatch(outputName: string, messages: Message[], done: (err?: Error, result?: results.MessageEnqueued) => void): void {
+
+**SRS_NODE_DEVICE_MQTT_18_051: [** `sendOutputEventBatch` shall throw a `NotImplementedError` exception. **]**
 
 ### abandon(message, done)
 
@@ -279,6 +326,18 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 
 **SRS_NODE_DEVICE_MQTT_16_061: [** `enableTwin` shall call its callback with an `Error` if subscribing to the topics fails. **]**
 
+### enableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_MQTT_18_059: [** `enableInputMessages` shall connect the MQTT connection if it is disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_060: [** `enableInputMessages` shall calls its callback with an `Error` object if it fails to connect. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_061: [** `enableInputMessages` shall subscribe to the MQTT topic for inputMessages. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_062: [** `enableInputMessages` shall call its callback with no arguments when the `SUBACK` packet is received. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_063: [** `enableInputMessages` shall call its callback with an `Error` if subscribing to the topic fails. **]**
+
 ### disableC2D
 
 **SRS_NODE_DEVICE_MQTT_16_041: [** `disableC2D` shall call its callback immediately if the MQTT connection is already disconnected. **]**
@@ -308,6 +367,16 @@ The `getTwinReceiver` method creates a `MqttTwinReceiver` object for the twin re
 **SRS_NODE_DEVICE_MQTT_16_064: [** `disableTwin` shall call its callback with no arguments when the `UNSUBACK` packet is received. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_065: [** `disableTwin` shall call its callback with an `Error` if an error is received while unsubscribing. **]**
+
+### disableInputMessages(callback: (err?: Error) => void): void;
+
+**SRS_NODE_DEVICE_MQTT_18_064: [** `disableInputMessages` shall call its callback immediately if the MQTT connection is already disconnected. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_065: [** `disableInputMessages` shall unsubscribe from the topic for inputMessages. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_066: [** `disableInputMessages` shall call its callback with no arguments when the `UNSUBACK` packet is received. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_067: [** `disableInputMessages` shall call its callback with an `Error` if an error is received while unsubscribing. **]**
 
 ### message Event
 
@@ -347,4 +416,23 @@ interface MethodMessage {
 }
 ```
 **]**
+
+### inputMessage event
+
+**SRS_NODE_DEVICE_MQTT_18_057: [** If there is a listener for the `inputMessage` event, a `inputMessage` event shall be emitted for each message received. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_058: [** When an `inputMessage` event is received, Mqtt shall extract the inputName from the topic according to the following convention: 'devices/<deviceId>/modules/<moduleId>/inputs/<inputName>' **]**
+
+**SRS_NODE_DEVICE_MQTT_18_056: [** When an `inputMessage` event is emitted, the first parameter shall be the inputName and the second parameter shall be of type `Message`. **]**
+
+
+
+
+
+
+
+
+
+
+
 

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -34,7 +34,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 86 --functions 93 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
@@ -81,7 +81,7 @@ These requirements apply whenever the transport connection is established
 
 **SRS_NODE_PROVISIONING_MQTT_18_038: [** When connecting, `Mqtt` shall set the `username` in the base `TransportConfig` object to '<idScope>/registrations/<registrationId>/api-version=<apiVersion>&clientVersion=<UrlEncode<userAgent>>'. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_050: [** When connecting, `Mqtt` shall set `host` in the base `TransportConfig` object to the `provisioningDeviceHost`. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_050: [** When connecting, `Mqtt` shall set `uri` in the base `TransportConfig` object to the 'mqtts://' + `provisioningDeviceHost`. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_039: [** If a uri is specified in the request object, `Mqtt` shall set it in the base `TransportConfig` object. **]**
 

--- a/provisioning/transport/mqtt/src/mqtt.ts
+++ b/provisioning/transport/mqtt/src/mqtt.ts
@@ -260,7 +260,7 @@ export class Mqtt extends EventEmitter implements X509ProvisioningTransport {
   private _connect(request: RegistrationRequest, callback: (err?: Error) => void): void {
 
     /* Codes_SRS_NODE_PROVISIONING_MQTT_18_037: [ When connecting, `Mqtt` shall pass in the `X509` certificate that was passed into `setAuthentication` in the base `TransportConfig` object.] */
-    /* Codes_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `host` in the base `TransportConfig` object to the `provisioningDeviceHost`.] */
+    /* Codes_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `uri` in the base `TransportConfig` object to the 'mqtts://' + `provisioningDeviceHost`.] */
     /* Codes_SRS_NODE_PROVISIONING_MQTT_18_035: [ When connecting, `Mqtt` shall set `clientId` in the base `registrationRequest` object to the registrationId.] */
     /* Codes_SRS_NODE_PROVISIONING_MQTT_18_036: [ When connecting, `Mqtt` shall set the `clean` flag in the base `TransportConfig` object to true.] */
     /* Codes_SRS_NODE_PROVISIONING_MQTT_18_038: [ When connecting, `Mqtt` shall set the `username` in the base `TransportConfig` object to '<idScope>/registrations/<registrationId>/api-version=<apiVersion>&clientVersion=<UrlEncode<userAgent>>'.] */

--- a/provisioning/transport/mqtt/test/_mqtt_test.js
+++ b/provisioning/transport/mqtt/test/_mqtt_test.js
@@ -97,10 +97,10 @@ describe('Mqtt', function () {
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_037: [ When connecting, `Mqtt` shall pass in the `X509` certificate that was passed into `setAuthentication` in the base `TransportConfig` object.] */
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_001: [ The certificate and key passed as properties of the `auth` function shall be used to connect to the Device Provisioning Service.] */
           assert.strictEqual(config.x509, fakeX509);
-          /* Tests_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `host` in the base `TransportConfig` object to the `provisioningDeviceHost`.] */
-          assert.strictEqual(config.host, fakeHost);
+          /* Tests_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `uri` in the base `TransportConfig` object to the 'mqtts://' + `provisioningDeviceHost`.] */
+          assert.strictEqual(config.uri, 'mqtts://' + fakeHost);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_035: [ When connecting, `Mqtt` shall set `clientId` in the base `registrationRequest` object to the registrationId.] */
-          assert.strictEqual(config.deviceId, fakeRequest.registrationId);
+          assert.strictEqual(config.clientId, fakeRequest.registrationId);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_036: [ When connecting, `Mqtt` shall set the `clean` flag in the base `TransportConfig` object to true.] */
           assert.strictEqual(config.clean, true);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_038: [ When connecting, `Mqtt` shall set the `username` in the base `TransportConfig` object to '<idScope>/registrations/<registrationId>/api-version=<apiVersion>&clientVersion=<UrlEncode<userAgent>>'.] */


### PR DESCRIPTION
This is larger than I thought it would be.  

I did the following:
1) Removed the onInputMessage() and removeInputMessageHandler() functions, opting for on('inputMessage', function(inputName, msg)) instead.
2) Added enableInputMessages and disableInputMessages at the transport level.
3) Diverged code paths for sendEvent and sendOutputEvent.  A module can do both Event and OutputEvent.  Likewise, a device can do both.  
4) Diverged code paths for on('message') and on('inputMessage').
5) Added unit test coverage.

I have mixed feelings about this change.  It feels like I've added a lot of complexity that maybe isn't necessary. 