### PR TITLE
refactor(amqp): use AmqpMessage instead of Message in ReceiverLink

### DIFF
--- a/common/transport/amqp/src/amqp_cbs.ts
+++ b/common/transport/amqp/src/amqp_cbs.ts
@@ -136,15 +136,15 @@ export class ClaimsBasedSecurityAgent {
                       /*Codes_SRS_NODE_AMQP_CBS_16_020: [All responses shall be accepted.]*/
                       this._receiverLink.accept(msg);
                       for (let i = 0; i < this._putToken.outstandingPutTokens.length; i++) {
-                        if (msg.correlationId === this._putToken.outstandingPutTokens[i].correlationId) {
+                        if (msg.properties.correlationId === this._putToken.outstandingPutTokens[i].correlationId) {
                           const completedPutToken = this._putToken.outstandingPutTokens[i];
                           this._putToken.outstandingPutTokens.splice(i, 1);
                           if (completedPutToken.putTokenCallback) {
                             /*Codes_SRS_NODE_AMQP_CBS_16_019: [A put token response of 200 will invoke `putTokenCallback` with null parameters.]*/
                             let error = null;
-                            if (msg.properties.getValue('status-code') !== 200) {
+                            if (msg.applicationProperties['status-code'] !== 200) {
                               /*Codes_SRS_NODE_AMQP_CBS_16_018: [A put token response not equal to 200 will invoke `putTokenCallback` with an error object of UnauthorizedError.]*/
-                              error = new errors.UnauthorizedError(msg.properties.getValue('status-description'));
+                              error = new errors.UnauthorizedError(msg.applicationProperties['status-description']);
                             }
                             completedPutToken.putTokenCallback(error);
                           }

--- a/common/transport/amqp/test/_receiver_link_test.js
+++ b/common/transport/amqp/test/_receiver_link_test.js
@@ -58,7 +58,7 @@ describe('ReceiverLink', function() {
         var link = new ReceiverLink('link', {}, fakeAmqp10Client);
         link.attach(function() {
           link[testConfig.recvLinkMethod](fakeMessage, function() {
-            assert(fakeLinkObj[testConfig.amqp10LinkMethod].calledWith(fakeMessage.transportObj));
+            assert(fakeLinkObj[testConfig.amqp10LinkMethod].calledWith(fakeMessage));
             testCallback();
           });
         });
@@ -196,7 +196,7 @@ describe('ReceiverLink', function() {
         var link = new ReceiverLink('link', {}, fakeAmqp10Client);
         link.attach(function() {
           link.on('message', function(msg) {
-            assert.strictEqual(msg.transportObj, amqpMessage);
+            assert.strictEqual(msg, amqpMessage);
             testCallback();
           });
           fakeLinkObj.emit('message', amqpMessage);

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -61,7 +61,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
   private _d2cLink: SenderLink;
 
   private _c2dErrorListener: (err: Error) => void;
-  private _c2dMessageListener: (msg: Message) => void;
+  private _c2dMessageListener: (msg: AmqpMessage) => void;
 
   private _d2cErrorListener: (err: Error) => void;
 
@@ -124,7 +124,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
     };
 
     this._c2dMessageListener = (msg) => {
-      this.emit('message', msg);
+      this.emit('message', AmqpMessage.toMessage(msg));
     };
 
     this._d2cErrorListener = (err) => {
@@ -559,7 +559,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
   /*Codes_SRS_NODE_DEVICE_AMQP_16_013: [The ‘complete’ method shall call the ‘complete’ method of the C2D `ReceiverLink` object and pass it the message and the callback given as parameters.] */
   complete(message: Message, done?: (err?: Error, result?: results.MessageCompleted) => void): void {
     if (this._c2dLink) {
-      this._c2dLink.complete(message, done);
+      this._c2dLink.complete(message.transportObj, done);
     } else {
       done(new errors.DeviceMessageLockLostError('No active C2D link'));
     }
@@ -576,7 +576,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
   /*Codes_SRS_NODE_DEVICE_AMQP_16_014: [The ‘reject’ method shall call the ‘reject’ method of the C2D `ReceiverLink` object and pass it the message and the callback given as parameters.] */
   reject(message: Message, done?: (err?: Error, result?: results.MessageRejected) => void): void {
     if (this._c2dLink) {
-      this._c2dLink.reject(message, done);
+      this._c2dLink.reject(message.transportObj, done);
     } else {
       done(new errors.DeviceMessageLockLostError('No active C2D link'));
     }
@@ -593,7 +593,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
   /*Codes_SRS_NODE_DEVICE_AMQP_16_012: [The ‘abandon’ method shall call the ‘abandon’ method of the C2D `ReceiverLink` object and pass it the message and the callback given as parameters.] */
   abandon(message: Message, done?: (err?: Error, result?: results.MessageAbandoned) => void): void {
     if (this._c2dLink) {
-      this._c2dLink.abandon(message, done);
+      this._c2dLink.abandon(message.transportObj, done);
     } else {
       done(new errors.DeviceMessageLockLostError('No active C2D link'));
     }

--- a/device/transport/amqp/src/amqp_device_method_client.ts
+++ b/device/transport/amqp/src/amqp_device_method_client.ts
@@ -107,11 +107,11 @@ export class AmqpDeviceMethodClient extends EventEmitter {
                         this._receiverLink.on('message', (msg) => {
                           debug('got method request');
                           debug(JSON.stringify(msg, null, 2));
-                          const methodName = msg.properties.getValue(methodMessagePropertyKeys.methodName);
+                          const methodName = msg.applicationProperties[methodMessagePropertyKeys.methodName];
                           const methodRequest = {
                             methods: { methodName: methodName },
-                            requestId: msg.correlationId,
-                            body: msg.getData()
+                            requestId: msg.properties.correlationId,
+                            body: msg.body
                           };
 
                           debug(JSON.stringify(methodRequest, null, 2));

--- a/device/transport/amqp/test/_amqp_device_method_client_test.js
+++ b/device/transport/amqp/test/_amqp_device_method_client_test.js
@@ -3,7 +3,7 @@
 var assert = require('chai').assert;
 var sinon = require('sinon');
 var EventEmitter = require('events').EventEmitter;
-var Message = require('azure-iot-common').Message;
+var AmqpMessage = require('azure-iot-amqp-base').AmqpMessage;
 var errors = require('azure-iot-common').errors;
 var endpoint = require('azure-iot-common').endpoint;
 
@@ -55,9 +55,14 @@ describe('AmqpDeviceMethodClient', function () {
     it('saves the callback argument and calls it with a DeviceMethodRequest when a method request message is received', function(testCallback) {
       var fakeAmqpReceiver = new EventEmitter();
       var fakeMethodName = 'testMethod';
-      var fakeMethodRequest = new Message('payload');
-      fakeMethodRequest.correlationId = 'fakeCorrelationId';
-      fakeMethodRequest.properties.add('IoThub-methodname', fakeMethodName);
+      var fakeMethodRequest = new AmqpMessage();
+      fakeMethodRequest.body = 'payload';
+      fakeMethodRequest.properties = {
+        correlationId: 'fakeCorrelationId'
+      };
+      fakeMethodRequest.applicationProperties = {
+        'IoThub-methodname': fakeMethodName
+      };
       var fakeAmqpClient = {
         /*Tests_SRS_NODE_AMQP_DEVICE_METHOD_CLIENT_16_014: [The `AmqpDeviceMethodClient` object shall set 2 properties of any AMQP link that it create:
         - `com.microsoft:api-version` shall be set to the current API version in use.
@@ -86,8 +91,8 @@ describe('AmqpDeviceMethodClient', function () {
           - `body`: the payload of the message received, which is also the payload of the method request
           - `methods`: an object with a `methodName` property containing the name of the method that is being called, extracted from the incoming message's application property named `IoThub-methodname`.]*/
           assert.strictEqual(methodRequest.methods.methodName, fakeMethodName);
-          assert.strictEqual(methodRequest.requestId, fakeMethodRequest.correlationId);
-          assert.strictEqual(methodRequest.body, fakeMethodRequest.getData());
+          assert.strictEqual(methodRequest.requestId, fakeMethodRequest.properties.correlationId);
+          assert.strictEqual(methodRequest.body, fakeMethodRequest.body);
           testCallback();
         });
 
@@ -98,9 +103,14 @@ describe('AmqpDeviceMethodClient', function () {
     it('saves the callback for the method even though it is detached and works when attached', function (testCallback) {
       var fakeAmqpReceiver = new EventEmitter();
       var fakeMethodName = 'testMethod';
-      var fakeMethodRequest = new Message('payload');
-      fakeMethodRequest.correlationId = 'fakeCorrelationId';
-      fakeMethodRequest.properties.add('IoThub-methodname', fakeMethodName);
+      var fakeMethodRequest = new AmqpMessage();
+      fakeMethodRequest.body = 'payload';
+      fakeMethodRequest.properties = {
+        correlationId: 'fakeCorrelationId'
+      };
+      fakeMethodRequest.applicationProperties = {
+        'IoThub-methodname': fakeMethodName
+      };
       var fakeAmqpClient = {
         attachSenderLink: sinon.stub().callsArgWith(2, null, new EventEmitter()),
         attachReceiverLink: sinon.stub().callsArgWith(2, null, fakeAmqpReceiver)
@@ -113,8 +123,8 @@ describe('AmqpDeviceMethodClient', function () {
         - `body`: the payload of the message received, which is also the payload of the method request
         - `methods`: an object with a `methodName` property containing the name of the method that is being called, extracted from the incoming message's application property named `IoThub-methodname`.]*/
         assert.strictEqual(methodRequest.methods.methodName, fakeMethodName);
-        assert.strictEqual(methodRequest.requestId, fakeMethodRequest.correlationId);
-        assert.strictEqual(methodRequest.body, fakeMethodRequest.getData());
+        assert.strictEqual(methodRequest.requestId, fakeMethodRequest.properties.correlationId);
+        assert.strictEqual(methodRequest.body, fakeMethodRequest.body);
         testCallback();
       });
 
@@ -126,9 +136,14 @@ describe('AmqpDeviceMethodClient', function () {
     it('saves the callback for the method even though it is attaching and works when attached', function (testCallback) {
       var fakeAmqpReceiver = new EventEmitter();
       var fakeMethodName = 'testMethod';
-      var fakeMethodRequest = new Message('payload');
-      fakeMethodRequest.correlationId = 'fakeCorrelationId';
-      fakeMethodRequest.properties.add('IoThub-methodname', fakeMethodName);
+      var fakeMethodRequest = new AmqpMessage();
+      fakeMethodRequest.body = 'payload';
+      fakeMethodRequest.properties = {
+        correlationId: 'fakeCorrelationId'
+      };
+      fakeMethodRequest.applicationProperties = {
+        'IoThub-methodname': fakeMethodName
+      };
       var attachCallback;
       var fakeAmqpClient = {
         attachSenderLink: sinon.stub().callsFake(function (endpoint, linkOptions, callback) {
@@ -144,8 +159,8 @@ describe('AmqpDeviceMethodClient', function () {
       // now blocked in the 'attaching' state
       client.onDeviceMethod(fakeMethodName, function(methodRequest) {
         assert.strictEqual(methodRequest.methods.methodName, fakeMethodName);
-        assert.strictEqual(methodRequest.requestId, fakeMethodRequest.correlationId);
-        assert.strictEqual(methodRequest.body, fakeMethodRequest.getData());
+        assert.strictEqual(methodRequest.requestId, fakeMethodRequest.properties.correlationId);
+        assert.strictEqual(methodRequest.body, fakeMethodRequest.body);
         testCallback();
       });
 

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -8,6 +8,7 @@ var uuid = require('uuid');
 var assert = require('chai').assert;
 var sinon = require('sinon');
 
+var AmqpMessage = require('azure-iot-amqp-base').AmqpMessage;
 var Message = require('azure-iot-common').Message;
 var Amqp = require('../lib/amqp.js').Amqp;
 var AmqpTwinClient = require('../lib/amqp_twin_client.js').AmqpTwinClient;
@@ -25,7 +26,7 @@ describe('Amqp', function () {
   var fakeX509AuthenticationProvider = null;
 
   var testMessage = new Message();
-  testMessage._transportObj = {};
+  testMessage.transportObj = {};
   var testCallback = function () { };
   var configWithSSLOptions = { host: 'hub.host.name', deviceId: 'deviceId', x509: 'some SSL options' };
   var simpleSas = 'SharedAccessSignature sr=foo&sig=123&se=123';
@@ -982,7 +983,7 @@ describe('Amqp', function () {
           transport.on('message', function () {});
           transport.enableC2D(function () {
             transport.complete(testMessage, function () {
-              assert(receiver.complete.calledWith(testMessage));
+              assert(receiver.complete.calledWith(testMessage.transportObj));
               testCallback();
             });
           });
@@ -1004,7 +1005,7 @@ describe('Amqp', function () {
           transport.on('message', function () {});
           transport.enableC2D(function () {
             transport.reject(testMessage, function () {
-              assert(receiver.reject.calledWith(testMessage));
+              assert(receiver.reject.calledWith(testMessage.transportObj));
               testCallback();
             });
           });
@@ -1026,7 +1027,7 @@ describe('Amqp', function () {
           transport.on('message', function () {});
           transport.enableC2D(function () {
             transport.abandon(testMessage, function () {
-              assert(receiver.abandon.calledWith(testMessage));
+              assert(receiver.abandon.calledWith(testMessage.transportObj));
               testCallback();
             });
           });
@@ -1104,10 +1105,11 @@ describe('Amqp', function () {
       });
 
       it('forwards messages to the client once connected and authenticated', function (testCallback) {
-        var fakeMessage = new Message('fake');
+        var fakeMessage = new AmqpMessage();
 
         transport.on('message', function (msg) {
-          assert.strictEqual(msg, fakeMessage);
+          assert.instanceOf(msg, Message);
+          assert.strictEqual(msg.transportObj, fakeMessage);
           testCallback();
         });
 

--- a/device/transport/amqp/test/_amqp_twin_client_test.js
+++ b/device/transport/amqp/test/_amqp_twin_client_test.js
@@ -9,7 +9,7 @@ var sinon = require('sinon');
 
 var AmqpTwinClient = require('../lib/amqp_twin_client.js').AmqpTwinClient;
 var Amqp = require('../lib/amqp').Amqp;
-var Message = require('azure-iot-common').Message;
+var AmqpMessage = require('azure-iot-amqp-base').AmqpMessage;
 var errors = require('azure-iot-common').errors;
 var endpoint = require('azure-iot-common').endpoint;
 
@@ -202,8 +202,10 @@ describe('AmqpTwinClient', function () {
       });
 
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
-        data: new Buffer(JSON.stringify(fakeTwin))
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        },
+        body: new Buffer(JSON.stringify(fakeTwin))
       });
     });
   });
@@ -280,12 +282,15 @@ describe('AmqpTwinClient', function () {
         assert.strictEqual(fakeSenderLink.send.secondCall.args[0].messageAnnotations.operation, 'DELETE');
         testCallback();
       });
+
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        },
         messageAnnotations: {
           status: 200
         },
-        data: undefined
+        body: undefined
       });
     });
 
@@ -301,7 +306,9 @@ describe('AmqpTwinClient', function () {
       });
 
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -316,7 +323,9 @@ describe('AmqpTwinClient', function () {
         testCallback();
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -331,7 +340,9 @@ describe('AmqpTwinClient', function () {
         testCallback();
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -346,7 +357,9 @@ describe('AmqpTwinClient', function () {
         testCallback();
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -377,7 +390,9 @@ describe('AmqpTwinClient', function () {
         });
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -400,7 +415,9 @@ describe('AmqpTwinClient', function () {
         });
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -423,7 +440,9 @@ describe('AmqpTwinClient', function () {
         });
       });
       fakeReceiverLink.emit('message', {
-        correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+        properties: {
+          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+        },
         messageAnnotations: {
           status: 200
         },
@@ -445,15 +464,17 @@ describe('AmqpTwinClient', function () {
 
         twinClient.enableTwinDesiredPropertiesUpdates(function () {
           fakeReceiverLink.emit('message', {
-            data: JSON.stringify(desiredPropDelta)
+            body: JSON.stringify(desiredPropDelta)
           });
         });
         fakeReceiverLink.emit('message', {
-          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          properties: {
+            correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+          },
           messageAnnotations: {
             status: 200
           },
-          data: undefined
+          body: undefined
         });
       });
 
@@ -469,7 +490,9 @@ describe('AmqpTwinClient', function () {
           fakeReceiverLink.emit('message', {});
         });
         fakeReceiverLink.emit('message', {
-          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          properties: {
+            correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+          },
           messageAnnotations: {
             status: 200
           },
@@ -491,7 +514,9 @@ describe('AmqpTwinClient', function () {
           fakeSenderLink.emit('error', fakeError);
         });
         fakeReceiverLink.emit('message', {
-          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          properties: {
+            correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+          },
           messageAnnotations: {
             status: 200
           },
@@ -511,7 +536,9 @@ describe('AmqpTwinClient', function () {
           fakeReceiverLink.emit('error', fakeError);
         });
         fakeReceiverLink.emit('message', {
-          correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId,
+          properties: {
+            correlationId: fakeSenderLink.send.firstCall.args[0].properties.correlationId
+          },
           messageAnnotations: {
             status: 200
           },

--- a/provisioning/transport/amqp/src/amqp.ts
+++ b/provisioning/transport/amqp/src/amqp.ts
@@ -66,13 +66,13 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
     const amqpErrorListener = (err) => this._amqpStateMachine.handle('amqpError', err);
 
     const responseHandler = (msg) => {
-      debug('got message with correlationId: ' + msg.correlationId);
+      debug('got message with correlationId: ' + msg.properties.correlationId);
       /*Codes_SRS_NODE_PROVISIONING_AMQP_16_007: [The `registrationRequest` method shall call its callback with a `RegistrationResult` object parsed from the body of the response message which `correlationId` matches the `correlationId` of the request message sent on the sender link.]*/
       /*Codes_SRS_NODE_PROVISIONING_AMQP_16_017: [The `queryOperationStatus` method shall call its callback with a `RegistrationResult` object parsed from the body of the response message which `correlationId` matches the `correlationId` of the request message sent on the sender link.]*/
-      const registrationResult = JSON.parse(msg.data);
-      if (this._operations[msg.correlationId]) {
-        const requestCallback = this._operations[msg.correlationId];
-        delete this._operations[msg.correlationId];
+      const registrationResult = JSON.parse(msg.body);
+      if (this._operations[msg.properties.correlationId]) {
+        const requestCallback = this._operations[msg.properties.correlationId];
+        delete this._operations[msg.properties.correlationId];
         requestCallback(null, registrationResult, msg, this._config.pollingInterval);
       } else {
         debug('ignoring message with unknown correlationId');

--- a/provisioning/transport/amqp/test/_amqp_test.js
+++ b/provisioning/transport/amqp/test/_amqp_test.js
@@ -7,7 +7,7 @@
 var EventEmitter = require('events').EventEmitter;
 var assert = require('chai').assert;
 var sinon = require('sinon');
-var Message = require('azure-iot-common').Message;
+var AmqpMessage = require('azure-iot-amqp-base').AmqpMessage;
 var errors = require('azure-iot-common').errors;
 var ProvisioningDeviceConstants = require('azure-iot-provisioning-device').ProvisioningDeviceConstants;
 var Amqp = require('../lib/amqp.js').Amqp;
@@ -44,18 +44,24 @@ describe('Amqp', function () {
     fakeSenderLink.send = sinon.stub().callsFake((message, callback) => {
       var fakeResponse;
       if (message.applicationProperties['iotdps-operation-type'] === 'iotdps-register') {
-        fakeResponse = new Message(JSON.stringify({
+        fakeResponse = new AmqpMessage();
+        fakeResponse.body = JSON.stringify({
           operationId: 'fakeOpId',
           status: 'assigning'
-        }));
-        fakeResponse.correlationId = message.properties.correlationId;
+        });
+        fakeResponse.properties = {
+          correlationId: message.properties.correlationId
+        };
       } else {
-        fakeResponse = new Message(JSON.stringify({
+        fakeResponse = new AmqpMessage();
+        fakeResponse.body = JSON.stringify({
           operationId: message.applicationProperties['iotdps-operation-id'],
           status: 'assigned',
           registrationState: {}
-        }));
-        fakeResponse.correlationId = message.properties.correlationId;
+        });
+        fakeResponse.properties = {
+          correlationId: message.properties.correlationId
+        };
       }
 
       process.nextTick(() => {

--- a/service/devdoc/service_receiver_requirements.md
+++ b/service/devdoc/service_receiver_requirements.md
@@ -1,0 +1,59 @@
+# azure-iothub.ServiceReceiver requirements
+
+# Overview
+
+The `ServiceReceiver` object wraps over the `ReceiverLink` object and takes care of translating the AmqpMessage events into transport-agnostic Message events.
+
+# Responsibilities
+- `ServiceReceiver` hides the AMQP ReceiverLink object, to protect against refactoring in the lower AMQP layers
+- `ServiceReceiver` translates an AMQP message into a transport-agnostic message
+
+# Non-reponsibilities
+- `ServiceReceiver` is NOT responsible for maintaining/monitoring the state of the AMQP link
+- `ServiceReceiver` is NOT responsible for translating errors.
+
+# Public API
+```typescript
+class ServiceReceiver extends EventEmitter implements Client.ServiceReceiver {
+  constructor(receiver: ReceiverLink);
+  complete(message: Message, done?: Client.Callback<results.MessageCompleted>): void;
+  abandon(message: Message, done?: Client.Callback<results.MessageAbandoned>): void;
+  reject(message: Message, done?: Client.Callback<results.MessageRejected>): void;
+}
+```
+
+## constructor(receiver: ReceiverLink);
+
+**SRS_NODE_SERVICE_RECEIVER_16_001: [** The constructor shall subscribe to the `message` event of the `ReceiverLink` object passed as argument. **]**
+
+**SRS_NODE_SERVICE_RECEIVER_16_002: [** The constructor shall subscribe to the `error` event of the `ReceiverLink` object passed as argument. **]**
+
+## complete(message: Message, done?: Client.Callback<results.MessageCompleted>): void;
+
+**SRS_NODE_SERVICE_RECEIVER_16_003: [** The `complete` method shall call the `complete` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument. **]**
+
+## abandon(message: Message, done?: Client.Callback<results.MessageAbandoned>): void;
+
+**SRS_NODE_SERVICE_RECEIVER_16_004: [** The `abandon` method shall call the `abandon` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument. **]**
+
+## reject(message: Message, done?: Client.Callback<results.MessageRejected>): void;
+
+**SRS_NODE_SERVICE_RECEIVER_16_005: [** The `reject` method shall call the `reject` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument. **]**
+
+## events
+
+### message
+
+**SRS_NODE_SERVICE_RECEIVER_16_006: [** The `ServiceReceiver` class shall convert any `AmqpMessage` received with the `message` event from the `ReceiverLink` object into `Message` objects and emit a `message` event with that newly created `Message` object for argument. **]**
+
+### error
+
+**SRS_NODE_SERVICE_RECEIVER_16_007: [** Any error event received from the `ReceiverLink` object shall be forwarded as is. **]**
+
+## detach(callback: (err?: Error) => void): void;
+
+**SRS_NODE_SERVICE_RECEIVER_16_008: [** The `detach` method shall call the `detach` method on the `ReceiverLink` object and pass it its `callback` argument. **]**
+
+## forceDetach(err?: Error): void;
+
+**SRS_NODE_SERVICE_RECEIVER_16_009: [** The `forceDetach` method shall call the `forceDetach` method on the `ReceiverLink` object and pass it its `err` argument. **]**

--- a/service/package.json
+++ b/service/package.json
@@ -38,7 +38,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm run typings && npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm run typings && npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 97 --branches 93  --lines 97 --functions 93",
+    "check-cover": "istanbul check-coverage --statements 96 --branches 92  --lines 97 --functions 92",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js"
   },
   "engines": {

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -9,10 +9,11 @@ import * as machina from 'machina';
 import * as async from 'async';
 
 import { anHourFromNow, endpoint, errors, results, SharedAccessSignature, Message } from 'azure-iot-common';
-import { Amqp as Base, AmqpMessage, SenderLink, ReceiverLink } from 'azure-iot-amqp-base';
+import { Amqp as Base, AmqpMessage, SenderLink } from 'azure-iot-amqp-base';
 import { translateError } from './amqp_service_errors.js';
 import { Callback } from './interfaces';
 import { Client } from './client';
+import { ServiceReceiver } from './service_receiver.js';
 
 const UnauthorizedError = errors.UnauthorizedError;
 const DeviceNotFoundError = errors.DeviceNotFoundError;
@@ -63,11 +64,11 @@ export class Amqp extends EventEmitter implements Client.Transport {
   private _c2dErrorListener: (err: Error) => void;
 
   private _feedbackEndpoint: string = '/messages/serviceBound/feedback';
-  private _feedbackReceiver: ReceiverLink;
+  private _feedbackReceiver: ServiceReceiver;
   private _feedbackErrorListener: (err: Error) => void;
 
   private _fileNotificationEndpoint: string = '/messages/serviceBound/filenotifications';
-  private _fileNotificationReceiver: ReceiverLink;
+  private _fileNotificationReceiver: ServiceReceiver;
   private _fileNotificationErrorListener: (err: Error) => void;
 
   /**
@@ -264,7 +265,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
                 if (err) {
                   callback(err);
                 } else {
-                  this._feedbackReceiver = link;
+                  this._feedbackReceiver = new ServiceReceiver(link);
                   this._feedbackReceiver.on('error', this._feedbackErrorListener);
                   callback(null, this._feedbackReceiver);
                 }
@@ -281,7 +282,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
                 if (err) {
                   callback(err);
                 } else {
-                  this._fileNotificationReceiver = link;
+                  this._fileNotificationReceiver = new ServiceReceiver(link);
                   this._fileNotificationReceiver.on('error', this._fileNotificationErrorListener);
                   callback(null, this._fileNotificationReceiver);
                 }

--- a/service/src/service_receiver.ts
+++ b/service/src/service_receiver.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import { Message, results } from 'azure-iot-common';
+import { ReceiverLink, AmqpMessage } from 'azure-iot-amqp-base';
+import { EventEmitter } from 'events';
+import { Client } from './client';
+
+export class ServiceReceiver extends EventEmitter implements Client.ServiceReceiver {
+  private _receiver: ReceiverLink;
+
+  constructor(receiver: ReceiverLink) {
+    super();
+    this._receiver = receiver;
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_001: [The constructor shall subscribe to the `message` event of the `ReceiverLink` object passed as argument.]*/
+    this._receiver.on('message', (amqpMessage) => {
+      /*Codes_SRS_NODE_SERVICE_RECEIVER_16_006: [The `ServiceReceiver` class shall convert any `AmqpMessage` received with the `message` event from the `ReceiverLink` object into `Message` objects and emit a `message` event with that newly created `Message` object for argument.]*/
+      this.emit('message', AmqpMessage.toMessage(amqpMessage));
+    });
+
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_002: [The constructor shall subscribe to the `error` event of the `ReceiverLink` object passed as argument.]*/
+    this._receiver.on('error', (err) => {
+      /*Codes_SRS_NODE_SERVICE_RECEIVER_16_007: [Any error event received from the `ReceiverLink` object shall be forwarded as is.]*/
+      this.emit('error', err);
+    });
+  }
+
+  complete(message: Message, done?: Client.Callback<results.MessageCompleted>): void {
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_003: [The `complete` method shall call the `complete` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+    this._receiver.complete(message.transportObj, done);
+  }
+
+  abandon(message: Message, done?: Client.Callback<results.MessageAbandoned>): void {
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_004: [The `abandon` method shall call the `abandon` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+    this._receiver.abandon(message.transportObj, done);
+  }
+
+  reject(message: Message, done?: Client.Callback<results.MessageRejected>): void {
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_005: [The `reject` method shall call the `reject` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+    this._receiver.reject(message.transportObj, done);
+  }
+
+  detach(callback: (err?: Error) => void): void {
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_008: [The `detach` method shall call the `detach` method on the `ReceiverLink` object and pass it its `callback` argument.]*/
+    this._receiver.detach(callback);
+  }
+
+  forceDetach(err?: Error): void {
+    /*Codes_SRS_NODE_SERVICE_RECEIVER_16_009: [The `forceDetach` method shall call the `forceDetach` method on the `ReceiverLink` object and pass it its `err` argument.]*/
+    this._receiver.forceDetach(err);
+  }
+}

--- a/service/test/_client_common_testrun.js
+++ b/service/test/_client_common_testrun.js
@@ -7,7 +7,6 @@ var assert = require('chai').assert;
 var Client = require('../lib/client.js').Client;
 var errors = require('azure-iot-common').errors;
 var Message = require('azure-iot-common').Message;
-var AmqpReceiver = require('azure-iot-amqp-base').AmqpReceiver;
 
 function transportSpecificTests(opts) {
   describe('Client', function () {
@@ -97,7 +96,6 @@ function transportSpecificTests(opts) {
         testSubject.getFeedbackReceiver(function (err, receiver) {
             if (err) done(err);
             else {
-              assert.instanceOf(receiver, AmqpReceiver);
               done();
             }
         });
@@ -112,7 +110,6 @@ function transportSpecificTests(opts) {
         testSubject.getFileNotificationReceiver(function (err, receiver) {
           if (err) done(err);
           else {
-            assert.instanceOf(receiver, AmqpReceiver);
             done();
           }
         });

--- a/service/test/_service_receiver_test.js
+++ b/service/test/_service_receiver_test.js
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var Message = require('azure-iot-common').Message;
+var ServiceReceiver = require('../lib/service_receiver.js').ServiceReceiver;
+
+describe('ServiceReceiver', function () {
+  describe('constructor', function () {
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_001: [The constructor shall subscribe to the `message` event of the `ReceiverLink` object passed as argument.]*/
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_002: [The constructor shall subscribe to the `error` event of the `ReceiverLink` object passed as argument.]*/
+    it('subscribes to the \'message\' and \'error\' events of the ReceiverLink passed as argument', function () {
+      var fakeLink = new EventEmitter();
+      sinon.spy(fakeLink, 'on');
+      var receiver = new ServiceReceiver(fakeLink);
+      assert.isTrue(fakeLink.on.calledTwice);
+      assert.isTrue(fakeLink.on.calledWith('message'));
+      assert.isTrue(fakeLink.on.calledWith('error'));
+    });
+
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_006: [The `ServiceReceiver` class shall convert any `AmqpMessage` received with the `message` event from the `ReceiverLink` object into `Message` objects and emit a `message` event with that newly created `Message` object for argument.]*/
+    it('translates then forwards the message events', function(testCallback) {
+      var fakeLink = new EventEmitter();
+      sinon.spy(fakeLink, 'on');
+      var receiver = new ServiceReceiver(fakeLink);
+      var fakeAmqpMessage = {
+        body: 'foo'
+      };
+      receiver.on('message', function (msg) {
+        assert.instanceOf(msg, Message);
+        assert.strictEqual(msg.transportObj, fakeAmqpMessage);
+        testCallback();
+      });
+
+      fakeLink.emit('message', fakeAmqpMessage);
+    });
+
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_007: [Any error event received from the `ReceiverLink` object shall be forwarded as is.]*/
+    it('forwards the error events', function (testCallback) {
+      var fakeLink = new EventEmitter();
+      sinon.spy(fakeLink, 'on');
+      var receiver = new ServiceReceiver(fakeLink);
+      var fakeError = new Error('fake');
+      receiver.on('error', function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+
+      fakeLink.emit('error', fakeError);
+    });
+  });
+
+  /*Tests_SRS_NODE_SERVICE_RECEIVER_16_003: [The `complete` method shall call the `complete` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+  /*Tests_SRS_NODE_SERVICE_RECEIVER_16_004: [The `abandon` method shall call the `abandon` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+  /*Tests_SRS_NODE_SERVICE_RECEIVER_16_005: [The `reject` method shall call the `reject` method on the `ReceiverLink` object and pass it the `AmqpMessage` stored within the `transportObj` property of the `Message` object as well as the `done` callback passed as argument.]*/
+  ['abandon', 'complete', 'reject'].forEach(function (methodName) {
+    describe('#' + methodName, function () {
+      it('calls the \'' + methodName + '\' method on the link object and passes it the AmqpMessage and the callback', function () {
+        var fakeLink = new EventEmitter();
+        fakeLink[methodName] = sinon.stub().callsArg(1);
+        var receiver = new ServiceReceiver(fakeLink);
+        var fakeMessage = new Message();
+        fakeMessage.transportObj = {};
+        var fakeCallback = function () {};
+        receiver[methodName](fakeMessage, fakeCallback);
+        assert.isTrue(fakeLink[methodName].calledWith(fakeMessage.transportObj, fakeCallback));
+      });
+    });
+  });
+
+  describe('forceDetach', function () {
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_009: [The `forceDetach` method shall call the `forceDetach` method on the `ReceiverLink` object and pass it its `err` argument.]*/
+    it('calls forceDetach on the ReceiverLink with the error', function () {
+      var fakeLink = new EventEmitter();
+      fakeLink.forceDetach = sinon.stub();
+      var receiver = new ServiceReceiver(fakeLink);
+      var fakeError = new Error('fake');
+      receiver.forceDetach(fakeError);
+      assert.isTrue(fakeLink.forceDetach.calledWith(fakeError));
+    });
+  });
+
+  describe('detach', function () {
+    /*Tests_SRS_NODE_SERVICE_RECEIVER_16_008: [The `detach` method shall call the `detach` method on the `ReceiverLink` object and pass it its `callback` argument.]*/
+    it('calls detach on the ReceiverLink with the callback', function () {
+      var fakeLink = new EventEmitter();
+      fakeLink.detach = sinon.stub();
+      var receiver = new ServiceReceiver(fakeLink);
+      var fakeCallback = function () {};
+      receiver.detach(fakeCallback);
+      assert.isTrue(fakeLink.detach.calledWith(fakeCallback));
+    });
+  });
+});


### PR DESCRIPTION
# Description of the problem
in the AMQP transport `SenderLink` manipulates `AmqpMessage` objects but `ReceiverLink` operates with transport-agnostic `Message` object. this asymetry makes it complicated for features relying on `ReceiverLink` objects to inspect the message annotations etc. 

# Description of the solution
- Change `ReceiverLink` APIs to use the internal `AmqpMessage` type
- Change classes depending on `ReceiverLink` to do the `Message` translation themselves
- Create a `ServiceReceiver` class that wraps the `ReceiverLink` in the Service SDK so as not to break compatibility while isolating the `ReceiverLink` from the public API (and allow the changes)

*note: code coverage is going down in the service because there are areas of the generated javascript (From typescript) that are not tested at the beginning of the file - not something we care about*
