### PR TITLE
add edge module that can run in Docker, push CA down from app to TLS

### DIFF
--- a/build/build_parallel/config.json
+++ b/build/build_parallel/config.json
@@ -99,6 +99,12 @@
       "directory": "security/tpm"
     },
     {
+      "directory": "device/samples",
+      "skip_build": true,
+      "skip_test": true,
+      "skip_ci": true
+    },
+    {
       "directory": "device/edge-sample",
       "skip_build": true,
       "skip_test": true,

--- a/build/build_parallel/config.json
+++ b/build/build_parallel/config.json
@@ -97,6 +97,12 @@
     },
     {
       "directory": "security/tpm"
+    },
+    {
+      "directory": "device/edge-sample",
+      "skip_build": true,
+      "skip_test": true,
+      "skip_ci": true
     }
   ]
 }

--- a/common/core/src/authorization.ts
+++ b/common/core/src/authorization.ts
@@ -76,6 +76,10 @@ export interface TransportConfig {
    * IP address or internet name of the host machine working as a device or protocol gateway.  Used when communicating with Azure Edge devices.
    */
   gatewayHostName?: string;
+  /**
+   * Public certificate for the CA to use when validating the connection to the server
+  */
+  ca?: string;
 }
 
 /**
@@ -109,4 +113,5 @@ export interface X509 {
    * @private
    */
   keyFile?: string;
+
 }

--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -211,7 +211,8 @@ export class MqttBase extends EventEmitter {
       reconnectPeriod: 0,  // Client will handle reconnection at the higher level.
       /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_016: [The `connect` method shall configure the `keepalive` ping interval to 3 minutes by default since the Azure Load Balancer TCP Idle timeout default is 4 minutes.]*/
       keepalive: 180,
-      reschedulePings: false
+      reschedulePings: false,
+      ca: this._config.ca
     };
 
     if (this._config.sharedAccessSignature) {
@@ -273,5 +274,6 @@ export interface MqttBaseTransportConfig {
   username: string;
   clean?: boolean;
   uri: string;
+  ca?: string;
 }
 

--- a/device/edge-sample/Dockerfile
+++ b/device/edge-sample/Dockerfile
@@ -1,9 +1,7 @@
-FROM node:6
+FROM iot-hub-module-base:latest
 
-ARG EXE_DIR=.
+COPY edge_sample_module.js /APP
+WORKDIR /APP
+EXPOSE 9229
 
-WORKDIR /app
-
-COPY $EXE_DIR/ ./
-
-CMD ["node", "edge_sample_module.js"]
+CMD ["node", "--inspect", "edge_sample_module.js"]

--- a/device/edge-sample/Dockerfile
+++ b/device/edge-sample/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:6
+
+ARG EXE_DIR=.
+
+WORKDIR /app
+
+COPY $EXE_DIR/ ./
+
+CMD ["node", "edge_sample_module.js"]

--- a/device/edge-sample/Dockerfile.base
+++ b/device/edge-sample/Dockerfile.base
@@ -1,0 +1,6 @@
+FROM node:6-alpine
+
+COPY . /APP 
+WORKDIR /APP
+
+CMD ["node", "edge_sample_module.js"]

--- a/device/edge-sample/build_base_image.sh
+++ b/device/edge-sample/build_base_image.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+tar -czh . | docker build -t iot-hub-module-base:latest -f Dockerfile.base -
+exit $?
+
+

--- a/device/edge-sample/edge_sample_module.js
+++ b/device/edge-sample/edge_sample_module.js
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+var Client = require('azure-iot-device').Client;
+var Message = require('azure-iot-device').Message;
+var SharedAccessKeyAuthenticationProvider = require('azure-iot-device').SharedAccessKeyAuthenticationProvider;
+var fs = require('fs');
+
+var connectionString = process.env.EdgeHubConnectionString;
+
+var authProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(connectionString);
+authProvider.getDeviceCredentials(function(err, credentials) {
+  if (err) {
+    throw new Error('unexpected: getDeviceCredentials failure');
+  } else {
+    credentials.ca = fs.readFileSync(process.env.EdgeModuleCACertificateFile).toString('ascii');
+  }
+});
+var client = Client.fromAuthenticationProvider(authProvider, Protocol);
+
+client.on('error', function (err) {
+  console.error(err.message);
+});
+
+client.open(function (err) {
+  if (err) {
+    console.error('Could not connect: ' + err.message);
+  } else {
+    console.log('Client connected');
+
+    // Act on input messages to the module.
+    client.on('inputMessage', function (inputName, msg) {
+
+      client.complete(msg, printResultFor('completed'));
+
+      if (inputName === 'deviceControl') {
+        var messageBody = JSON.parse(msg.getBytes.toString('ascii'));
+        console.log('deviceControl message received: enable = ' + messageBody.enabled);
+      } else {
+        console.log('unknown inputMessage received on input ' + inputName);
+        console.log(msg.getBytes.toString('ascii'));
+      }
+    });
+  }
+});
+
+// Create a message and send it every two seconds
+setInterval(function () {
+  var temperature = 20 + (Math.random() * 10); // range: [20, 30]
+  var temperatureAlert = (temperature > 28) ? 'true' : 'false';
+  var data = JSON.stringify({ deviceId: 'myFirstDevice', temperature: temperature, temperatureAlert: temperatureAlert });
+  var message = new Message(data);
+  console.log('Sending message: ' + message.getData());
+  client.sendOutputEvent('temperature', message, printResultFor('sendOutputEvent'));
+}, 2000);
+
+// Helper function to print results in the console
+function printResultFor(op) {
+  return function printResult(err, res) {
+    if (err) console.log(op + ' error: ' + err.toString());
+    if (res) console.log(op + ' status: ' + res.constructor.name);
+  };
+}

--- a/device/edge-sample/edge_sample_module.js
+++ b/device/edge-sample/edge_sample_module.js
@@ -53,7 +53,7 @@ setInterval(function () {
   var temperatureAlert = (temperature > 28) ? 'true' : 'false';
   var data = JSON.stringify({ deviceId: 'myFirstDevice', temperature: temperature, temperatureAlert: temperatureAlert });
   var message = new Message(data);
-  console.log('Sending message: ' + message.getData());
+  console.log('XXX Sending message: ' + message.getData());
   client.sendOutputEvent('temperature', message, printResultFor('sendOutputEvent'));
 }, 2000);
 

--- a/device/edge-sample/package.json
+++ b/device/edge-sample/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "iot-edge-sample",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Sample module showing an Azure IoT Edge module in Node.js",
+  "author": "Microsoft Corp.",
+  "license": "MIT",
+  "dependencies": {
+    "azure-iot-device": "1.3.2",
+    "azure-iot-device-mqtt": "1.3.2"
+  },
+  "devDependencies": {
+    "jshint": "^2.9.2"
+  },
+  "scripts": {
+    "lint": "jshint --show-non-errors .",
+    "test": "npm -s run lint",
+    "build": "echo nothing to build"
+  }
+}

--- a/device/edge-sample/readme.md
+++ b/device/edge-sample/readme.md
@@ -1,0 +1,112 @@
+# Microsoft Azure IoT SDK for Node.js edge module sample
+
+This folder contains a set of Dockerfiles which can be used to crate an Azure IoT Edge module using node.js which can be deployed and run inside of an Azure IoT Edge environment
+
+## Implementation details
+
+Because our build system relies heavily on the npm link command, and because our current code isn't available in the npm registry just yet, it is necessary to jump through a few (hopefully small) hoops to make this container work.
+
+We do this by first building a base image which contains the azure-iot-sdk-node code from your current clone of the repository.  We do this once, assuming this code won't change.  If you do make changes to the various azure modules, or if you pull a new set of changes down, you will need to re-build the base image.  Otherwise, if the azure-iot-sdk-node code doesn't change, you can build it and forget about it.
+
+The base imagew is perfectly usable as an edge module.  You can tag this and push it to your Docker image registry and it should work as is.
+
+If you want to modify the edge_sample_module.js file, implement your own module, or use a remote debugger to debug the module, you can create an image on top of the base with the appropriate changes.  Details on this are below.
+
+## WARNINGS
+
+Do not use node:carbon images to build.  There are current incompatibilities with the Azure IoT SDK scripts and Node version 8.  Instead, use node:6 (currently at v6.12.3)
+
+These steps will not work on a Windows device.  You need to run these steps with a *nix host.  (Windows is expected to work by GA)
+
+## one-time setup
+
+If you haven't already done so, clone this repo and run build/dev-setup.sh.
+
+If you're running inside of a docker container, make sure to use node:6, and make sure to launch with -v to map the docker daemon socket into your container.  This is necessary to use the host docker instance to build an image from inside of your container.  You will also need to install Docker CE to get access to the docker CLI.
+
+```
+bertk@bertk-edge:~$ docker run -v /var/run/docker.sock:/var/run/docker.sock -it node:6 /bin/bash
+root@2e1c0a98438e:/azure-iot-sdk-node# curl -sSL https://get.docker.com/ | sh
+# Executing docker install script, commit: 02d7c3c
++ sh -c apt-get update -qq >/dev/null
+
+<-- snip -->
+```
+
+If you haven't already done so, clone the repo. 
+```
+root@88bd7a1e504f:/# git clone https://www.github.com/Azure/azure-iot-sdk-node
+Cloning into 'azure-iot-sdk-node'...
+
+<--snip-->
+```
+
+Switch to the appropriate branch (again, you may need to change the branch name if necessary)
+```
+root@88bd7a1e504f:/# cd azure-iot-sdk-node
+root@88bd7a1e504f:/azure-iot-sdk-node# git checkout module_docker
+Branch module_docker set up to track remote branch module_docker from origin.
+Switched to a new branch 'module_docker'
+```
+
+Then run build/dev-setup.sh to install and link all dependencies.
+```
+
+root@88bd7a1e504f:/azure-iot-sdk-node# build/dev-setup.sh
+
+-- Setting up build_parallel tool --
+iothub-buildparallel@0.0.1 /azure-iot-sdk-node/build/build_parallel
+
+<--snip-->
+```
+
+Finally, build the base image.  If you're inside of a Docker container at this point, you will be using the Docker daemon from the host.
+
+```
+root@aa2532356264:/azure-iot-sdk-node# cd device/edge-sample
+root@aa2532356264:/azure-iot-sdk-node/device/edge-sample# ./build_base_image.sh
+Sending build context to Docker daemon  52.27MB
+Step 1/4 : FROM node:6-alpine
+
+ <--snip-->
+
+Successfully tagged iot-hub-module-base:latest
+```
+
+## Iterating
+
+At this point, you have a base image and you can build images on top of it fairly quickly using the Dockerfile in this directory.
+
+```
+root@aa2532356264:/azure-iot-sdk-node/device/edge-sample# docker build -t my_module:latest .
+Sending build context to Docker daemon  5.147MB
+Step 1/5 : FROM iot-hub-module-base:latest
+ ---> 19707dcd8af1
+
+<-- snip -->
+
+Successfully built 9121691fc4f5
+Successfully tagged my_module:latest
+```
+
+This image can then be pushed to your docker image repository and referenced from the Azure Portal via Image URI as documented [here](https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-simulate-device-windows#deploy-a-module)
+
+## A note about debugging
+
+The Dockerfile referenced in the 'Iterating' step above exposes port 9229 and launches node with the --inspect flag.  There are two additional tricks here:
+1. If you want to bind port 9229 to the host, you can follow the instructions [here](https://dariuszparys.github.io/2017/12/04/Understanding-IoT-Edge-Module-createOptions/) with the following create options
+```
+{
+  "HostConfig": {
+    "PortBindings": {
+      "9229/tcp": [
+        {
+          "HostPort": "9229"
+        }
+      ]
+    }
+  }
+}
+```
+
+2. If your Dockerfile launches node with the --inspect-brk option, you _may_ need to set the Restart Policy on your module to "never" as documented [here](https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-simulate-device-windows#deploy-a-module)

--- a/device/samples/package.json
+++ b/device/samples/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "lint": "jshint --show-non-errors .",
-    "test": "npm -s run lint"
+    "test": "npm -s run lint",
+    "build": "echo nothing to build"
   }
 }

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -737,7 +737,8 @@ export class Mqtt extends EventEmitter implements Client.Transport {
         '&DeviceClientType=' + this._sdkVersionString,
       clientId: clientId,
       sharedAccessSignature: credentials.sharedAccessSignature,
-      x509: credentials.x509
+      x509: credentials.x509,
+      ca: credentials.ca
     };
     return baseConfig;
   }

--- a/readme-modules.md
+++ b/readme-modules.md
@@ -7,18 +7,11 @@ This code is not currently published on NPM.  In order to use these modules, you
 
 ## Current functionality.
 
-### Connection string support to connect to Azure IoT Edge instances
-
-To connect to an Edge instance, you need to use a module connection string which includes the ModuleId and GatewayHostName fields.  A correct connection string will look like this:
-HostName='hubName';DeviceId='deviceId';ModuleId='moduleId';SharedAccessKey='key';GatewayHostName='edgeIp'
-
-* 'hubName' is the name of your IoT hub, possibly in the azure-devices.net domain. (e.g. foo.azure-devices.net)
-* 'deviceId' is the name of your IoT Edge Device
-* 'moduleId' is the name of your Edge Module
-* 'key' is the shared access key for your module
-* 'edgeIp' is the IP address or DNS name for the machine hosting the edgeHub instance for the 'deviceId' device.  TCP port 8883 must be open on this device and be routed to the container hosting the edgeHub module.
-
-Currently, a connection string can be obtained using the Bootstrapping instructions below.
+### Recent updates:
+* It is no longer to extract the connection string from an existing module.
+* It is now possible to run and debug your module code inside of a docker container.
+* You no longer need to edit mqtt_base.ts to change the value of `reject_unauthorized`
+* Module methods are supported
 
 ### Module inputs
 
@@ -43,59 +36,35 @@ client.sendOutputEvent(outputName, msg);
 
 A module can act as a twin using the existing twin API.  The only difference between a device twin and a module twin is the connection string used to connect.
 
+### Module methods
+
+A module can also support methods using the existing method API.
+
 ## Sample Code.
 
-Sample code can be found in this branch in the [device/core/samples][samples] directory:
-simple_sample_module.js has an example of on('inputMessage') and sendOutputEvent functionality.
-simple_sample_module_twin.js has an example of module twin functionality.
+Some sample code can be found in this branch in the [device/core/samples](./device/core/samples/) directory:
+* simple_sample_module.js has an example of on('inputMessage') and sendOutputEvent functionality.
+* simple_sample_module_twin.js has an example of module twin functionality.
+* simple_sample_module_method.js has an example of module method functionality.
 
-## Bootstrapping
+Sample code for a docker container can be found in the [device/edge_sample](./device/edge-sample/) directory. Checkout the [readme](./device/edge-sample/readme.md) to learn more
 
-Since there are no Docker containers for Node.js Edge Modules, there is a convoluted set of steps necessary to bring a test module online.  As soon as a docker container is created (see roadmap below), these steps will not be necessary
+## Future changes
 
-To create a module for use with this SDK, we use the Azure portal to create one of the sample modules, and we steal the connection string from this module.  In order to make this work, we tell the edgeAgent that it doesn't need to restart this module.
-
-Assuming you have your Edge device created, you can use the Simulated Device instructions for creating a new module.  You can find the instruction [here][tutorial-simulate-device-windows].  Your Edge instance doesn't need to be running on Windows.  It can just as easily be running on Linux.  Use these [instructions][tutorial-simulate-device-linux] if it makes you more comfortable, though the gist is the same.
-
-You can find the relevant instructions at the [Deploy A Module][deploy-a-module] section.
-
-You should name your module as you wish, but use 'microsoft/azureiotedge-simulated-temperature-sensor:1.0-preview' in the Image URI field.  This is the Docker image that we use to start, but we will be quickly terminating it after we harvest its connection string.
-
-It is important that you set the 'Restart Policy' for your module to 'Never' so that the hubAgent doesn't attempt to automatically restart the module.
-
-Once the module is running, use the `docker exec` command to open a bash shell on the container and get value of the EdgeHubConnectionString variable.
-
+The samples all have a block of code at the top which retrieves a certificate from the container file system and passes it down to the transport.  For now, you should consider this to be boilerplate code.  The APIs used here will likely changed and replaced with different boilerplate code in a future drop:
 ```
-bertk@bertk-edge:~$ docker exec -it mod2 /bin/bash
-moduleuser@cfa838074c49:/app$ echo ${EdgeHubConnectionString}
-HostName=bertk-edge.azure-devices.net;GatewayHostName=bertk-edge;DeviceId=edge-03;ModuleId=mod2;SharedAccessKey=<redacted>
-moduleuser@cfa838074c49:/app$ exit
-exit
-bertk@bertk-edge:~$
+var authProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(connectionString);
+authProvider.getDeviceCredentials(function(err, credentials) {
+  if (err) {
+    throw new Error('unexpected: getDeviceCredentials failure');
+  } else {
+    credentials.ca = fs.readFileSync(process.env.EdgeModuleCACertificateFile).toString('ascii');
+  }
+});
+var client = Client.fromAuthenticationProvider(authProvider, Protocol);
 ```
 
-Once we have the connection string, we can stop that container using the `docker stop` command.  We are done with it and won't ever need to launch it again.
-
-You should then use the `docker ps` command to verify that the container is no longer running.
-
-One final temporary change is necessary to establish the connection between the node.js module and the Edge instance.  Inside mqtt_base.ts and mqtt_base.js is an MQTT configuration structure that contains the following value.
-```
-rejectUnauthorized: true,
-```
-
-It is temporarily necessary to set this value to false.  After you do this, you need to run `npm run build` to transpile the TypeScript to JavaScript.
-
-
-## Roadmap
-* NPM packages need to be published
-* Module methods needs to be implemented.
-* A way to use the correct x509 certificate when connecting needs to be created.  This will remove the need for the rejectUnauthorized change above.
-* A standard recipe for docker container that can host a module needs to be created.  This should alleviate the need for the bootstrapping steps above.
-
-
-[samples]: ./device/core/samples
 [tutorial-simulate-device-windows]: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-simulate-device-windows
 [tutorial-simulate-device-linux]: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-simulate-device-linux
 [deploy-a-module]: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-simulate-device-linux#deploy-a-module
-[mqtt-ts]: ./common/transport/mqtt/src/mqtt_base.ts
 


### PR DESCRIPTION
Adding a sample that shows a docker container running an Edge module written in Node.js.  

To make this work, I needed to use the edgeHub's CA certificate to establish TLS between the module and edgeHub.  I added some plumbing to take the CA from the application all the way down to mqtt_base.

My one question centers around _how_ I add the CA in edge_sample_module.js.  Getting the config object from the auth provider and editing it before we connect seems skeevy.  Should we have a setOptions property that we can use to pass the CA down.

A possible moment of confusion will come from the fact that we're using SAK authentication and passing an X509 cert down to the transport.  This is completely valid.  The X509 CA cert that we pass down is used to validate the TLS connection between the module and the edgeHub.

Another moment of confusion will come from the fact that node.js doesn't use the trusted cert store that the OS provides.  Instead, node.js has a hardcoded cert store, so we can't simply set the edgeHub CA cert in the trusted store because Node doesn't use that. :(
