### PR TITLE
feat(device): Add support for contentType and contentEncoding properties

### DIFF
--- a/common/core/src/message.ts
+++ b/common/core/src/message.ts
@@ -46,6 +46,16 @@ export class Message {
   ack: string;
 
   /**
+   * Content type property used to routes with the message body. Should be 'application/json'.
+   */
+  contentType: undefined | 'application/json';
+
+  /**
+   * Content encoding of the message body. can be 'utf-8', 'utf-16' or 'utf-32'.
+   */
+  contentEncoding: undefined | 'utf-8' | 'utf-16' | 'utf-32';
+
+  /**
    * @private
    */
   transportObj: any;
@@ -68,6 +78,8 @@ export class Message {
     this.lockToken = '';
     this.correlationId = '';
     this.userId = '';
+    this.contentEncoding = undefined;
+    this.contentType = undefined;
   }
 
   /**

--- a/common/transport/amqp/devdoc/amqp_message.md
+++ b/common/transport/amqp/devdoc/amqp_message.md
@@ -52,6 +52,10 @@ As this is an internal API, the input argument message can be assumed to be of t
 
 **SRS_NODE_IOTHUB_AMQPMSG_16_010: [** If the `message` argument has a `correlationId` property, the `properties` property of the `AmqpMessage` object shall have a property named `correlationId` with the same value. **]**
 
+**SRS_NODE_IOTHUB_AMQPMSG_16_014: [** If the `message` argument has a `contentEncoding` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentEncoding` with the same value. **]**
+
+**SRS_NODE_IOTHUB_AMQPMSG_16_015: [** If the `message` argument has a `contentType` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentType` with the same value. **]**
+
 **SRS_NODE_IOTHUB_AMQPMSG_16_012: [** If the `Message.correlationId` property is a UUID, the AMQP type of the `AmqpMessage.properties.correlationId` property shall be forced to UUID. **]**
 
 **SRS_NODE_IOTHUB_AMQPMSG_05_008: [** If needed, the created `AmqpMessage` object shall have a property of type `Object` named `applicationProperties`. **]**
@@ -80,6 +84,10 @@ The `toMessage` static method takes an AMQP message from the underlying library 
 **SRS_NODE_IOTHUB_AMQPMSG_16_005: [** The `toMessage` method shall set the `Message.to` property to the `AmqpMessage.properties.to` value if it is present. **]**
 
 **SRS_NODE_IOTHUB_AMQPMSG_16_006: [** The `toMessage` method shall set the `Message.expiryTimeUtc` property to the `AmqpMessage.properties.absoluteExpiryTime` value if it is present. **]**
+
+**SRS_NODE_IOTHUB_AMQPMSG_16_016: [** The `toMessage` method shall set the `Message.contentType` property to the `AmqpMessage.properties.contentType` value if it is present.  **]**
+
+**SRS_NODE_IOTHUB_AMQPMSG_16_017: [** The `toMessage` method shall set the `Message.contentEncoding` property to the `AmqpMessage.properties.contentEncoding` value if it is present.  **]**
 
 **SRS_NODE_IOTHUB_AMQPMSG_16_007: [** The `toMessage` method shall convert the user-defined `AmqpMessage.applicationProperties` to a `Properties` collection stored in `Message.applicationProperties`. **]**
 

--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -36,7 +36,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --functions 92 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/amqp/src/amqp_message.ts
+++ b/common/transport/amqp/src/amqp_message.ts
@@ -30,6 +30,8 @@ export class AmqpMessage {
     messageId?: string;
     correlationId?: string;
     reply_to?: string;
+    contentType?: undefined | 'application/json';
+    contentEncoding?: undefined | 'utf-8' | 'utf-16' | 'utf-32';
   };
 
   body: any;
@@ -73,6 +75,16 @@ export class AmqpMessage {
     if (message.correlationId) {
       /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_012: [If the `Message.correlationId` property is a UUID, the AMQP type of the `AmqpMessage.properties.correlationId` property shall be forced to UUID.]*/
       amqpMessage.properties.correlationId = encodeUuid(message.correlationId);
+    }
+
+    /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_014: [If the `message` argument has a `contentEncoding` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentEncoding` with the same value.]*/
+    if (message.contentEncoding) {
+      amqpMessage.properties.contentEncoding = message.contentEncoding;
+    }
+
+    /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_015: [If the `message` argument has a `contentType` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentType` with the same value.]*/
+    if (message.contentType) {
+      amqpMessage.properties.contentType = message.contentType;
     }
 
     /*Codes_SRS_NODE_IOTHUB_AMQPMSG_05_008: [If needed, the created AmqpMessage object shall have a property of type Object named applicationProperties.]*/
@@ -151,6 +163,16 @@ export class AmqpMessage {
       /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_003: [The `toMessage` method shall set the `Message.correlationId` property to the `AmqpMessage.properties.correlationId` value if it is present.]*/
       if (amqpMessage.properties.correlationId) {
         msg.correlationId = amqpMessage.properties.correlationId;
+      }
+
+      /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_016: [The `toMessage` method shall set the `Message.contentType` property to the `AmqpMessage.properties.contentType` value if it is present. ]*/
+      if (amqpMessage.properties.contentType) {
+        msg.contentType = amqpMessage.properties.contentType;
+      }
+
+      /*Codes_SRS_NODE_IOTHUB_AMQPMSG_16_017: [The `toMessage` method shall set the `Message.contentEncoding` property to the `AmqpMessage.properties.contentEncoding` value if it is present. ]*/
+      if (amqpMessage.properties.contentEncoding) {
+        msg.contentEncoding = amqpMessage.properties.contentEncoding;
       }
     }
 

--- a/common/transport/amqp/test/_amqp_message_test.js
+++ b/common/transport/amqp/test/_amqp_message_test.js
@@ -103,6 +103,22 @@ describe('AmqpMessage', function () {
       assert.notNestedProperty(amqpMessage, 'properties.messageId');
     });
 
+    /*Tests_SRS_NODE_IOTHUB_AMQPMSG_16_014: [If the `message` argument has a `contentEncoding` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentEncoding` with the same value.]*/
+    it('maps message.contentEncoding to amqpMessage.properties.contentEncoding', function () {
+      var message = new Message();
+      message.contentEncoding = 'utf-8';
+      var amqpMessage = AmqpMessage.fromMessage(message);
+      assert.equal(amqpMessage.properties.contentEncoding, message.contentEncoding);
+    });
+
+    /*Tests_SRS_NODE_IOTHUB_AMQPMSG_16_015: [If the `message` argument has a `contentType` property, the `properties` property of the `AmqpMessage` object shall have a property named `contentType` with the same value.]*/
+    it('maps message.contentType to amqpMessage.properties.contentType', function () {
+      var message = new Message();
+      message.contentType = 'utf-8';
+      var amqpMessage = AmqpMessage.fromMessage(message);
+      assert.equal(amqpMessage.properties.contentType, message.contentType);
+    });
+
     /*Tests_SRS_NODE_IOTHUB_AMQPMSG_05_008: [If needed, the created AmqpMessage object shall have a property of type Object named applicationProperties.]*/
     it('does not create amqpMessage.applicationProperties object if the are no application properties', function () {
       var amqpMessage = AmqpMessage.fromMessage(new Message());
@@ -246,6 +262,30 @@ describe('AmqpMessage', function () {
 
       var convertedMessage = AmqpMessage.toMessage(testAmqpMessage);
       assert.strictEqual(convertedMessage.expiryTimeUtc, testAmqpMessage.properties.absoluteExpiryTime);
+    });
+
+    /*Tests_SRS_NODE_IOTHUB_AMQPMSG_16_017: [The `toMessage` method shall set the `Message.contentEncoding` property to the `AmqpMessage.properties.contentEncoding` value if it is present. ]*/
+    it('sets the contentEncoding property', function() {
+      var testAmqpMessage = {
+        properties: {
+          contentEncoding: 'utf-8'
+        }
+      };
+
+      var convertedMessage = AmqpMessage.toMessage(testAmqpMessage);
+      assert.strictEqual(convertedMessage.contentEncoding, testAmqpMessage.properties.contentEncoding);
+    });
+
+    /*Tests_SRS_NODE_IOTHUB_AMQPMSG_16_016: [The `toMessage` method shall set the `Message.contentType` property to the `AmqpMessage.properties.contentType` value if it is present. ]*/
+    it('sets the contentType property', function() {
+      var testAmqpMessage = {
+        properties: {
+          contentType: 'utf-8'
+        }
+      };
+
+      var convertedMessage = AmqpMessage.toMessage(testAmqpMessage);
+      assert.strictEqual(convertedMessage.contentType, testAmqpMessage.properties.contentType);
     });
 
     /*Tests_SRS_NODE_IOTHUB_AMQPMSG_16_008: [The `toMessage` method shall set the `Message.ack` property to the `AmqpMessage.applicationProperties['iothub-ack']` value if it is present.]*/

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -91,6 +91,10 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_16_019: [** If the `message` object has a `ack` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Ack`. **]**
 
+**SRS_NODE_DEVICE_HTTP_16_037: [** If the `message` object has a `contentType` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contenttype`. **]**
+
+**SRS_NODE_DEVICE_HTTP_16_038: [** If the `message` object has a `contentEncoding` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contentencoding`. **]**
+
 ### sendEventBatch(messages, done)
 
 The sendEventBatch method sends a list of events to an IoT hub on behalf of the device indicated in the constructor argument.

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -33,7 +33,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 92 --branches 83 --lines 94 --functions 90"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 84 --lines 94 --functions 90"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -166,33 +166,43 @@ export class Http extends EventEmitter implements Client.Transport {
         }
 
         if (message.messageId) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_014: [If the `message` object has a `messageId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-MessageId`.]*/
-            httpHeaders['IoTHub-MessageId'] = message.messageId;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_014: [If the `message` object has a `messageId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-MessageId`.]*/
+          httpHeaders['IoTHub-MessageId'] = message.messageId;
         }
 
         if (message.correlationId) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_015: [If the `message` object has a `correlationId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-CorrelationId`.]*/
-            httpHeaders['IoTHub-CorrelationId'] = message.correlationId;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_015: [If the `message` object has a `correlationId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-CorrelationId`.]*/
+          httpHeaders['IoTHub-CorrelationId'] = message.correlationId;
         }
 
         if (message.userId) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_016: [If the `message` object has a `userId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-UserId`.]*/
-            httpHeaders['IoTHub-UserId'] = message.userId;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_016: [If the `message` object has a `userId` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-UserId`.]*/
+          httpHeaders['IoTHub-UserId'] = message.userId;
         }
 
         if (message.to) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_017: [If the `message` object has a `to` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-To`.]*/
-            httpHeaders['IoTHub-To'] = message.to;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_017: [If the `message` object has a `to` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-To`.]*/
+          httpHeaders['IoTHub-To'] = message.to;
         }
 
         if (message.expiryTimeUtc) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_018: [If the `message` object has a `expiryTimeUtc` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Expiry`.]*/
-            httpHeaders['IoTHub-Expiry'] = message.expiryTimeUtc;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_018: [If the `message` object has a `expiryTimeUtc` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Expiry`.]*/
+          httpHeaders['IoTHub-Expiry'] = message.expiryTimeUtc;
         }
 
         if (message.ack) {
-            /*Codes_SRS_NODE_DEVICE_HTTP_16_019: [If the `message` object has a `ack` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Ack`.]*/
-            httpHeaders['IoTHub-Ack'] = message.ack;
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_019: [If the `message` object has a `ack` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Ack`.]*/
+          httpHeaders['IoTHub-Ack'] = message.ack;
+        }
+
+        if (message.contentType) {
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_037: [If the `message` object has a `contentType` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contenttype`.]*/
+          httpHeaders['iothub-contenttype'] = message.contentType;
+        }
+
+        if (message.contentEncoding) {
+          /*Codes_SRS_NODE_DEVICE_HTTP_16_038: [If the `message` object has a `contentEncoding` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contentencoding`.]*/
+          httpHeaders['iothub-contentencoding'] = message.contentEncoding;
         }
 
         /*Codes_SRS_NODE_DEVICE_HTTP_16_013: [If using x509 authentication the `Authorization` header shall not be set and the x509 parameters shall instead be passed to the underlying transpoort.]*/

--- a/device/transport/http/test/_http_test.js
+++ b/device/transport/http/test/_http_test.js
@@ -196,13 +196,17 @@ describe('Http', function () {
     /*Tests_SRS_NODE_DEVICE_HTTP_16_017: [If the `message` object has a `to` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-To`.]*/
     /*Tests_SRS_NODE_DEVICE_HTTP_16_018: [If the `message` object has a `expiryTimeUtc` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Expiry`.]*/
     /*Tests_SRS_NODE_DEVICE_HTTP_16_019: [If the `message` object has a `ack` property, the value of the property shall be inserted in the headers of the HTTP request with the key `IoTHub-Ack`.]*/
+    /*Tests_SRS_NODE_DEVICE_HTTP_16_037: [If the `message` object has a `contentType` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contenttype`.]*/
+    /*Tests_SRS_NODE_DEVICE_HTTP_16_038: [If the `message` object has a `contentEncoding` property, the value of the property shall be inserted in the headers of the HTTP request with the key `iothub-contentencoding`.]*/
     [
       { messagePropertyName: 'messageId', headerName: 'IoTHub-MessageId', fakeValue: 'fakeMessageId' },
       { messagePropertyName: 'correlationId', headerName: 'IoTHub-CorrelationId', fakeValue: 'fakeCorrelationId' },
       { messagePropertyName: 'userId', headerName: 'IoTHub-UserId', fakeValue: 'fakeUserId' },
       { messagePropertyName: 'to', headerName: 'IoTHub-To', fakeValue: 'fakeTo' },
       { messagePropertyName: 'expiryTimeUtc', headerName: 'IoTHub-Expiry', fakeValue: new Date().toISOString() },
-      { messagePropertyName: 'ack', headerName: 'IoTHub-Ack', fakeValue: 'full' }
+      { messagePropertyName: 'ack', headerName: 'IoTHub-Ack', fakeValue: 'full' },
+      { messagePropertyName: 'contentType', headerName: 'iothub-contenttype', fakeValue: 'application/json' },
+      { messagePropertyName: 'contentEncoding', headerName: 'iothub-contentencoding', fakeValue: 'utf-8' }
     ].forEach(function(testConfig) {
       it('correctly populates the ' + testConfig.headerName + ' header if the message has a ' + testConfig.messagePropertyName + ' property', function() {
         transport._http = {

--- a/device/transport/mqtt/devdoc/mqtt_receiver_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_receiver_requirements.md
@@ -43,3 +43,7 @@ interface MethodMessage {
 **SRS_NODE_DEVICE_MQTT_RECEIVER_16_011: [** When a message is received, the receiver shall populate the generated `Message` object `correlationId` with the value of the property `$.cid` serialized in the topic, if present. **]**
 
 **SRS_NODE_DEVICE_MQTT_RECEIVER_16_012: [** When a message is received, the receiver shall populate the generated `Message` object `userId` with the value of the property `$.uid` serialized in the topic, if present. **]**
+
+**SRS_NODE_DEVICE_MQTT_RECEIVER_16_013: [** When a message is received, the receiver shall populate the generated `Message` object `contentType` with the value of the property `$.ct` serialized in the topic, if present. **]**
+
+**SRS_NODE_DEVICE_MQTT_RECEIVER_16_014: [** When a message is received, the receiver shall populate the generated `Message` object `contentEncoding` with the value of the property `$.ce` serialized in the topic, if present. **]**

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -121,6 +121,10 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_COMMON_MQTT_BASE_16_015: [** The `sendEvent` method shall serialize the `expiryTimeUtc` property of the message as a key-value pair on the topic with the key `$.exp`. **]**
 
+**SRS_NODE_DEVICE_MQTT_16_083: [** The `sendEvent` method shall serialize the `contentEncoding` property of the message as a key-value pair on the topic with the key `$.ce`. **]**
+
+**SRS_NODE_DEVICE_MQTT_16_084: [** The `sendEvent` method shall serialize the `contentType` property of the message as a key-value pair on the topic with the key `$.ct`. **]**
+
 **SRS_NODE_DEVICE_MQTT_16_023: [** The `sendEvent` method shall connect the Mqtt connection if it is disconnected. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_024: [** The `sendEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to establish a connection. **]**

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -35,7 +35,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 94 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -365,6 +365,10 @@ export class Mqtt extends EventEmitter implements Client.Transport {
       const expiryString = message.expiryTimeUtc instanceof Date ? message.expiryTimeUtc.toISOString() : message.expiryTimeUtc;
       systemProperties['$.exp'] = (expiryString || undefined);
     }
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_084: [The `sendEvent` method shall serialize the `contentType` property of the message as a key-value pair on the topic with the key `$.ct`.]*/
+    if (message.contentType) systemProperties['$.ct'] = <string>message.contentType;
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_083: [The `sendEvent` method shall serialize the `contentEncoding` property of the message as a key-value pair on the topic with the key `$.ce`.]*/
+    if (message.contentEncoding) systemProperties['$.ce'] = <string>message.contentEncoding;
 
     const sysPropString = querystring.stringify(systemProperties);
     topic += sysPropString;
@@ -709,6 +713,14 @@ export class Mqtt extends EventEmitter implements Client.Transport {
           case '$.uid':
             /*Codes_SRS_NODE_DEVICE_MQTT_RECEIVER_16_012: [When a message is received, the receiver shall populate the generated `Message` object `userId` with the value of the property `$.uid` serialized in the topic, if present.]*/
             msg.userId = v;
+            break;
+          case '$.ct':
+            /*Codes_SRS_NODE_DEVICE_MQTT_RECEIVER_16_013: [When a message is received, the receiver shall populate the generated `Message` object `contentType` with the value of the property `$.ct` serialized in the topic, if present.]*/
+            msg.contentType = <any>v;
+            break;
+          case '$.ce':
+            /*Codes_SRS_NODE_DEVICE_MQTT_RECEIVER_16_014: [When a message is received, the receiver shall populate the generated `Message` object `contentEncoding` with the value of the property `$.ce` serialized in the topic, if present.]*/
+            msg.contentEncoding = <any>v;
             break;
           default:
             /*Codes_SRS_NODE_DEVICE_MQTT_RECEIVER_16_007: [When a message is received, the receiver shall populate the generated `Message` object `properties` property with the user properties serialized in the topic.]*/

--- a/device/transport/mqtt/test/_mqtt_receiver_test.js
+++ b/device/transport/mqtt/test/_mqtt_receiver_test.js
@@ -148,6 +148,38 @@ describe('Mqtt as MqttReceiver', function () {
         });
       });
 
+      /*Tests_SRS_NODE_DEVICE_MQTT_RECEIVER_16_013: [When a message is received, the receiver shall populate the generated `Message` object `contentType` with the value of the property `$.ct` serialized in the topic, if present.]*/
+      it('populates Message.contentType from the topic', function (done) {
+        var contentType = 'application/json';
+        var receiver = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);
+        receiver.connect(function () {
+          receiver.on('message', function (msg) {
+            assert.equal(msg.constructor.name, 'Message');
+            assert.equal(msg.contentType, contentType);
+            done();
+          });
+
+          fakeMqttBase.emit('message', 'devices/foo/messages/devicebound/%24.ct=' + encodeURIComponent(contentType));
+        });
+      });
+
+      /*Tests_SRS_NODE_DEVICE_MQTT_RECEIVER_16_014: [When a message is received, the receiver shall populate the generated `Message` object `contentEncoding` with the value of the property `$.ce` serialized in the topic, if present.]*/
+      it('populates Message.contentEncoding from the topic', function (done) {
+        var contentEncoding = 'utf-8';
+        var receiver = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);
+        receiver.connect(function () {
+          receiver.on('message', function (msg) {
+            assert.equal(msg.constructor.name, 'Message');
+            assert.equal(msg.contentEncoding, contentEncoding);
+            done();
+          });
+
+          fakeMqttBase.emit('message', 'devices/foo/messages/devicebound/%24.ce=' + contentEncoding);
+        });
+      });
+
+
+
 
       it('creates a message even if the properties topic segment is empty', function(done) {
         var receiver = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -237,7 +237,11 @@ describe('Mqtt', function () {
       { propName: 'to', serializedAs: '%24.to', fakeValue: 'fakeTo' },
       /*Tests_SRS_NODE_COMMON_MQTT_BASE_16_015: [The `sendEvent` method shall serialize the `expiryTimeUtc` property of the message as a key-value pair on the topic with the key `$.exp`.]*/
       { propName: 'expiryTimeUtc', serializedAs: '%24.exp', fakeValue: 'fakeDateString' },
-      { propName: 'expiryTimeUtc', serializedAs: '%24.exp', fakeValue: new Date(1970, 1, 1), fakeSerializedValue: encodeURIComponent(new Date(1970, 1, 1).toISOString()) }
+      { propName: 'expiryTimeUtc', serializedAs: '%24.exp', fakeValue: new Date(1970, 1, 1), fakeSerializedValue: encodeURIComponent(new Date(1970, 1, 1).toISOString()) },
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_083: [The `sendEvent` method shall serialize the `contentEncoding` property of the message as a key-value pair on the topic with the key `$.ce`.]*/
+      { propName: 'contentEncoding', serializedAs: '%24.ce', fakeValue: 'utf-8' },
+      /*Tests_SRS_NODE_DEVICE_MQTT_16_084: [The `sendEvent` method shall serialize the `contentType` property of the message as a key-value pair on the topic with the key `$.ct`.]*/
+      { propName: 'contentType', serializedAs: '%24.ct', fakeValue: 'application/json', fakeSerializedValue: encodeURIComponent('application/json') }
     ].forEach(function(testProperty) {
       it('serializes Message.' + testProperty.propName + ' as ' + decodeURIComponent(testProperty.serializedAs) + ' on the topic', function(done) {
         var testMessage = new Message('message');


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#219 

# Description of the problem
Routing messages using the content of the body requires the ability for users to set the `contentType` and `contentEncoding` properties on the `Message`object. These properties have not been implemented nor has the code to encode them in different protocols

# Description of the solution
- Add `contentType` and `contentEncoding` properties to the `Message`
- Translate them into the appropriate formats for MQTT, AMQP and HTTP
