### PR TITLE
fix(amqp,twin): properly handle errors coming in twin responses.

### DIFF
--- a/common/core/src/errors.ts
+++ b/common/core/src/errors.ts
@@ -417,6 +417,21 @@ export class TwinDetachedError extends Error {
 }
 
 /**
+ * Generic error thrown when a twin request fails with an unknown error code.
+ *
+ * @augments {Error}
+ */
+export class TwinRequestError extends Error {
+  transportError: any;
+  constructor(message?: string) {
+    super(message);
+    this.name = 'TwinRequestError';
+    this.message = message;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
  * Error thrown when any operation (local or remote) is cancelled
  *
  * @augments {Error}

--- a/common/core/src/retry_error_filter.ts
+++ b/common/core/src/retry_error_filter.ts
@@ -34,6 +34,7 @@ export interface ErrorFilter {
   BadDeviceResponseError: boolean;
   GatewayTimeoutError: boolean; // ??
   DeviceTimeoutError: boolean;// ??
+  TwinRequestError?: boolean;
 }
 
 /* tslint:disable:variable-name */
@@ -67,5 +68,6 @@ export class DefaultErrorFilter implements ErrorFilter {
   BadDeviceResponseError: boolean = false;
   GatewayTimeoutError: boolean = false; // ??
   DeviceTimeoutError: boolean = false;// ??
+  TwinRequestError?: boolean = false;
 }
 /* tslint:enable:variable-name */

--- a/common/core/test/_errors_test.js
+++ b/common/core/test/_errors_test.js
@@ -38,6 +38,7 @@ describe('errors', function() {
     errors.CloudToDeviceDetachedError,
     errors.DeviceMethodsDetachedError,
     errors.TwinDetachedError,
+    errors.TwinRequestError,
     errors.OperationCancelledError,
     errors.DeviceRegistrationFailedError,
     errors.SecurityDeviceError

--- a/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
+++ b/device/transport/amqp/devdoc/amqp_twin_client_requirements.md
@@ -41,6 +41,8 @@ class AmqpTwinClient extends EventEmitter {
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_014: [** The `getTwin` method shall parse the body of the received message and call its callback with a `null` error object and the parsed object as a result. **]**
 
+**SRS_NODE_DEVICE_AMQP_TWIN_16_038: [** The `getTwin` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the `status` message annotation is `> 300`. **]**
+
 ### updateTwinReportedProperties(patch: any, callback: (err?: Error) => void): void;
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_015: [** The `updateTwinReportedProperties` method shall attach the sender link if it's not already attached. **]**
@@ -61,9 +63,9 @@ class AmqpTwinClient extends EventEmitter {
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_021: [** The `updateTwinReportedProperties` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
-**SRS_NODE_DEVICE_AMQP_TWIN_16_022: [** The `updateTwinReportedProperties` method shall call its callback with no argument when a response is received **]**
-// TODO: we need to check error codes!
+**SRS_NODE_DEVICE_AMQP_TWIN_16_022: [** The `updateTwinReportedProperties` method shall call its callback with no argument when a response is received and the `status` message annotation code is `>= 200` or `< 300` **]**
 
+**SRS_NODE_DEVICE_AMQP_TWIN_16_039: [** The `updateTwinReportedProperties` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the `status` message annotation is `> 300`. **]**
 
 ### enableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
 
@@ -86,7 +88,8 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_029: [** The `enableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_030: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
-// TODO: we need to check error codes!
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_040: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the status message annotation is `> 300`. **]**
 
 ### disableTwinDesiredPropertiesUpdates(callback: (err?: Error) => void): void;
 
@@ -103,7 +106,8 @@ class AmqpTwinClient extends EventEmitter {
 **SRS_NODE_DEVICE_AMQP_TWIN_16_034: [** The `disableTwinDesiredPropertiesUpdates` method shall monitor `Message` objects on the `ReceiverLink.on('message')` handler until a message with the same `correlationId` as the one that was sent is received. **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_035: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with no argument when a response is received **]**
-// TODO: we need to check error codes!
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_041: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the status message annotation is `> 300`. **]**
 
 ### detach(callback: (err?: Error) => void): void;
 
@@ -141,3 +145,32 @@ class AmqpTwinClient extends EventEmitter {
       } **]**
 
 **SRS_NODE_DEVICE_AMQP_TWIN_16_036: [** The same correlationId shall be used for both the sender and receiver links. **]**
+
+### Errors
+
+There are 2 failure modes for Twin requests:
+- the initial request is rejected: in that case, the error shall be translated using the usual `azure-iot-amqp-base.translateError` function
+- the request is accepted but contains an invalid payload and leads to an error: in that case, the response sent on the receiver link will have a status code > 300 and shall be translated using **SRS_NODE_DEVICE_AMQP_TWIN_16_037**:
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_037: [** The responses containing errors received on the receiver link shall be translated according to the following table:
+| statusCode | ErrorType               |
+| ---------- | ------------------------|
+| 400        | FormatError             |
+| 401        | UnauthorizedError       |
+| 403        | InvalidOperationError   |
+| 404        | DeviceNotFoundError     |
+| 429        | ThrottlingError         |
+| 500        | InternalServerError     |
+| 503        | ServiceUnavailableError |
+| 504        | TimeoutError            |
+| others     | TwinRequestError        |
+**]**
+
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_038: [** The `getTwin` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the `status` message annotation is `> 300`. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_039: [** The `updateTwinReportedProperties` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the `status` message annotation is `> 300`. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_040: [** The `enableTwinDesiredPropertiesUpdates` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the status message annotation is `> 300`. **]**
+
+**SRS_NODE_DEVICE_AMQP_TWIN_16_041: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with a translated error according to the table described in **SRS_NODE_DEVICE_AMQP_TWIN_16_037** if the status message annotation is `> 300`. **]**

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 93 --branches 83  --lines 94 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 83  --lines 94 --functions 92"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#206
# Description of the problem
In the AMQP implementation of the Twin, some errors come back as dispositions when the request message is sent, and others come as response messages with a status code set to something else than 2xx. with the latest refactoring of twin we weren't translating those

# Description of the solution
Added a new function to translate errors coming as responses, as well as a new error type just in case the service later adds more errors.
