### PR TITLE
Adjust MQTT QoS level of C2D subscriptions to 1

### DIFF
--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -240,7 +240,9 @@ export class MqttBase extends EventEmitter {
     const offlineCallback = createErrorCallback('offline');
     const disconnectCallback = createErrorCallback('disconnect');
     const messageCallback = (topic, payload) => {
-      this.emit('message', topic, payload);
+      process.nextTick(() => {
+        this.emit('message', topic, payload);
+      });
     };
 
     this._mqttClient = this.mqttprovider.connect(uri, options);

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -248,7 +248,7 @@ The `updateTwinReportedProperties` method is used to retrieve the device twin.
 
 **SRS_NODE_DEVICE_MQTT_16_048: [** `enableC2D` shall calls its callback with an `Error` object if it fails to connect. **]**
 
-**SRS_NODE_DEVICE_MQTT_16_049: [** `enableC2D` shall subscribe to the MQTT topic for messages. **]**
+**SRS_NODE_DEVICE_MQTT_16_049: [** `enableC2D` shall subscribe to the MQTT topic for messages with a QoS of `1`. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_050: [** `enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received. **]**
 

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -275,10 +275,10 @@ export class Mqtt extends EventEmitter implements Client.Transport {
             });
           },
           enableC2D: (callback) => {
-            this._setupSubscription(this._topics.message, callback);
+            this._setupSubscription(this._topics.message, 1, callback);
           },
           enableMethods: (callback) => {
-            this._setupSubscription(this._topics.method, callback);
+            this._setupSubscription(this._topics.method, 0, callback);
           },
           disableC2D: (callback) => {
             this._removeSubscription(this._topics.message, callback);
@@ -623,13 +623,13 @@ export class Mqtt extends EventEmitter implements Client.Transport {
 
   }
 
-  private _setupSubscription(topic: TopicDescription, callback: (err?: Error) => void): void {
+  private _setupSubscription(topic: TopicDescription, qos: 0 | 1, callback: (err?: Error) => void): void {
     debug('subscribe: ' + JSON.stringify(topic));
     topic.subscribeInProgress = true;
 
-    /*Codes_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages.]*/
+    /*Codes_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages with a QoS of `1`.]*/
     /*Codes_SRS_NODE_DEVICE_MQTT_16_040: [`enableMethods` shall subscribe to the MQTT topic for direct methods.]*/
-    this._mqtt.subscribe(topic.name, { qos: 0 }, (err) => {
+    this._mqtt.subscribe(topic.name, { qos: qos }, (err) => {
       topic.subscribeInProgress = false;
       topic.subscribed = true;
       /*Codes_SRS_NODE_DEVICE_MQTT_16_050: [`enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received.]*/

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -677,11 +677,13 @@ describe('Mqtt', function () {
   [
     {
       methodName: 'enableC2D',
-      topicName: 'devices/deviceId/messages/devicebound/#'
+      topicName: 'devices/deviceId/messages/devicebound/#',
+      qos: 1
      },
      {
       methodName: 'enableMethods',
-      topicName: '$iothub/methods/POST/#'
+      topicName: '$iothub/methods/POST/#',
+      qos: 0
      }
   ].forEach(function (testConfig) {
     describe('#' + testConfig.methodName, function () {
@@ -695,9 +697,10 @@ describe('Mqtt', function () {
           /*Tests_SRS_NODE_DEVICE_MQTT_16_050: [`enableC2D` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
           /*Tests_SRS_NODE_DEVICE_MQTT_16_051: [`enableMethods` shall call its callback with no arguments when the `SUBACK` packet is received.]*/
           assert.isUndefined(err);
-          /*Tests_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages.]*/
+          /*Tests_SRS_NODE_DEVICE_MQTT_16_049: [`enableC2D` shall subscribe to the MQTT topic for messages with a QoS of `1`.]*/
           /*Tests_SRS_NODE_DEVICE_MQTT_16_040: [`enableMethods` shall subscribe to the MQTT topic for direct methods.]*/
           assert.isTrue(fakeMqttBase.subscribe.calledWith(testConfig.topicName));
+          assert.strictEqual(fakeMqttBase.subscribe.firstCall.args[1].qos, testConfig.qos);
           testCallback();
         });
       });


### PR DESCRIPTION
# Description of the problem
QoS of subscriptions for c2d messages is currently set to 0.

# Description of the solution
set it to 1