### PR TITLE
Make popper

### DIFF
--- a/build/tools/popper.js
+++ b/build/tools/popper.js
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var fs = require('fs');
+var pem = require('pem');
+var chalk = require('chalk');
+
+var argv = require('yargs')
+           .usage('Usage: $0  --ca <root cert pem file name> --key <root cert key pem file name> --nonce <nonce>')
+           .demand(['ca', 'key', 'nonce'])
+           .describe('ca', 'pem file name of the root')
+           .describe('key', 'pem file name of the key')
+           .describe('nonce', 'common name will be used as the file name')
+           .argv;
+
+
+var CARootCert = fs.readFileSync(argv.ca, 'utf-8').toString();
+var CARootCertKey = fs.readFileSync(argv.key, 'utf-8').toString();
+
+function createCACertDevice(nonce, done) {
+
+  pem.createCSR( { commonName: nonce }, function (err, csrResult) {
+    if (err) {
+      done(err);
+    } else {
+      pem.createCertificate(
+        {
+          csr: csrResult.csr,
+          clientKey: csrResult.clientKey,
+          serviceKey: CARootCertKey,
+          serviceCertificate: CARootCert,
+          serial: Math.floor(Math.random() * 1000000000),
+          days: 1
+        }, function (err, certConstructionResult) {
+          if (err) {
+            done(err);
+          } else {
+            fs.writeFileSync(nonce + '-key.pem', certConstructionResult.certificate);
+            done();
+          }
+      })
+    }
+  })
+}
+
+createCACertDevice(argv.nonce, (err) => {
+  if (err) {
+    console.log('Error in generation: ' + err);
+  }
+});
+

--- a/build/tools/popper.js
+++ b/build/tools/popper.js
@@ -8,7 +8,7 @@ var pem = require('pem');
 var chalk = require('chalk');
 
 var argv = require('yargs')
-           .usage('Usage: $0  --ca <root cert pem file name> --key <root cert key pem file name> --nonce <nonce>')
+           .usage('Usage: $0  --ca <root cert pem file name> --key <root cert key pem file name> --nonce <nonce>  NOT FOR PRODUCTION USE!!!!')
            .demand(['ca', 'key', 'nonce'])
            .describe('ca', 'pem file name of the root')
            .describe('key', 'pem file name of the key')
@@ -37,7 +37,7 @@ function createCACertDevice(nonce, done) {
           if (err) {
             done(err);
           } else {
-            fs.writeFileSync(nonce + '-key.pem', certConstructionResult.certificate);
+            fs.writeFileSync(nonce + '-cert.pem', certConstructionResult.certificate);
             done();
           }
       })


### PR DESCRIPTION
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
It's a bit of a pain to do proof of possession for x509 certs.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 
Very simple app not for use in production that will use supplied signing cert and private key (in pem files) and create a signed cert with the supplied nonce as the subject.