### PR TITLE
Fix handling error during disconnect.

### DIFF
--- a/device/core/src/client.ts
+++ b/device/core/src/client.ts
@@ -602,13 +602,11 @@ export class Client extends EventEmitter {
       safeCallback(closeCallback, err, result);
     };
 
-    this._disableC2D(() => {
-      /*Codes_SRS_NODE_DEVICE_CLIENT_16_001: [The `close` function shall call the transport's `disconnect` function if it exists.]*/
-      this._transport.disconnect((disconnectError, disconnectResult) => {
-        /*Codes_SRS_NODE_DEVICE_CLIENT_16_046: [The `close` method shall remove the listener that has been attached to the transport `disconnect` event.]*/
-        this._transport.removeListener('disconnect', this._disconnectHandler);
-        onDisconnected(disconnectError, disconnectResult);
-      });
+    /*Codes_SRS_NODE_DEVICE_CLIENT_16_046: [The `close` method shall remove the listener that has been attached to the transport `disconnect` event.]*/
+    this._transport.removeListener('disconnect', this._disconnectHandler);
+    /*Codes_SRS_NODE_DEVICE_CLIENT_16_001: [The `close` function shall call the transport's `disconnect` function if it exists.]*/
+    this._transport.disconnect((disconnectError, disconnectResult) => {
+      onDisconnected(disconnectError, disconnectResult);
     });
   }
 


### PR DESCRIPTION

<!-- Please be as precise as possible: what issue you experienced, how often... -->
If an error occurs during shutdown of the protocol transport, the disconnect handler will be invoked.  This handler will then proceed to try to reconnect.  This is undesirable.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Move the removal of the disconnnect handler before the actual transport protocol disconnect.  In addition, do not attempt to disable the c2d messages.  This conforms to how other SDK's handling subscribed topics.