### PR TITLE
fix(amqp) disconnection logic was causing "cannot read property write of null" errors

### DIFF
--- a/common/transport/amqp/src/amqp.ts
+++ b/common/transport/amqp/src/amqp.ts
@@ -107,7 +107,12 @@ export class Amqp {
     };
 
     this._amqp.on('disconnected', () => {
-      this._fsm.handle('amqpDisconnected');
+      // deferring this is necessary because in some instances
+      // the amqp10 library might want to send a close frame - and we don't want
+      // to trigger anything (especially not reconnection) before it has done so.
+      process.nextTick(() => {
+        this._fsm.handle('amqpDisconnected');
+      });
     });
 
     this._fsm = new machina.Fsm({

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -244,3 +244,11 @@ This method is deprecated. The `AmqpReceiver` object and pattern is going away a
 **SRS_NODE_DEVICE_AMQP_16_078: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback with and error if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` fails. **]**
 
 **SRS_NODE_DEVICE_AMQP_16_079: [** The `disableTwinDesiredPropertiesUpdates` method shall call its callback no arguments if the call to `AmqpTwinClient.disableTwinDesiredPropertiesUpdates` succeeds. **]**
+
+### Errors
+
+**SRS_NODE_DEVICE_AMQP_16_080: [** if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is disconnected, the call shall be ignored. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_081: [** if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is connecting or authenticating, the connection shall be stopped and an `disconnect` event shall be emitted with the error translated to a transport-agnostic error. **]**
+
+**SRS_NODE_DEVICE_AMQP_16_082: [** if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is connected, the connection shall be disconnected and an `disconnect` event shall be emitted with the error translated to a transport-agnostic error. **]**

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 93 --branches 83  --lines 94 --functions 92"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 84  --lines 95 --functions 93"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -92,7 +92,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
     this._amqp = baseClient || new BaseAmqpClient(false, 'azure-iot-device/' + packageJson.version);
     this._amqp.setDisconnectHandler((err) => {
       debug('disconnected event handler: ' + (err ? err.toString() : 'no error'));
-      this._fsm.handle('disconnectError', err, () => {
+      this._fsm.handle('amqpConnectionClosed', err, () => {
         this.emit('disconnect', getTranslatedError(err, 'AMQP client disconnected'));
       });
     });
@@ -237,9 +237,9 @@ export class Amqp extends EventEmitter implements Client.Transport {
             // if we are disconnected the C2D link is already detached.
             callback();
           },
-          disconnectError: (err, callback) => {
+          amqpConnectionClosed: (err, callback) => {
             /*Codes_SRS_NODE_DEVICE_AMQP_16_080: [if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is disconnected, the call shall be ignored.]*/
-            debug('ignoring disconnectError because already disconnected: ' + err.toString());
+            debug('ignoring amqpConnectionClosed because already disconnected: ' + err.toString());
             callback();
           }
         },
@@ -270,7 +270,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
             callback(null, new results.SharedAccessSignatureUpdated(false));
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_081: [if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is connecting or authenticating, the connection shall be stopped and an `disconnect` event shall be emitted with the error translated to a transport-agnostic error.]*/
-          disconnectError: (err, callback) => this._fsm.transition('disconnecting', err, callback),
+          amqpConnectionClosed: (err, callback) => this._fsm.transition('disconnecting', err, callback),
           '*': () => this._fsm.deferUntilTransition()
         },
         authenticating: {
@@ -305,7 +305,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
           },
           disconnect: (disconnectCallback) => this._fsm.transition('disconnecting', null, disconnectCallback),
           /*Codes_SRS_NODE_DEVICE_AMQP_16_081: [if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is connecting or authenticating, the connection shall be stopped and an `disconnect` event shall be emitted with the error translated to a transport-agnostic error.]*/
-          disconnectError: (err, callback) => this._fsm.transition('disconnecting', err, callback),
+          amqpConnectionClosed: (err, callback) => this._fsm.transition('disconnecting', err, callback),
           '*': () => this._fsm.deferUntilTransition()
         },
         authenticated: {
@@ -397,7 +397,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
             this._deviceMethodClient.detach(callback);
           },
           /*Codes_SRS_NODE_DEVICE_AMQP_16_082: [if the handler specified in the `setDisconnectHandler` call is called while the `Amqp` object is connected, the connection shall be disconnected and an `disconnect` event shall be emitted with the error translated to a transport-agnostic error.]*/
-          disconnectError: (err, callback) => this._fsm.transition('disconnecting', err, callback)
+          amqpConnectionClosed: (err, callback) => this._fsm.transition('disconnecting', err, callback)
         },
         disconnecting: {
           _onEnter: (err, disconnectCallback) => {


### PR DESCRIPTION
# Description of the problem
Because of some error in the code the build was sometimes hitting an error where something was trying to write on a socket that had been closed, causing a "cannot read property "write" of null" error.

# Description of the solution
A couple of things at play here:
1. the `amqp10` library, when it is trying to properly close the socket, emits the `disconnect` event _before_ completely closing and resetting its state machine which may lead to issues when retrying to connect before the disconnect is complete. that's what the `process.nextTick` call is for in amqp-base.
2. The error bubbled up with the `disconnect` event was swallowed, causing the SDK to try and disconnect cleanly (by trying to send detach frames on the socket even though the amqp10 library was already disconnecting and the socket dead: this caused the error previously described).
3. Looks like the C2D disconnection logic was missing a callback, causing a hang once the fix was implemented. fixed that too.
4. also shuffled a few parameters around to adhere to the convention that callbacks should always come last even in the internal state machine transition handlers.
