### PR TITLE
Basic long-haul test harness & d2c test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -228,5 +228,7 @@ service/lib
 
 ts-e2e/lib
 
+longhaultests/lib
+
 # Build artifacts
 build/build_parallel/temp

--- a/longhaultests/package.json
+++ b/longhaultests/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "lint": "tslint --project . -c ../tslint.json",
     "build": "tsc",
+    "setup_links": "npm link azure-iot-common azure-iot-device azure-iot-device-amqp azure-iot-device-mqtt azure-iot-device-http azure-iothub",
     "start": "node lib/iothub_longhaul.js"
   },
   "repository": {

--- a/longhaultests/package.json
+++ b/longhaultests/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "longhaultests",
+  "version": "0.0.1",
+  "description": "Long haul tests for the Azure IoT SDKs for Node.js",
+  "main": "./lib/iothub_longhaul.js",
+  "bin": "./lib/iothub_longhaul.js",
+  "scripts": {
+    "lint": "tslint --project . -c ../tslint.json",
+    "build": "tsc",
+    "start": "node lib/iothub_longhaul.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/azure/azure-iot-sdk-node.git"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/azure/azure-iot-sdk-node/issues"
+  },
+  "homepage": "https://github.com/azure/azure-iot-sdk-node#readme",
+  "devDependencies": {
+    "@types/node": "^9.6.0",
+    "@types/uuid": "^3.4.3",
+    "tslint": "^5.9.1",
+    "typescript": "^2.7.2"
+  },
+  "dependencies": {
+    "async": "^2.6.0",
+    "azure-iot-common": "^1.5.0",
+    "azure-iot-device": "^1.4.0",
+    "azure-iot-device-amqp": "^1.4.0",
+    "azure-iot-device-http": "^1.4.0",
+    "azure-iot-device-mqtt": "^1.4.0",
+    "azure-iothub": "^1.3.0",
+    "debug": "^3.1.0",
+    "uuid": "^3.2.1"
+  }
+}

--- a/longhaultests/src/d2c_sender.ts
+++ b/longhaultests/src/d2c_sender.ts
@@ -1,0 +1,95 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import * as async from 'async';
+import * as uuid from 'uuid';
+import * as dbg from 'debug';
+const debug = dbg('longhaul:d2c_sender');
+
+import { Message } from 'azure-iot-common';
+import { Client, SharedAccessKeyAuthenticationProvider } from 'azure-iot-device';
+import { EventEmitter } from 'events';
+
+export class D2CSender extends EventEmitter {
+  private _timer: number;
+  private _client: Client;
+  private _sendInterval: number;
+  private _sendTimeout: number;
+
+  constructor(connStr: string, protocol: any, sendInterval: number, sendTimeout: number) {
+    super();
+    this._sendInterval = sendInterval;
+    this._sendTimeout = sendTimeout;
+    const authProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(connStr);
+    this._client = Client.fromAuthenticationProvider(authProvider, protocol);
+    this._client.on('error', (err) => {
+      debug('error emitted by client: ' + err.toString());
+      this.stop((stopErr) => {
+        debug('error stopping: ' + stopErr.toString());
+      });
+    });
+
+    this._client.on('disconnect', (err) => {
+      this.stop((stopErr) => {
+        debug('error stopping: ' + stopErr.toString());
+      });
+    });
+  }
+
+  start(callback: (err?: Error) => void): void {
+    debug('starting...');
+    this._client.open((err) => {
+      if (err) {
+        debug('failed to start: ' + err.toString());
+      } else {
+        debug('connected!');
+        this._startSending();
+      }
+      callback(err);
+    });
+  }
+
+  stop(callback: (err?: Error) => void): void {
+    debug('stopping');
+    if (this._timer) {
+      debug('clearing timeout');
+      clearTimeout(this._timer);
+      this._timer = null;
+    }
+
+    this._client.close((err) => {
+      if (err) {
+        debug('error while closing: ', err.toString());
+      } else {
+        debug('closed');
+      }
+      this._client.removeAllListeners();
+      this._client = null;
+      callback(err);
+    });
+  }
+
+  private _startSending(): void {
+    debug('starting send timer: 1 message every ' + this._sendInterval + ' milliseconds');
+    this._timer = setTimeout(this._send.bind(this), this._sendInterval);
+  }
+
+  private _send(): void {
+    const id = uuid.v4();
+    let msg = new Message(id);
+    msg.messageId = id;
+    debug('sending message with id: ' + id);
+    async.timeout(this._client.sendEvent.bind(this._client), this._sendTimeout)(msg, (err) => {
+      if (err) {
+        debug('error sending message: ' + id + ': ' + err.message);
+        this.emit('error', err);
+      } else {
+        debug('sent message with id: ' + id);
+        this._timer = setTimeout(this._send.bind(this), this._sendInterval);
+        this.emit('sent', id);
+      }
+    });
+  }
+}

--- a/longhaultests/src/iothub_longhaul.ts
+++ b/longhaultests/src/iothub_longhaul.ts
@@ -105,8 +105,11 @@ createDevice((err, deviceConnectionString) => {
     });
 
     const endTimeout = setTimeout(() => {
+      debug('end timeout: test completed successfully');
       stopSender(() => {
+        debug('sender stopped. deleting device');
         deleteDevice(() => {
+          debug('test device deleted from registry. Exiting.');
           process.exit(OK_EXIT_CODE);
         });
       });
@@ -118,6 +121,7 @@ createDevice((err, deviceConnectionString) => {
         debug('error starting d2c_sender: ' + err.toString());
         clearTimeout(endTimeout);
         deleteDevice(() => {
+          debug('test device deleted. Exiting.')
           process.exit(ERROR_EXIT_CODE);
         });
       } else {

--- a/longhaultests/src/iothub_longhaul.ts
+++ b/longhaultests/src/iothub_longhaul.ts
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+import * as uuid from 'uuid';
+import * as async from 'async';
+import * as dbg from 'debug';
+const debug = dbg('longhaul:main');
+
+import { Registry, ConnectionString as HubConnectionString } from 'azure-iothub';
+import { ConnectionString as DeviceConnectionString } from 'azure-iot-device';
+
+import { D2CSender } from './d2c_sender';
+
+const MAX_EXECUTION_TIME = parseInt(process.env.MAX_EXECUTION_TIME_SECONDS) * 1000;
+const SEND_INTERVAL = parseInt(process.env.DEVICE_SEND_INTERVAL_SECONDS) * 1000;
+const SEND_TIMEOUT = parseInt(process.env.DEVICE_SEND_TIMEOUT_SECONDS) * 1000;
+
+const MAX_CREATE_TIME = 30000;
+const MAX_DELETE_TIME = 30000;
+const MAX_START_TIME = 30000;
+const MAX_STOP_TIME = 30000;
+
+const ERROR_EXIT_CODE = -1;
+const OK_EXIT_CODE = 0;
+
+const hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
+const registry = Registry.fromConnectionString(hubConnectionString);
+
+const deviceId = 'node-longhaul-sak-' + uuid.v4();
+let protocol;
+
+/* tslint:disable:no-var-requires */
+switch (process.env.DEVICE_PROTOCOL) {
+  case 'amqp':
+    protocol = require('azure-iot-device-amqp').Amqp;
+  break;
+  case 'amqp-ws':
+    protocol = require('azure-iot-device-amqp').AmqpWs;
+  break;
+  case 'mqtt':
+    protocol = require('azure-iot-device-mqtt').Mqtt;
+  break;
+  case 'mqtt-ws':
+    protocol = require('azure-iot-device-mqtt').MqttWs;
+  break;
+  case 'http':
+    protocol = require('azure-iot-device-mqtt').Http;
+  break;
+  default:
+    debug('unknown protocol: ' + process.env.DEVICE_PROTOCOL);
+    process.exit(ERROR_EXIT_CODE);
+}
+/* tslint:enable:no-var-requires */
+
+const createDevice = (callback) => {
+  debug('creating device: ' + deviceId);
+  async.timeout(registry.create.bind(registry), MAX_CREATE_TIME)({ deviceId: deviceId }, (err, deviceInfo) => {
+    if (err) {
+      debug('error creating device: ' + deviceId + ':' + err.toString());
+      callback(err);
+    } else {
+      debug('device created: ' + deviceId);
+      const cs = HubConnectionString.parse(hubConnectionString);
+      callback(null, DeviceConnectionString.createWithSharedAccessKey(cs.HostName, deviceInfo.deviceId, deviceInfo.authentication.symmetricKey.primaryKey));
+    }
+  });
+};
+
+const deleteDevice = (callback) => {
+  debug('deleting device: ' + deviceId);
+  async.timeout(registry.delete.bind(registry), MAX_DELETE_TIME)(deviceId, (err) => {
+    if (err) {
+      debug('error deleting the test device: ' + err.toString());
+    } else {
+      debug('test device deleted. Exiting.');
+    }
+    callback();
+  });
+};
+
+createDevice((err, deviceConnectionString) => {
+  if (err) {
+    process.exit(ERROR_EXIT_CODE);
+  } else {
+    const sender = new D2CSender(deviceConnectionString, protocol, SEND_INTERVAL, SEND_TIMEOUT);
+
+    const stopSender = (callback) => {
+      async.timeout(sender.stop.bind(sender), MAX_STOP_TIME)((err) =>  {
+        if (err) {
+          debug('error stopping the sender: ' + err.toString());
+        } else {
+          debug('sender stopped.');
+        }
+        callback();
+      });
+    };
+
+    sender.on('error', (err) => {
+      debug('d2c_sender failed with error: ' + err.toString());
+      deleteDevice(() => {
+        process.exit(ERROR_EXIT_CODE);
+      });
+    });
+
+    const endTimeout = setTimeout(() => {
+      stopSender(() => {
+        deleteDevice(() => {
+          process.exit(OK_EXIT_CODE);
+        });
+      });
+    }, MAX_EXECUTION_TIME);
+
+    debug('starting d2c_sender');
+    async.timeout(sender.start.bind(sender), MAX_START_TIME)((err) => {
+      if (err) {
+        debug('error starting d2c_sender: ' + err.toString());
+        clearTimeout(endTimeout);
+        deleteDevice(() => {
+          process.exit(ERROR_EXIT_CODE);
+        });
+      } else {
+        debug('d2c_sender started');
+      }
+    });
+  }
+});

--- a/longhaultests/tsconfig.json
+++ b/longhaultests/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "outDir": "./lib",
+        "target":"es5",
+        "sourceMap": true,
+        "declaration": true
+    },
+    "include": [
+        "./src/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Add a basic long-haul test harness as well as a d2c test.

The basic idea is to have intervals, timeouts and protocol configurable at build time, and spin a process or even a build for each test.

I don't know yet how this will evolve as we add more features to test (C2D, twins etc) so I kept it minimalistic. no use of test frameworks, fancy command line or anything else (yet)