### PR TITLE
Increase/Clean up e2e timeouts. need to be at least 60 seconds for device creation.

### DIFF
--- a/e2etests/test/authentication.js
+++ b/e2etests/test/authentication.js
@@ -25,7 +25,7 @@ var transports = [Amqp, AmqpWs, Mqtt, MqttWs, Http];
 var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
 describe('Authentication', function() {
-  this.timeout(40000);
+  this.timeout(60000);
   var hostName = ServiceConnectionString.parse(hubConnectionString).HostName;
   var testDeviceId = 'nodee2etestDeviceAuth-' + uuid.v4();
   var testDeviceKey = '';

--- a/e2etests/test/c2d_disconnect.js
+++ b/e2etests/test/c2d_disconnect.js
@@ -109,7 +109,7 @@ var protocolAndTermination = [
 
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/service clients - disconnect c2d', function () {
-    this.timeout(30000);
+    this.timeout(60000);
 
     var serviceClient, deviceClient;
 
@@ -127,20 +127,17 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       sendMessageTimeout = null;
     });
 
     afterEach(function (testCallback) {
-      this.timeout(20000);
       closeDeviceServiceClients(deviceClient, serviceClient, testCallback);
       if (sendMessageTimeout !== null) clearTimeout(sendMessageTimeout);
     });
 
     doConnectTest(testConfiguration.testEnabled)('Service sends a C2D message, device receives it, and' + testConfiguration.closeReason + 'which is noted by the iot hub client', function (testCallback) {
-      this.timeout(20000);
       var receivingSideDone = false;
       var sendingSideDone = false;
       var uuidData = uuid.v4();
@@ -209,7 +206,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     doConnectTest(testConfiguration.testEnabled)('Service sends ' + numberOfC2DMessages + ' C2D messages, device receives first and' + testConfiguration.closeReason + 'which is never seen by the iot hub client', function (testCallback) {
-      this.timeout(60000);
       var originalMessages = [];
       var messagesReceived = 0;
       var messagesSent = 0;

--- a/e2etests/test/d2c_disconnect.js
+++ b/e2etests/test/d2c_disconnect.js
@@ -107,7 +107,7 @@ var protocolAndTermination = [
 
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/eventhub clients - disconnect d2c', function () {
-    this.timeout(20000);
+    this.timeout(60000);
     var deviceClient, ehClient, senderInterval, provisionedDevice, ehReceivers;
 
     before(function (beforeCallback) {
@@ -122,7 +122,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       ehClient = eventHubClient.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       senderInterval = null;
@@ -130,13 +129,11 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     afterEach(function (testCallback) {
-      this.timeout(20000);
       closeDeviceEventHubClients(deviceClient, ehClient, ehReceivers, testCallback);
       if (sendMessageTimeout !== null) clearTimeout(sendMessageTimeout);
     });
 
     doConnectTest(testConfiguration.testEnabled)('device sends a message, event hub client receives it, and' + testConfiguration.closeReason + 'which is noted by the iot hub device client', function (testCallback) {
-      this.timeout(40000);
       var uuidData = uuid.v4();
       var originalMessage = new Message(uuidData);
       var messageReceived = false;
@@ -200,7 +197,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
           });
 
     doConnectTest(testConfiguration.testEnabled)('device sends ' + numberOfD2CMessages + ' messages, when event hub client receives first, it ' + testConfiguration.closeReason + 'which is not seen by the iot hub device client', function (testCallback) {
-      this.timeout(40000);
       var originalMessages = [];
       var messagesReceived = 0;
       var messagesSent = 0;

--- a/e2etests/test/device_method.js
+++ b/e2etests/test/device_method.js
@@ -31,8 +31,6 @@ var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
     // create a new device for every test
     beforeEach(function (done) {
-      this.timeout(20000);
-
       deviceDescription = {
         deviceId:  '0000e2etest-delete-me-node-device-method-' + uuid.v4(),
         status: 'enabled',
@@ -57,7 +55,6 @@ var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
     // nuke the test device after every test
     afterEach(function (done) {
-      this.timeout(20000);
       if (!!deviceClient) {
         deviceClient.close(function(err) {
           if (!!err) {

--- a/e2etests/test/device_service.js
+++ b/e2etests/test/device_service.js
@@ -47,7 +47,7 @@ var maximumMessageSize = ((256*1024)-512);
 
 function device_service_tests(deviceTransport, createDeviceMethod) {
   describe('Over ' + deviceTransport.name + ' using device/service clients c2d', function () {
-    this.timeout(20000);
+    this.timeout(60000);
 
     var serviceClient, deviceClient;
     var provisionedDevice;
@@ -64,13 +64,11 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(deviceTransport, provisionedDevice);
     });
 
     afterEach(function (done) {
-      this.timeout(20000);
       closeDeviceServiceClients(deviceClient, serviceClient, done);
     });
 
@@ -161,7 +159,7 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
   });
 
   describe('Over ' + deviceTransport.name + ' using device/eventhub clients - messaging', function () {
-    this.timeout(20000);
+    this.timeout(60000);
 
     var deviceClient, ehClient, ehReceivers, provisionedDevice;
 
@@ -177,14 +175,12 @@ function device_service_tests(deviceTransport, createDeviceMethod) {
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       ehClient = eventHubClient.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(deviceTransport, provisionedDevice);
       ehReceivers = [];
     });
 
     afterEach(function (done) {
-      this.timeout(20000);
       closeDeviceEventHubClients(deviceClient, ehClient, ehReceivers, done);
     });
 

--- a/e2etests/test/file_upload.js
+++ b/e2etests/test/file_upload.js
@@ -47,13 +47,11 @@ describe('File upload - HTTP transport', function () {
   });
 
   beforeEach(function () {
-    this.timeout(20000);
     serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString);
     deviceClient = createDeviceClient(HttpTransport, provisionedDevice);
   });
 
   afterEach(function (done) {
-    this.timeout(20000);
     closeDeviceServiceClients(deviceClient, serviceClient, done);
   });
 

--- a/e2etests/test/method_disconnect.js
+++ b/e2etests/test/method_disconnect.js
@@ -114,13 +114,13 @@ var protocolAndTermination = [
 
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/eventhub clients - disconnect methods', function () {
+    this.timeout(60000);
 
     var deviceClient, serviceClient;
     var secondMethodTimeout;
     var provisionedDevice;
 
     before(function (beforeCallback) {
-      this.timeout(20000);
       DeviceIdentityHelper.createDeviceWithSas(function (err, testDeviceInfo) {
         provisionedDevice = testDeviceInfo;
         beforeCallback(err);
@@ -128,19 +128,16 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     after(function (afterCallback) {
-      this.timeout(20000);
       DeviceIdentityHelper.deleteDevice(provisionedDevice.deviceId, afterCallback);
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       secondMethodTimeout = null;
     });
 
     afterEach(function (testCallback) {
-      this.timeout(20000);
       closeDeviceServiceClients(deviceClient, serviceClient, testCallback);
       if (secondMethodTimeout) clearTimeout(secondMethodTimeout);
     });
@@ -201,7 +198,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     };
 
     doConnectTest(testConfiguration.testEnabled)('Service sends a method, iothub client receives it, and' + testConfiguration.closeReason + 'which is noted by the device', function (testCallback) {
-      this.timeout(20000);
       var firstMethodSent = false;
       deviceClient.setRetryPolicy(new NoRetry());
       var disconnectHandler = function () {
@@ -234,7 +230,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     doConnectTest(testConfiguration.testEnabled)('Service client sends 2 methods, when iot hub client receives first, it ' + testConfiguration.closeReason + 'which is not seen by the device', function (testCallback) {
-      this.timeout(20000);
       deviceClient.on('disconnect', function () {
         testCallback(new Error('unexpected disconnect'));
       });

--- a/e2etests/test/registry.js
+++ b/e2etests/test/registry.js
@@ -42,7 +42,7 @@ var deviceIdWithThumbprints = {
 };
 
 describe('Registry', function () {
-  this.timeout(30000);
+  this.timeout(60000);
   it('Creates a device with only a deviceId and gets it', function (done){
     var registry = Registry.fromConnectionString(hubConnectionString);
 

--- a/e2etests/test/sas_token_tests.js
+++ b/e2etests/test/sas_token_tests.js
@@ -38,7 +38,7 @@ transports.forEach(function (deviceTransport) {
     });
 
     after(function (afterCallback) {
-      debug('deleting test device: ' + provisionedDevice.deviceId);      
+      debug('deleting test device: ' + provisionedDevice.deviceId);
       DeviceIdentityHelper.deleteDevice(provisionedDevice.deviceId, afterCallback);
     });
 
@@ -101,7 +101,6 @@ transports.forEach(function (deviceTransport) {
     });
 
     it('Renews SAS after connection and is still able to send D2C messages', function(testCallback) {
-      this.timeout(60000);
       var beforeSas = uuid.v4();
       var afterSas = uuid.v4();
 
@@ -118,7 +117,7 @@ transports.forEach(function (deviceTransport) {
           ehClient.close().then(function () {
             testCallback(err);
           });
-        }); 
+        });
       }
 
       var ehReceivers = [];

--- a/e2etests/test/service.js
+++ b/e2etests/test/service.js
@@ -14,9 +14,9 @@ var assert = require('chai').assert;
 var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
 describe('Service Client', function () {
-  [Amqp, AmqpWs].forEach(function (Transport) {
+    this.timeout(60000);
+    [Amqp, AmqpWs].forEach(function (Transport) {
     it('Service client can connect over ' + Transport.name + ' using a shared access signature', function(done) {
-      this.timeout(60000);
       var connStr = serviceSdk.ConnectionString.parse(hubConnectionString);
       var sas = serviceSas.create(connStr.HostName, connStr.SharedAccessKeyName, connStr.SharedAccessKey, anHourFromNow()).toString();
       var serviceClient = serviceSdk.Client.fromSharedAccessSignature(sas, Transport);
@@ -33,7 +33,6 @@ describe('Service Client', function () {
     });
 
     it('Service client can connect over ' + Transport.name + ' using a connection string', function(done) {
-      this.timeout(60000);
       var serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString, Transport);
       serviceClient.open(function(err, result) {
         if(err) {

--- a/e2etests/test/throttle_disconnect.js
+++ b/e2etests/test/throttle_disconnect.js
@@ -58,7 +58,7 @@ var protocolAndTermination = [
 
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/eventhub clients - disconnect d2c', function () {
-    this.timeout(20000);
+    this.timeout(60000);
     var deviceClient, ehClient, senderInterval, ehReceivers, provisionedDevice;
 
     before(function (beforeCallback) {
@@ -73,7 +73,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     beforeEach(function () {
-      this.timeout(20000);
       ehClient = eventHubClient.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       senderInterval = null;
@@ -81,7 +80,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     afterEach(function (testCallback) {
-      this.timeout(20000);
       closeDeviceEventHubClients(deviceClient, ehClient, ehReceivers, testCallback);
       if (sendMessageTimeout !== null) clearTimeout(sendMessageTimeout);
     });

--- a/e2etests/test/twin_disconnect.js
+++ b/e2etests/test/twin_disconnect.js
@@ -118,14 +118,13 @@ delete nullMergeResult.tweedle;
 protocolAndTermination.forEach( function (testConfiguration) {
   describe(testConfiguration.transport.name + ' using device/service clients - disconnect twin', function () {
 
-    this.timeout(30000);
+    this.timeout(60000);
     var deviceClient, deviceTwin;
     var serviceTwin;
 
     var deviceDescription;
 
     beforeEach(function (done) {
-      this.timeout(30000);
       setTwinMoreNewPropsTimeout = null;
       var host = ConnectionString.parse(hubConnectionString).HostName;
       var pkey = new Buffer(uuid.v4()).toString('base64');
@@ -167,7 +166,6 @@ protocolAndTermination.forEach( function (testConfiguration) {
     });
 
     afterEach(function (done) {
-      this.timeout(30000);
       if (setTwinMoreNewPropsTimeout) clearTimeout(setTwinMoreNewPropsTimeout);
       if (deviceClient) {
         deviceClient.close(function(err) {

--- a/e2etests/test/twin_e2e_tests.js
+++ b/e2etests/test/twin_e2e_tests.js
@@ -50,16 +50,13 @@ delete nullMergeResult.tweedle;
   deviceMqtt.Mqtt
 ].forEach(function(protocolCtor) {
   describe('Twin over ' + protocolCtor.name, function() {
-
-    this.timeout(20000);
+    this.timeout(60000);
     var deviceClient, deviceTwin;
     var serviceTwin;
 
     var deviceDescription;
 
     beforeEach(function (done) {
-      this.timeout(20000);
-
       var host = ConnectionString.parse(hubConnectionString).HostName;
       var pkey = new Buffer(uuid.v4()).toString('base64');
       var deviceId = '0000e2etest-delete-me-twin-e2e-' + protocolCtor.name + '-'  + uuid.v4();
@@ -101,7 +98,6 @@ delete nullMergeResult.tweedle;
     });
 
     afterEach(function (done) {
-      this.timeout(20000);
       if (deviceClient) {
         deviceClient.close(function(err) {
           if (err) return done(err);
@@ -348,7 +344,7 @@ delete nullMergeResult.tweedle;
 
     it('can renew SAS 20 times without failure', function(done)
     {
-      this.timeout(120000);
+      this.timeout(180000);
       var iteration = 0;
       var doItAgain = function() {
         iteration++;

--- a/e2etests/test/upload_disconnect.js
+++ b/e2etests/test/upload_disconnect.js
@@ -53,13 +53,11 @@ var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
     });
 
     beforeEach(function () {
-      this.timeout(120000);
       serviceClient = serviceSdk.Client.fromConnectionString(hubConnectionString);
       deviceClient = createDeviceClient(deviceTransport, provisionedDevice);
     });
 
     afterEach(function (done) {
-      this.timeout(120000);
       closeDeviceServiceClients(deviceClient, serviceClient, done);
     });
 

--- a/ts-e2e/src/d2c.tests.ts
+++ b/ts-e2e/src/d2c.tests.ts
@@ -14,7 +14,7 @@ const debug = dbg('ts-e2e-d2c');
 
 
 describe('D2C', function () {
-  this.timeout(20000);
+  this.timeout(60000);
   const testDevice = testUtils.createTestDevice();
 
   const hostName = ServiceConnectionString.parse(process.env.IOTHUB_CONNECTION_STRING).HostName;

--- a/ts-e2e/src/device_methods.tests.ts
+++ b/ts-e2e/src/device_methods.tests.ts
@@ -19,7 +19,7 @@ const debug = dbg('ts-e2e-methods');
 describe('Device Methods', function () {
   [DeviceMqtt, DeviceMqttWs, DeviceAmqp, DeviceAmqpWs].forEach((TransportCtor: any) => {
     describe('Over ' + TransportCtor.name, function() {
-      this.timeout(20000);
+      this.timeout(60000);
 
       const testDevice = testUtils.createTestDevice();
       const scs = ServiceConnectionString.parse(process.env.IOTHUB_CONNECTION_STRING);

--- a/ts-e2e/src/device_twin.tests.ts
+++ b/ts-e2e/src/device_twin.tests.ts
@@ -19,7 +19,7 @@ const debug = dbg('ts-e2e-twin');
 describe('Device Twin', function () {
   [DeviceMqtt, DeviceMqttWs].forEach((TransportCtor: any) => {
     describe('Over ' + TransportCtor.name, function() {
-      this.timeout(20000);
+      this.timeout(60000);
 
       const testDevice = testUtils.createTestDevice();
       const scs = ServiceConnectionString.parse(process.env.IOTHUB_CONNECTION_STRING);

--- a/ts-e2e/src/file_upload.tests.ts
+++ b/ts-e2e/src/file_upload.tests.ts
@@ -11,7 +11,7 @@ const debug = dbg('ts-e2e-d2c');
 
 
 describe('File upload', function () {
-  this.timeout(20000);
+  this.timeout(60000);
   const testDevice = testUtils.createTestDevice();
 
   const hostName = ServiceConnectionString.parse(process.env.IOTHUB_CONNECTION_STRING).HostName;

--- a/ts-e2e/src/registry.tests.ts
+++ b/ts-e2e/src/registry.tests.ts
@@ -3,7 +3,7 @@ import * as uuid from 'uuid';
 import { assert } from 'chai';
 
 describe('Registry', function() {
-  this.timeout(20000);
+  this.timeout(60000);
   it('creates a device -> gets it -> updates it -> deletes it', (testCallback) => {
     const testDeviceId = uuid.v4();
     const registry = Registry.fromConnectionString(process.env.IOTHUB_CONNECTION_STRING);


### PR DESCRIPTION
# Description of the problem
Device creation can take up to 45 seconds. tests should not timeout before that.

# Description of the solution
increased test timeouts to 60 seconds.
