### PR TITLE
 disable AmqpWs for DPS Group enrollment e2e test

### DIFF
--- a/provisioning/e2e/_provisioning_e2e.js
+++ b/provisioning/e2e/_provisioning_e2e.js
@@ -30,7 +30,7 @@ var registry = Registry.fromConnectionString(registryConnectionString);
 
 
 var X509IndividualTransports = [ Http, Amqp, AmqpWs, Mqtt, MqttWs ];
-var X509GroupTransports = [ Http, Amqp, AmqpWs, Mqtt, MqttWs ];
+var X509GroupTransports = [ Http, Amqp, Mqtt, MqttWs ]; // AmqpWs is disabled because of an occasional ECONNRESET error when closing the socket. See Task 2233264.
 var TpmIndividualTransports = [ Http, Amqp, AmqpWs ];
 
 var rootCert = {


### PR DESCRIPTION
# Description of the problem
E2E tests for DPS sometimes fail with an `ECONNRESET` error when closing the socket. Suspect it's a bug with the web socket transport. 
 
# Description of the solution
Disable that test while we investigate. AmqpWs test still enabled for individual enrollments and TPM.