### PR TITLE
Move symlinks into local directory for easier cleanup use of multiple…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,6 @@ longhaultests/lib
 
 # Build artifacts
 build/build_parallel/temp
+
+# directory with dev-setup symlinks
+npm-symlinks/

--- a/build/dev-setup.cmd
+++ b/build/dev-setup.cmd
@@ -8,6 +8,9 @@ set node-root=%~dp0..
 REM // resolve to fully qualified path
 for %%i in ("%node-root%") do set node-root=%%~fi
 
+set NPM_CONFIG_PREFIX=%node-root%\npm-symlinks
+if NOT exist %NPM_CONFIG_PREFIX% mkdir %NPM_CONFIG_PREFIX%
+
 echo.
 echo -- Setting up build_parallel tool --
 cd %node-root%\build\build_parallel

--- a/build/dev-setup.sh
+++ b/build/dev-setup.sh
@@ -5,6 +5,11 @@
 
 node_root=$(cd "$(dirname "$0")/.." && pwd)
 
+export NPM_CONFIG_PREFIX=$node_root/npm-symlinks
+if [ ! -d $NPM_CONFIG_PREFIX ]; then
+  mkdir $NPM_CONFIG_PREFIX
+fi
+
 cleanup_and_exit()
 {
     exit $1

--- a/build/dev-teardown.cmd
+++ b/build/dev-teardown.cmd
@@ -8,6 +8,19 @@ set node-root=%~dp0..
 REM // resolve to fully qualified path
 for %%i in ("%node-root%") do set node-root=%%~fi
 
+if "%1" == "" ( 
+  echo Not removing any files because symlinks are in %node-root%\npm-symlinks and teardown isn't necessary.
+  echo If you want to tear down anyway, run dev-teardown.cmd with the --force flag
+  exit /b 0
+)
+
+if "%1" NEQ "--force" (
+  echo usage: dev-teardown.cmd [--force]
+  exit /b 1
+)
+
+set NPM_CONFIG_PREFIX=%node-root%\npm-symlinks
+
 echo -- Removing links for build tools --
 cd %node-root%\build\tools
 echo .

--- a/build/dev-teardown.sh
+++ b/build/dev-teardown.sh
@@ -5,6 +5,19 @@
 
 node_root=$(cd "$(dirname "$0")/.." && pwd)
 
+if [ -z "$1" ]; then
+  echo "Not removing any files because symlinks are in $node_root\npm-symlinks and teardown isn't necessary."
+  echo "If you want to tear down anyway, run dev-teardown.cmd with the --force flag"
+  exit 0
+fi
+
+if [ "$1" != "--force" ]; then
+  echo "usage: dev-teardown.cmd [--force]"
+  exit 1
+fi
+
+export NPM_CONFIG_PREFIX=$node_root/npm-symlinks
+
 echo "\n-- Removing links for build tools --"
 cd $node_root/build/tools
 npm rm azure-iothub


### PR DESCRIPTION
Move symlinks into local directory for easier cleanup use of multiple clones on a single machine

This moves the symlink folder under $node_root so that:
1) We don't have to call dev-teardown in the Windows jenkins job anymore.
2) We can have multiple clones and they don't collide because they don't share the same symlinks.

Note:  This allows us to keep the call to dev-teardown in our jenkins job because some jenkins builds will need it for a while (anyone except master, including the LTS branches).  If you want to force a teardown, call dev-teardown with the --force flag.
