### PR TITLE
fix(e2e:methods): reuse test device across device methods tests

### DIFF
--- a/provisioning/e2e/_service_create_delete.js
+++ b/provisioning/e2e/_service_create_delete.js
@@ -39,8 +39,8 @@ var enrollmentGroup = {
 };
 
 describe('provisioning service client', function () {
+  this.timeout(60000);
   before(function(done) {
-    this.timeout(60000);
     certHelper.createIntermediateCaCert('test cert', null, function(err, cert) {
       if (err) {
         done(err);
@@ -71,7 +71,6 @@ describe('provisioning service client', function () {
   ];
   testSpecification.forEach(function(testConfiguration) {
     describe('#Create', function() {
-      this.timeout(5000);
       var enrollmentToDelete = {};
       after(function(done) {
         testConfiguration.deleteFunction(enrollmentToDelete, function(err) {
@@ -98,7 +97,6 @@ describe('provisioning service client', function () {
 
   testSpecification.forEach(function(testConfiguration) {
     describe('#Delete', function() {
-      this.timeout(5000);
       var enrollmentToDelete = {};
       before(function(done) {
         testConfiguration.createFunction(testConfiguration.enrollmentObject, function(err, returnedEnrollment) {
@@ -125,7 +123,6 @@ describe('provisioning service client', function () {
 
   testSpecification.forEach(function(testConfiguration) {
     describe('#Update', function() {
-      this.timeout(10000);
       var enrollmentToDelete = {};
       var enrollmentToUpdate = {};
       before(function(done) {

--- a/provisioning/transport/mqtt/test/_mqtt_test.js
+++ b/provisioning/transport/mqtt/test/_mqtt_test.js
@@ -32,8 +32,6 @@ describe('Mqtt', function () {
   };
   var fakeErrorText = 'fake error text';
 
-  this.timeout(100);
-
   beforeEach(function() {
     fakeBase = new EventEmitter();
     fakeBase.connect = sinon.stub().callsArg(1); // (config: MqttBase.TransportConfig, done: (err?: Error, result?: any) => void): void
@@ -500,4 +498,3 @@ describe('Mqtt', function () {
   });
 
 });
-


### PR DESCRIPTION
# Description of the problem
device methods e2e tests create 1 device per test, which leads to some registry APIs errors

# Description of the solution
reuse the same device across the test suite (1 device / protocol)
also add logs to make it easier to debug failures later
