### PR TITLE
manual port of MqttBaseTransportConfig changes from modules-preview t…

### DIFF
--- a/common/core/src/authorization.ts
+++ b/common/core/src/authorization.ts
@@ -68,6 +68,10 @@ export interface TransportConfig {
    * Object containing the certificate and key used by the device to connect and authenticate with the Azure IoT hub instance.
    */
   x509?: X509;
+  /**
+   * IP address or internet name of the host machine working as a device or protocol gateway.  Used when communicating with Azure Edge devices.
+   */
+  gatewayHostName?: string;
 }
 
 /**

--- a/common/transport/mqtt/devdoc/mqtt_base_requirements.md
+++ b/common/transport/mqtt/devdoc/mqtt_base_requirements.md
@@ -38,7 +38,7 @@ The `Mqtt` constructor receives the configuration parameters to configure the MQ
 
 ### MqttBase.connect(config, done)
 The `connect` method establishes a connection with the server using the config object passed in the arguments.
-**SRS_NODE_COMMON_MQTT_BASE_16_006: [** The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: deviceId, host, and one of sharedAccessSignature or x509.cert and x509.key. **]**
+**SRS_NODE_COMMON_MQTT_BASE_16_006: [** The `connect` method shall throw a ReferenceError if the config argument is falsy, or if one of the following properties of the config argument is falsy: uri, clientId, username, and one of sharedAccessSignature or x509.cert and x509.key. **]**
 
 **SRS_NODE_COMMON_MQTT_BASE_16_002: [** The `connect` method shall use the authentication parameters contained in the `config` argument to connect to the server. **]**
 

--- a/common/transport/mqtt/index.d.ts
+++ b/common/transport/mqtt/index.d.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { MqttBase } from './lib/mqtt_base';
+export { MqttBase,  MqttBaseTransportConfig } from './lib/mqtt_base';
 export { translateError } from './lib/mqtt_translate_error';

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -32,7 +32,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 93 --branches 83 --functions 84 --lines 95"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 82 --functions 84 --lines 95"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -61,7 +61,11 @@ The `Mqtt` and `MqttWs` constructors initialize a new instance of the MQTT trans
 
 **SRS_NODE_DEVICE_MQTT_12_003: [** The constructor shall create an MqttBase object and store it in a member variable.**]**
 
-**SRS_NODE_DEVICE_MQTT_16_016: [** The `Mqtt` constructor shall initialize the `uri` property of the `config` object to `mqtts://<host>`. **]**
+**SRS_NODE_DEVICE_MQTT_16_016: [** If the connection string does not specify a `gatewayHostName` value, the `Mqtt` constructor shall initialize the `uri` property of the `config` object to `mqtts://<host>`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_053: [** If a `moduleId` is not specified in the connection string, the Mqtt constructor shall initialize the `clientId` property of the `config` object to '<deviceId>'. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_055: [** The Mqtt constructor shall initialize the `username` property of the `config` object to '<host>/<clientId>/api-version=<version>&DeviceClientType=<agentString>'. **]**
 
 **SRS_NODE_DEVICE_MQTT_16_017: [** The `MqttWs` constructor shall initialize the `uri` property of the `config` object to `wss://<host>:443/$iothub/websocket`. **]**
 
@@ -76,6 +80,11 @@ The `Mqtt` and `MqttWs` constructors initialize a new instance of the MQTT trans
 The `connect` method initializes a connection to an IoT hub.
 
 **SRS_NODE_DEVICE_MQTT_12_004: [** The `connect` method shall call the `connect` method on `MqttBase`. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_029: [** If a `moduleId` is not specified, the `connect` method shall use a `clientId` of "<deviceId>" when connecting to the MQTT service. **]**
+
+**SRS_NODE_DEVICE_MQTT_18_030: [** If a `moduleId` is not specified, the `connect` method shall use a `username` of "<host>/<deviceId>/DeviceClientType=<userAgent>&apiVersion=<apiVersion>". **]**
+
 
 **SRS_NODE_DEVICE_MQTT_18_026: [** When `MqttBase` fires the `error` event, the `Mqtt` object shall emit a `disconnect` event. **]**
 

--- a/device/transport/mqtt/src/mqtt_ws.ts
+++ b/device/transport/mqtt/src/mqtt_ws.ts
@@ -4,6 +4,7 @@
 'use strict';
 
 import { Mqtt } from './mqtt';
+import { MqttBaseTransportConfig } from 'azure-iot-mqtt-base';
 import { AuthenticationProvider, TransportConfig } from 'azure-iot-common';
 
 /**
@@ -19,13 +20,14 @@ export class MqttWs extends Mqtt {
    * @constructor
    * @param   {Object}    config  Configuration object derived from the connection string by the client.
    */
-  constructor(authenticationProvider: AuthenticationProvider) {
-    super(authenticationProvider);
+  constructor(authenticationProvider: AuthenticationProvider, mqttBase?: any) {
+    super(authenticationProvider, mqttBase);
     /*Codes_SRS_NODE_DEVICE_MQTT_16_017: [The `MqttWs` constructor shall initialize the `uri` property of the `config` object to `wss://<host>:443/$iothub/websocket`.]*/
   }
 
-  protected _configureEndpoints(credentials: TransportConfig): void {
-    super._configureEndpoints(credentials);
-    (credentials as any).uri  = 'wss://' + credentials.host + ':443/$iothub/websocket';
+  protected _getBaseTransportConfig(credentials: TransportConfig): MqttBaseTransportConfig {
+    let baseConfig: MqttBaseTransportConfig = super._getBaseTransportConfig(credentials);
+    baseConfig.uri  = 'wss://' + (credentials.gatewayHostName || credentials.host) + ':443/$iothub/websocket';
+    return baseConfig;
   }
 }

--- a/device/transport/mqtt/test/_mqtt_ws_test.js
+++ b/device/transport/mqtt/test/_mqtt_ws_test.js
@@ -42,10 +42,10 @@ describe('MqttWs', function () {
 
   describe('#connect', function () {
     /*Tests_SRS_NODE_DEVICE_MQTT_16_017: [The `MqttWs` constructor shall initialize the `uri` property of the `config` object to `wss://<host>:443/$iothub/websocket`.]*/
-    it('sets the uri property to \'wss://<host>:443/$iothub/websocket\'', function () {
-      var mqttWs = new MqttWs(fakeAuthenticationProvider);
+    it('sets the uri property to \'wss://<host>:443/$iothub/websocket\'', function (testCallback) {
+      var mqttWs = new MqttWs(fakeAuthenticationProvider, fakeMqttBase);
       mqttWs.connect(function () {
-        assert.strictEqual(fakeMqttBase.connect.firstCall.args[0].uri, 'mqtts://' + fakeConfig.host);
+        assert.strictEqual(fakeMqttBase.connect.firstCall.args[0].uri, 'wss://' + fakeConfig.host + ':443/$iothub/websocket');
         testCallback();
       });
     });

--- a/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/provisioning/transport/mqtt/devdoc/mqtt_requirements.md
@@ -81,7 +81,7 @@ These requirements apply whenever the transport connection is established
 
 **SRS_NODE_PROVISIONING_MQTT_18_038: [** When connecting, `Mqtt` shall set the `username` in the base `TransportConfig` object to '<idScope>/registrations/<registrationId>/api-version=<apiVersion>&clientVersion=<UrlEncode<userAgent>>'. **]**
 
-**SRS_NODE_PROVISIONING_MQTT_18_050: [** When connecting, `Mqtt` shall set `host` in the base `TransportConfig` object to the `provisioningDeviceHost`. **]**
+**SRS_NODE_PROVISIONING_MQTT_18_050: [** When connecting, `Mqtt` shall set `uri` in the base `TransportConfig` object to the 'mqtts://' + `provisioningDeviceHost`. **]**
 
 **SRS_NODE_PROVISIONING_MQTT_18_039: [** If a uri is specified in the request object, `Mqtt` shall set it in the base `TransportConfig` object. **]**
 

--- a/provisioning/transport/mqtt/test/_mqtt_test.js
+++ b/provisioning/transport/mqtt/test/_mqtt_test.js
@@ -95,10 +95,10 @@ describe('Mqtt', function () {
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_037: [ When connecting, `Mqtt` shall pass in the `X509` certificate that was passed into `setAuthentication` in the base `TransportConfig` object.] */
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_001: [ The certificate and key passed as properties of the `auth` function shall be used to connect to the Device Provisioning Service.] */
           assert.strictEqual(config.x509, fakeX509);
-          /* Tests_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `host` in the base `TransportConfig` object to the `provisioningDeviceHost`.] */
-          assert.strictEqual(config.host, fakeHost);
+          /* Tests_SRS_NODE_PROVISIONING_MQTT_18_050: [ When connecting, `Mqtt` shall set `uri` in the base `TransportConfig` object to the 'mqtts://' + `provisioningDeviceHost`.] */
+          assert.strictEqual(config.uri, 'mqtts://' + fakeHost);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_035: [ When connecting, `Mqtt` shall set `clientId` in the base `registrationRequest` object to the registrationId.] */
-          assert.strictEqual(config.deviceId, fakeRequest.registrationId);
+          assert.strictEqual(config.clientId, fakeRequest.registrationId);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_036: [ When connecting, `Mqtt` shall set the `clean` flag in the base `TransportConfig` object to true.] */
           assert.strictEqual(config.clean, true);
           /* Tests_SRS_NODE_PROVISIONING_MQTT_18_038: [ When connecting, `Mqtt` shall set the `username` in the base `TransportConfig` object to '<idScope>/registrations/<registrationId>/api-version=<apiVersion>&clientVersion=<UrlEncode<userAgent>>'.] */


### PR DESCRIPTION
…o master

This is a manual port of some changes I made in modules-preview that just happens to make my agent string work easier.  In Mqtt, the agent string is part of the username field when connecting.  In modules-preview, I moved creation of the username string from common/mqtt into device/mqtt, and that makes the agent string work much easier.

You've reviewed this before.

There is some leakage from modules-preview that will make later merges easier.  In particular, I leaked some GatewayHostName references and a few moduleId referrences (but only in the text of requirements)