### PR TITLE
rewrite amqpBase.connect to accept a config structure

### DIFF
--- a/common/transport/amqp/devdoc/amqp_requirements.md
+++ b/common/transport/amqp/devdoc/amqp_requirements.md
@@ -60,8 +60,6 @@ A possibly undefined sslOptions structure.
 A done callback.
  **]**
 
-**SRS_NODE_COMMON_AMQP_06_002: [** The `connect` method shall throw a ReferenceError if the uri parameter has not been supplied.**]**
-
 **SRS_NODE_COMMON_AMQP_16_002: [**The `connect` method shall establish a connection with the IoT hub instance and if given as argument call the `done` callback with a null error object in the case of success and a `results.Connected` object.**]**
 
 **SRS_NODE_COMMON_AMQP_16_003: [**If given as an argument, the connect method shall call the `done` callback with a standard `Error` object if the connection or link/listener establishment fails.**]**

--- a/common/transport/amqp/index.d.ts
+++ b/common/transport/amqp/index.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { Amqp } from './lib/amqp';
+export { Amqp, AmqpBaseTransportConfig } from './lib/amqp';
 export { AmqpMessage } from './lib/amqp_message';
 export { ReceiverLink } from './lib/receiver_link';
 export { SenderLink } from './lib/sender_link';

--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -36,7 +36,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 83 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 92 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/amqp/test/_amqp_test.js
+++ b/common/transport/amqp/test/_amqp_test.js
@@ -31,24 +31,28 @@ describe('Amqp', function () {
 
     it('sets the session policy to not reestablish on failure', function () {
       var amqp = new Amqp();
+      void(amqp);
       assert.isFalse(amqp10.Client.firstCall.args[0].session.reestablish.forever);
       assert.strictEqual(amqp10.Client.firstCall.args[0].session.reestablish.retries, 0);
     });
 
     it('sets the sender link to not reattach on failure', function () {
       var amqp = new Amqp();
+      void(amqp);
       assert.isFalse(amqp10.Client.firstCall.args[0].senderLink.reattach.forever);
       assert.strictEqual(amqp10.Client.firstCall.args[0].senderLink.reattach.retries, 0);
     });
 
     it('sets the receiver link to not reattach on failure', function () {
       var amqp = new Amqp();
+      void(amqp);
       assert.isFalse(amqp10.Client.firstCall.args[0].receiverLink.reattach.forever);
       assert.strictEqual(amqp10.Client.firstCall.args[0].receiverLink.reattach.retries, 0);
     });
 
     it('sets the connection to not reconnect on failure', function () {
       var amqp = new Amqp();
+      void(amqp);
       assert.isFalse(amqp10.Client.firstCall.args[0].reconnect.forever);
       assert.strictEqual(amqp10.Client.firstCall.args[0].reconnect.retries, 0);
     });
@@ -59,22 +63,12 @@ describe('Amqp', function () {
   });
 
   describe('#connect', function () {
-    /* Tests_SRS_NODE_COMMON_AMQP_06_002: [The connect method shall throw a ReferenceError if the uri parameter has not been supplied.] */
-    [undefined, null, ''].forEach(function (badUri){
-      it('throws if uri is \'' + badUri +'\'', function () {
-        var newClient = new Amqp();
-        assert.throws(function () {
-          newClient.connect(badUri);
-        }, ReferenceError, '');
-      });
-    });
-
     /*Tests_SRS_NODE_COMMON_AMQP_16_002: [The connect method shall establish a connection with the IoT hub instance and if given as argument call the `done` callback with a null error object in the case of success and a `results.Connected` object.]*/
     /*Tests_SRS_NODE_COMMON_AMQP_06_011: [The `connect` method shall set up a listener for responses to put tokens.]*/
     it('Calls the done callback when successfully connected', function(testCallback) {
       var amqp = new Amqp();
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
-      amqp.connect('uri', null, function(err, res) {
+      amqp.connect({uri: 'uri'}, function(err, res) {
         if (err) testCallback(err);
         else {
           assert.instanceOf(res, results.Connected);
@@ -86,12 +80,12 @@ describe('Amqp', function () {
     it('Calls the done callback immediately when already connected', function(testCallback) {
       var amqp = new Amqp();
       var connectStub = sinon.stub(amqp._amqp, 'connect').resolves();
-      amqp.connect('uri', null, function(err, res) {
+      amqp.connect({uri: 'uri'}, function(err, res) {
         if (err) testCallback(err);
         else {
           assert.instanceOf(res, results.Connected);
           assert(connectStub.calledOnce);
-          amqp.connect('uri', null, function(err, res) {
+          amqp.connect({uri: 'uri'}, function(err, res) {
             if (err) testCallback(err);
             else {
               assert.instanceOf(res, results.Connected);
@@ -107,7 +101,7 @@ describe('Amqp', function () {
     it('Calls the done callback with an error if connecting fails (disconnected)', function(testCallback) {
       var amqp = new Amqp();
       sinon.stub(amqp._amqp, 'connect').rejects('connection failed');
-      amqp.connect('uri', null, function(err) {
+      amqp.connect({uri: 'uri'}, function(err) {
         assert.instanceOf(err, Error);
         testCallback();
       });
@@ -122,7 +116,7 @@ describe('Amqp', function () {
           reject(new Error('cannot connect'));
         });
       });
-      amqp.connect('uri', null, function(err) {
+      amqp.connect({uri: 'uri'}, function(err) {
         assert.strictEqual(err, testError);
         testCallback();
       });
@@ -136,7 +130,7 @@ describe('Amqp', function () {
       amqp.setDisconnectHandler(function() {
         testCallback();
       });
-      amqp.connect('uri', null, function () {
+      amqp.connect({uri: 'uri'}, function () {
         amqp._amqp.emit('disconnected');
       });
     });
@@ -156,7 +150,7 @@ describe('Amqp', function () {
       amqp.setDisconnectHandler(function() {
         assert.fail();
       });
-      amqp.connect('uri', undefined, function() {});
+      amqp.connect({uri: 'uri'}, function() {});
       amqp._amqp.emit('disconnected');
       testCallback();
     });
@@ -168,7 +162,7 @@ describe('Amqp', function () {
       amqp.setDisconnectHandler(function() {
         assert.fail();
       });
-      amqp.connect('uri', undefined, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.disconnect(function () { });
         amqp._amqp.emit('disconnected');
         testCallback();
@@ -186,7 +180,7 @@ describe('Amqp', function () {
         detach: sinon.stub().callsArg(0)
       };
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.disconnect(function(err) {
           if (err) {
             testCallback(err);
@@ -209,7 +203,7 @@ describe('Amqp', function () {
         detach: sinon.stub().callsArg(0)
       };
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp._senders.fake_sender_endpoint = fakeSender;
         amqp._receivers.fake_receiver_endpoint = fakeReceiver;
 
@@ -230,7 +224,7 @@ describe('Amqp', function () {
       var amqp = new Amqp();
       sinon.stub(amqp._amqp, 'connect').resolves();
       sinon.stub(amqp._amqp, 'disconnect').resolves();
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.disconnect(function(err) {
           if (err) testCallback(err);
           else {
@@ -245,7 +239,7 @@ describe('Amqp', function () {
       var amqp = new Amqp();
       sinon.stub(amqp._amqp, 'connect').resolves();
       sinon.stub(amqp._amqp, 'disconnect').rejects(new Error('disconnection error'));
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.disconnect(function(err) {
           if (err) {
             assert.instanceOf(err, Error);
@@ -271,11 +265,11 @@ describe('Amqp', function () {
       var amqp = new Amqp();
       sinon.stub(amqp._amqp, 'connect').resolves();
       sinon.stub(amqp._amqp, 'disconnect').callsFake(function () { return new Promise(function () {}); }); // will not resolve and block in the 'disconnecting' state
-      
+
       amqp.setDisconnectHandler(function() {
         assert.fail();
       });
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.disconnect(function() {});
         amqp._amqp.emit('client:errorReceived', new Error('should be ignored'));
         testCallback();
@@ -283,14 +277,20 @@ describe('Amqp', function () {
     });
   });
 
-  describe('#connectWithCustomSasl', function() {
+  describe('#connect using custom SASL', function() {
     it('sets the saslMechanism property in the policyOverride object', function (testCallback) {
       var amqp = new Amqp();
       var connectStub = sinon.stub(amqp._amqp, 'connect').resolves();
       var fakeSaslName = 'FAKE';
       var fakeSaslMechanism = { getInitFrame: function () {}, getResponseFrame: function () {}};
 
-      amqp.connectWithCustomSasl('uri', fakeSaslName, fakeSaslMechanism, function () {
+      var config = {
+        uri: 'uri',
+        saslMechanismName: fakeSaslName,
+        saslMechanism: fakeSaslMechanism
+      };
+
+      amqp.connect(config, function () {
         assert.strictEqual(connectStub.firstCall.args[1].saslMechanism, fakeSaslName);
         testCallback();
       });
@@ -302,8 +302,13 @@ describe('Amqp', function () {
       var registerSaslMechanismStub = sinon.stub(amqp._amqp, 'registerSaslMechanism');
       var fakeSaslName = 'FAKE';
       var fakeSaslMechanism = { getInitFrame: function () {}, getResponseFrame: function () {}};
+      var config= {
+        uri: 'uri',
+        saslMechanismName: fakeSaslName,
+        saslMechanism: fakeSaslMechanism
+      };
 
-      amqp.connectWithCustomSasl('uri', fakeSaslName, fakeSaslMechanism, function () {
+      amqp.connect(config, function () {
         assert.strictEqual(registerSaslMechanismStub.firstCall.args[0], fakeSaslName);
         assert.strictEqual(registerSaslMechanismStub.firstCall.args[1], fakeSaslMechanism);
         testCallback();
@@ -320,7 +325,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.send(new Message('message'), 'endpoint', 'deviceId', function(err, result) {
           if(!err) {
             assert.instanceOf(result, results.MessageEnqueued);
@@ -340,7 +345,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createSender').rejects('failed to create sender');
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.send(new Message('message'), 'endpoint', 'deviceId', function(err) {
           assert.instanceOf(err, Error);
           testCallback();
@@ -356,7 +361,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.send(new Message('message'), 'endpoint', 'deviceId', function(err) {
           assert.instanceOf(err, Error);
           testCallback();
@@ -373,7 +378,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.send(new Message('message'), endpointName, 'deviceId', function(err, result) {
           if (err) {
             testCallback(err);
@@ -401,7 +406,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
       assert.doesNotThrow(function() {
-        amqp.connect('uri', null, function() {
+        amqp.connect({uri: 'uri'}, function() {
           amqp.send(new Message('message'), 'endpoint', undefined, function() {
             assert.isUndefined(sender.send.args[0][0].properties.to);
             testCallback();
@@ -420,7 +425,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
       assert.doesNotThrow(function() {
-        amqp.connect('uri', null, function() {
+        amqp.connect({uri: 'uri'}, function() {
           amqp.send(new Message('message'), 'endpoint', 'deviceId');
         });
       });
@@ -435,7 +440,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').resolves(sender);
 
       assert.doesNotThrow(function() {
-        amqp.connect('uri', null, function() {
+        amqp.connect({uri: 'uri'}, function() {
           amqp.send(new Message('message'), 'endpoint', 'deviceId');
         });
       });
@@ -449,7 +454,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createReceiver').resolves(new EventEmitter());
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.getReceiver('endpoint', function(err, receiver) {
           assert.instanceOf(receiver, ReceiverLink);
           testCallback(err);
@@ -463,7 +468,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createReceiver').resolves(new EventEmitter());
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.getReceiver('endpoint', function(err, recv1) {
           if (err) {
             testCallback(err);
@@ -487,7 +492,7 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'connect').resolves('connected');
       sinon.stub(amqp._amqp, 'createReceiver').rejects(new Error('cannt create receiver'));
 
-      amqp.connect('uri', null, function() {
+      amqp.connect({uri: 'uri'}, function() {
         amqp.getReceiver('endpoint', function(err) {
           assert.instanceOf(err, Error);
           testCallback();
@@ -496,37 +501,8 @@ describe('Amqp', function () {
     });
   });
 
-  describe('#initializeCBS', function() {
-    it('tries to connect the client if it is disconnected', function(testCallback) {
-      var amqp = new Amqp();
-      var fakeSender = new EventEmitter();
-      fakeSender.forceDetach = function () {};
-      var fakeReceiver = new EventEmitter();
-      fakeReceiver.forceDetach = function () {};
-      sinon.stub(amqp._amqp, 'connect').resolves('connected');
-      sinon.stub(amqp._amqp, 'createSender').resolves(fakeSender);
-      sinon.stub(amqp._amqp, 'createReceiver').resolves(fakeReceiver);
-
-      amqp.initializeCBS(function() {
-        assert(amqp._amqp.connect.calledOnce);
-        testCallback();
-      });
-    });
-
-    it('calls the callback with an error if the client cannot be connected', function (testCallback) {
-      var amqp = new Amqp();
-      var fakeError = new Error('fake error');
-      sinon.stub(amqp._amqp, 'connect').rejects(fakeError);
-
-      amqp.initializeCBS(function(err) {
-        assert.strictEqual(err, fakeError);
-        testCallback();
-      });
-    });
-  });
-
   describe('#putToken', function() {
-    it('tries to connect the client and initialize the CBS endpoints if necessary', function(testCallback) {
+    it('initializes the CBS endpoints if necessary', function(testCallback) {
       var fakeUuid = uuid.v4();
       var uuidStub = sinon.stub(uuid,'v4');
       uuidStub.onCall(0).returns(fakeUuid);
@@ -539,6 +515,7 @@ describe('Amqp', function () {
       var fakeSender = new EventEmitter();
       fakeSender.send = function() {
         return new Promise(function (resolve, reject) {
+          void(reject);
           resolve();
           fakeReceiver.emit('message', responseMessage);
         });
@@ -555,23 +532,16 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').resolves(fakeSender);
       sinon.stub(amqp._amqp, 'createReceiver').resolves(fakeReceiver);
 
-      amqp.putToken('audience', 'token', function(err) {
-        uuid.v4.restore();
-        assert.isNull(err);
-        assert(amqp._amqp.connect.calledOnce);
-        assert(amqp._amqp.createSender.calledWith('$cbs'));
-        assert(amqp._amqp.createReceiver.calledWith('$cbs'));
-        testCallback();
-      });
-    });
-
-    it('calls the callback with an error if the client cannot be connected', function (testCallback) {
-      var amqp = new Amqp();
-      var fakeError = new Error('fake error');
-      sinon.stub(amqp._amqp, 'connect').rejects(fakeError);
-      amqp.putToken('audience', 'token', function(err) {
-        assert.strictEqual(err, fakeError);
-        testCallback();
+      amqp.connect({uri: 'uri'}, function(err) {
+        assert(!err);
+        amqp.putToken('audience', 'token', function(err) {
+          uuid.v4.restore();
+          assert.isNull(err);
+          assert(amqp._amqp.connect.calledOnce);
+          assert(amqp._amqp.createSender.calledWith('$cbs'));
+          assert(amqp._amqp.createReceiver.calledWith('$cbs'));
+          testCallback();
+        });
       });
     });
 
@@ -584,9 +554,12 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').rejects(fakeError);
       sinon.stub(amqp._amqp, 'createReceiver').resolves(fakeReceiver);
 
-      amqp.putToken('audience', 'token', function(err) {
-        assert.strictEqual(err, fakeError);
-        testCallback();
+      amqp.connect({uri: 'uri'}, function(err) {
+        assert(!err);
+        amqp.putToken('audience', 'token', function(err) {
+          assert.strictEqual(err, fakeError);
+          testCallback();
+        });
       });
     });
 
@@ -600,9 +573,12 @@ describe('Amqp', function () {
       sinon.stub(amqp._amqp, 'createSender').resolves(fakeSender);
       sinon.stub(amqp._amqp, 'createReceiver').rejects(fakeError);
 
-      amqp.putToken('audience', 'token', function(err) {
-        assert.strictEqual(err, fakeError);
-        testCallback();
+      amqp.connect({uri: 'uri'}, function(err) {
+        assert(!err);
+        amqp.putToken('audience', 'token', function(err) {
+          assert.strictEqual(err, fakeError);
+          testCallback();
+        });
       });
     });
   });
@@ -637,7 +613,7 @@ describe('Amqp', function () {
           var amqp = new Amqp();
           sinon.stub(amqp._amqp, 'connect').resolves('connected');
           sinon.stub(amqp._amqp, testConfig.amqp10Func).resolves(testConfig.fakeLinkObject);
-          amqp.connect('uri', null, function() {
+          amqp.connect({uri: 'uri'}, function() {
             amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function(err) {
               if (err) { return testCallback(err); }
               assert.isNotTrue(amqp._amqp[testConfig.amqp10Func].args[0][1]);
@@ -656,24 +632,14 @@ describe('Amqp', function () {
 
           sinon.stub(amqp._amqp, 'connect').resolves('connected');
           sinon.stub(amqp._amqp, testConfig.amqp10Func).resolves(testConfig.fakeLinkObject);
-          amqp.connect('uri', null, function() {
+          amqp.connect({uri: 'uri'}, function() {
+
             /*Tests_SRS_NODE_COMMON_AMQP_16_015: [The `attachSenderLink` method shall call the `done` callback with a `null` error and the link object that was created if the link was attached successfully.]*/
             /*Tests_SRS_NODE_COMMON_AMQP_16_020: [The `attachReceiverLink` method shall call the `done` callback with a `null` error and the link object that was created if the link was attached successfully.]*/
             amqp[testConfig.amqpFunc](fake_generic_endpoint, fakeLinkProps, function() {
               assert.deepEqual(amqp._amqp[testConfig.amqp10Func].args[0][1], { fakeKey: 'fakeValue'});
               testCallback();
             });
-          });
-        });
-
-        it('calls the callback with an error if the client cannot be connected', function (testCallback) {
-          var amqp = new Amqp();
-          var fakeError = new Error('fake error');
-          sinon.stub(amqp._amqp, 'connect').rejects(fakeError);
-
-          amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function(err) {
-            assert.strictEqual(err, fakeError);
-            testCallback();
           });
         });
 
@@ -684,7 +650,7 @@ describe('Amqp', function () {
           var fakeError = new Error('failed to create link');
           sinon.stub(amqp._amqp, 'connect').resolves('connected');
           sinon.stub(amqp._amqp, testConfig.amqp10Func).rejects(fakeError);
-          amqp.connect('uri', null, function() {
+          amqp.connect({uri: 'uri'}, function() {
             amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function(err) {
               assert.strictEqual(fakeError, err);
               testCallback();
@@ -698,7 +664,7 @@ describe('Amqp', function () {
           var fakeError = new Error('failed to create sender');
           sinon.stub(amqp._amqp, 'connect').resolves('connected');
           sinon.stub(amqp._amqp, testConfig.amqp10Func).resolves(testConfig.fakeLinkObject);
-          amqp.connect('uri', null, function() {
+          amqp.connect({uri: 'uri'}, function() {
             amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function(err) {
               assert.strictEqual(fakeError, err);
               testCallback();
@@ -712,8 +678,8 @@ describe('Amqp', function () {
           var amqp = new Amqp();
           sinon.stub(amqp._amqp, 'connect').resolves('connected');
           sinon.stub(amqp._amqp, testConfig.amqp10Func).resolves(testConfig.fakeLinkObject);
-          amqp.connect('uri', null, function() {
-            amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function(err) {
+          amqp.connect({uri: 'uri'}, function() {
+            amqp[testConfig.amqpFunc](fake_generic_endpoint, null, function() {
               testConfig.fakeLinkObject.emit('detached', { closed: true, error: new Error() });
               assert.isUndefined(amqp[testConfig.privateLinkArray][fake_generic_endpoint]);
               testCallback();
@@ -743,11 +709,13 @@ describe('Amqp', function () {
         amqp._amqp.connect = sinon.stub().resolves();
         amqp._amqp.createSender = sinon.stub().resolves(fakeLink);
 
-        amqp.attachSenderLink(fake_generic_endpoint, null, function() {
-          /*Tests_SRS_NODE_COMMON_AMQP_16_024: [The `detachSenderLink` method shall call the `done` callback with no arguments if detaching the link succeeded.]*/
-          amqp.detachSenderLink(fake_generic_endpoint, function(err) {
-            assert(fakeLink.detach.calledOnce);
-            testCallback(err);
+        amqp.connect({uri: 'uri'}, function() {
+          amqp.attachSenderLink(fake_generic_endpoint, null, function() {
+            /*Tests_SRS_NODE_COMMON_AMQP_16_024: [The `detachSenderLink` method shall call the `done` callback with no arguments if detaching the link succeeded.]*/
+            amqp.detachSenderLink(fake_generic_endpoint, function(err) {
+              assert(fakeLink.detach.calledOnce);
+              testCallback(err);
+            });
           });
         });
       });
@@ -756,7 +724,7 @@ describe('Amqp', function () {
       it('calls the callback immediately if there\'s no link attached', function (testCallback) {
         var amqp = new Amqp();
         amqp._amqp.connect = sinon.stub().resolves();
-        amqp.connect('fakeuri', null, function() {
+        amqp.connect({uri: 'uri'}, function() {
           amqp.detachSenderLink(fake_generic_endpoint, function(err) {
             testCallback(err);
           });
@@ -793,11 +761,13 @@ describe('Amqp', function () {
         amqp._amqp.connect = sinon.stub().resolves();
         amqp._amqp.createReceiver = sinon.stub().resolves(fakeLink);
 
-        amqp.attachReceiverLink(fake_generic_endpoint, null, function() {
-          /*Tests_SRS_NODE_COMMON_AMQP_16_029: [The `detachReceiverLink` method shall call the `done` callback with no arguments if detaching the link succeeded.]*/
-          amqp.detachReceiverLink(fake_generic_endpoint, function(err) {
-            assert(fakeLink.detach.calledOnce);
-            testCallback();
+        amqp.connect({uri: 'uri'}, function() {
+          amqp.attachReceiverLink(fake_generic_endpoint, null, function() {
+            /*Tests_SRS_NODE_COMMON_AMQP_16_029: [The `detachReceiverLink` method shall call the `done` callback with no arguments if detaching the link succeeded.]*/
+            amqp.detachReceiverLink(fake_generic_endpoint, function() {
+              assert(fakeLink.detach.calledOnce);
+              testCallback();
+            });
           });
         });
       });
@@ -806,7 +776,7 @@ describe('Amqp', function () {
       it('calls the callback immediately if there\'s no link attached', function (testCallback) {
         var amqp = new Amqp();
         amqp._amqp.connect = sinon.stub().resolves();
-        amqp.connect('fakeuri', null, function() {
+        amqp.connect({uri: 'uri'}, function() {
           amqp.detachReceiverLink(fake_generic_endpoint, function(err) {
             testCallback(err);
           });
@@ -820,6 +790,21 @@ describe('Amqp', function () {
           assert.isUndefined(err);
           testCallback();
         });
+      });
+    });
+  });
+
+  [
+    { functionName: 'attachSenderLink',   invoke: (amqp, callback) => amqp.attachSenderLink('endpoint', null, callback) },
+    { functionName: 'attachReceiverLink', invoke: (amqp, callback) => amqp.attachReceiverLink('endpoint', null, callback) },
+    { functionName: 'initializeCBS',      invoke: (amqp, callback) => amqp.initializeCBS(callback) },
+    { functionName: 'putToken',           invoke: (amqp, callback) => amqp.putToken('audience', 'token', callback) }
+  ].forEach(function(testConfig) {
+    it (testConfig.functionName + ' fails with NotConnectedError if not connected', function(callback) {
+      var amqp = new Amqp();
+      testConfig.invoke(amqp, function(err) {
+        assert.instanceOf(err, errors.NotConnectedError);
+        callback();
       });
     });
   });

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -9,7 +9,7 @@ const debug = dbg('azure-iot-device-amqp:Amqp');
 import { EventEmitter } from 'events';
 
 import { DeviceMethodResponse, Client, DeviceClientOptions, TwinProperties } from 'azure-iot-device';
-import { Amqp as BaseAmqpClient, translateError, AmqpMessage, SenderLink, ReceiverLink } from 'azure-iot-amqp-base';
+import { Amqp as BaseAmqpClient, AmqpBaseTransportConfig, translateError, AmqpMessage, SenderLink, ReceiverLink } from 'azure-iot-amqp-base';
 import { endpoint, SharedAccessSignature, errors, results, Message, AuthenticationProvider, AuthenticationType } from 'azure-iot-common';
 import { AmqpDeviceMethodClient } from './amqp_device_method_client';
 import { AmqpTwinClient } from './amqp_twin_client';
@@ -254,8 +254,11 @@ export class Amqp extends EventEmitter implements Client.Transport {
                 this._c2dEndpoint = endpoint.messagePath(encodeURIComponent(credentials.deviceId));
                 this._d2cEndpoint = endpoint.eventPath(credentials.deviceId);
 
-                const uri = this._getConnectionUri(credentials.host);
-                this._amqp.connect(uri, credentials.x509, (err, connectResult) => {
+                const config: AmqpBaseTransportConfig = {
+                  uri: this._getConnectionUri(credentials.host),
+                  sslOptions: credentials.x509
+                };
+                this._amqp.connect(config, (err, connectResult) => {
                   if (err) {
                     this._fsm.transition('disconnected', translateError('AMQP Transport: Could not connect', err), connectCallback);
                   } else {

--- a/device/transport/amqp/test/_amqp_receiver_test.js
+++ b/device/transport/amqp/test/_amqp_receiver_test.js
@@ -22,7 +22,7 @@ describe('AmqpReceiver', function () {
   var fakeMethodClient;
   var fakeAuthenticationProvider;
   var fakeAmqpBaseClient = {
-    connect: sinon.stub().callsArg(2),
+    connect: sinon.stub().callsArg(1),
     setDisconnectHandler: sinon.stub(),
     initializeCBS: sinon.stub().callsArg(0),
     putToken: sinon.stub().callsArg(2)

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -51,7 +51,7 @@ describe('Amqp', function () {
     sinon.spy(receiver, 'removeListener');
 
     fakeBaseClient = {
-      connect: sinon.stub().callsArgWith(2, null, new results.Connected()),
+      connect: sinon.stub().callsArgWith(1, null, new results.Connected()),
       disconnect: sinon.stub().callsArgWith(0, null, new results.Disconnected()),
       initializeCBS: sinon.stub().callsArgWith(0, null),
       putToken: sinon.stub().callsArgWith(2, null),
@@ -236,7 +236,7 @@ describe('Amqp', function () {
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_038: [The `enableMethods` method shall connect and authenticate the transport if it is disconnected.]*/
       it('calls the callback with an error if the transport fails to connect', function (testCallback) {
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, new Error('fake error'));
+        fakeBaseClient.connect = sinon.stub().callsArgWith(1, new Error('fake error'));
         transport.enableMethods(function (err) {
           assert(fakeBaseClient.connect.calledOnce);
           assert.instanceOf(err, Error);
@@ -381,7 +381,7 @@ describe('Amqp', function () {
       /*Tests_SRS_NODE_DEVICE_AMQP_16_008: [The `done` callback method passed in argument shall be called if the connection is established]*/
       it('calls done if connection established using SSL', function () {
         var transport = new Amqp(fakeX509AuthenticationProvider);
-        sinon.stub(transport._amqp,'connect').callsArgWith(2,null);
+        sinon.stub(transport._amqp,'connect').callsArgWith(1,null);
         transport.connect(function(err) {
           assert.isNotOk(err);
         });
@@ -390,7 +390,7 @@ describe('Amqp', function () {
       /*Tests_SRS_NODE_DEVICE_AMQP_16_009: [The `done` callback method passed in argument shall be called with an error object if the connection fails]*/
       it('calls done with an error if connection failed', function () {
         var transport = new Amqp(fakeX509AuthenticationProvider);
-        sinon.stub(transport._amqp,'connect').callsArgWith(2,new errors.UnauthorizedError('cryptic'));
+        sinon.stub(transport._amqp,'connect').callsArgWith(1,new errors.UnauthorizedError('cryptic'));
         transport.connect(function(err) {
           assert.isOk(err);
         });
@@ -440,13 +440,13 @@ describe('Amqp', function () {
       it('defers the call if already connecting', function (testCallback) {
         var connectErr = new Error('cannot connect');
         var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, done) {
+        fakeBaseClient.connect = sinon.stub().callsFake(function (config, done) {
           connectCallback = done;
         });
 
         transport.connect(function (err) {
           assert.strictEqual(err.amqpError, connectErr);
-          fakeBaseClient.connect = sinon.stub().callsArgWith(2, null, new results.Connected());
+          fakeBaseClient.connect = sinon.stub().callsArgWith(1, null, new results.Connected());
         });
 
         // now blocked in "connecting" state
@@ -526,7 +526,7 @@ describe('Amqp', function () {
         it('is deferred until connecting fails', function (testCallback) {
           var connectErr = new Error('cannot connect');
           var connectCallback;
-          fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, done) {
+          fakeBaseClient.connect = sinon.stub().callsFake(function (config, done) {
             // will block in "connecting" state since the callback isn't called.
             // calling connectCallback will unblock it.
             connectCallback = done;
@@ -534,7 +534,7 @@ describe('Amqp', function () {
 
           transport.connect(function (err) {
             assert.strictEqual(err.amqpError, connectErr);
-            fakeBaseClient.connect = sinon.stub().callsArgWith(2, null, new results.Connected());
+            fakeBaseClient.connect = sinon.stub().callsArgWith(1, null, new results.Connected());
           });
 
           transport.disconnect(function (err, result) {
@@ -557,7 +557,7 @@ describe('Amqp', function () {
           transport.connect(function (err, result) {
             assert.isNull(err);
             assert.instanceOf(result, results.Connected);
-            fakeBaseClient.connect = sinon.stub().callsArgWith(2, null, new results.Connected());
+            fakeBaseClient.connect = sinon.stub().callsArgWith(1, null, new results.Connected());
           });
 
           // now blocked in "connecting" state
@@ -727,7 +727,7 @@ describe('Amqp', function () {
 
       it('updates the shared access signature but results in a single putToken if called while connecting but not authenticated yet', function (testCallback) {
         var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, callback) {
+        fakeBaseClient.connect = sinon.stub().callsFake(function (config, callback) {
           connectCallback = callback;
         });
         transport.connect(function () {
@@ -904,7 +904,7 @@ describe('Amqp', function () {
 
       it('forwards the error if connecting fails while trying to send a message', function (testCallback) {
         var fakeError = new Error('failed to connect');
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, fakeError);
+        fakeBaseClient.connect = sinon.stub().callsArgWith(1, fakeError);
 
         transport.sendEvent(new Message('test'), function (err) {
           assert(fakeBaseClient.connect.calledOnce);
@@ -915,7 +915,7 @@ describe('Amqp', function () {
 
       it('sends the message even if called while the transport is connecting', function (testCallback) {
         var connectCallback;
-        fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, done) {
+        fakeBaseClient.connect = sinon.stub().callsFake(function (config, done) {
           // this will block in the 'connecting' state since the callback is not called.
           // calling connectCallback will unblock.
           connectCallback = done;
@@ -1124,7 +1124,7 @@ describe('Amqp', function () {
 
       /*Tests_SRS_NODE_DEVICE_AMQP_16_033: [The `enableC2D` method shall call its `callback` with an `Error` if the transport fails to connect, authenticate or attach link.]*/
       it('calls its callback with an Error if connecting the transport fails', function (testCallback) {
-        fakeBaseClient.connect = sinon.stub().callsArgWith(2, new Error('fake failed to connect'));
+        fakeBaseClient.connect = sinon.stub().callsArgWith(1, new Error('fake failed to connect'));
         transport.enableC2D(function (err) {
           assert(fakeBaseClient.connect.calledOnce);
           assert.instanceOf(err, Error);
@@ -1237,7 +1237,7 @@ describe('Amqp', function () {
 
         it('waits until connected and authenticated if called while connecting', function () {
           var connectCallback;
-          fakeBaseClient.connect = sinon.stub().callsFake(function (uri, options, callback) {
+          fakeBaseClient.connect = sinon.stub().callsFake(function (config, callback) {
             connectCallback = callback;
           });
 
@@ -1274,7 +1274,7 @@ describe('Amqp', function () {
         /*Tests_SRS_NODE_DEVICE_AMQP_16_072: [The `enableTwinDesiredPropertiesUpdates` method shall call its callback with an error if connecting fails.]*/
         it('calls its callback with an error if connecting the transport fails', function (testCallback) {
           var testError = new Error('failed to connect');
-          fakeBaseClient.connect = sinon.stub().callsArgWith(2, testError);
+          fakeBaseClient.connect = sinon.stub().callsArgWith(1, testError);
 
           methodUnderTest(function (err) {
             assert(fakeBaseClient.connect.calledOnce);

--- a/device/transport/amqp/test/_fake_amqp.js
+++ b/device/transport/amqp/test/_fake_amqp.js
@@ -66,7 +66,7 @@ var FakeAmqp = function() {
     detachCallback();
   }
 
-  this.connect = function (uri, sslOptions, callback) {
+  this.connect = function (config, callback) {
     callback(null, new results.Connected());
   }
 

--- a/provisioning/transport/amqp/src/amqp.ts
+++ b/provisioning/transport/amqp/src/amqp.ts
@@ -12,7 +12,7 @@ const debug = dbg('azure-iot-provisioning-device-amqp:Amqp');
 
 import { X509, errors } from 'azure-iot-common';
 import { ProvisioningTransportOptions, X509ProvisioningTransport, TpmProvisioningTransport, RegistrationRequest, RegistrationResult, ProvisioningDeviceConstants } from 'azure-iot-provisioning-device';
-import { Amqp as Base, SenderLink, ReceiverLink, AmqpMessage } from 'azure-iot-amqp-base';
+import { Amqp as Base, SenderLink, ReceiverLink, AmqpMessage, AmqpBaseTransportConfig } from 'azure-iot-amqp-base';
 import { GetSasTokenCallback, SaslTpm } from './sasl_tpm';
 
 /**
@@ -125,7 +125,11 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
           _onEnter: (request, callback) => {
             /*Codes_SRS_NODE_PROVISIONING_AMQP_16_002: [The `registrationRequest` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method.]*/
             /*Codes_SRS_NODE_PROVISIONING_AMQP_16_012: [The `queryOperationStatus` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method. **]**]*/
-            this._amqpBase.connect(this._getConnectionUri(request), this._x509Auth, (err) => {
+            const config: AmqpBaseTransportConfig = {
+              uri: this._getConnectionUri(request),
+              sslOptions: this._x509Auth
+            };
+            this._amqpBase.connect(config, (err) => {
               if (err) {
                 debug('_amqpBase.connect failed');
                 debug(err);
@@ -512,7 +516,12 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
       callback(null, challenge);
     });
 
-    this._amqpBase.connectWithCustomSasl(this._getConnectionUri(request), this._customSaslMechanism.name, this._customSaslMechanism, (err) => {
+    const config: AmqpBaseTransportConfig = {
+      uri: this._getConnectionUri(request),
+      saslMechanismName: this._customSaslMechanism.name,
+      saslMechanism: this._customSaslMechanism
+    };
+    this._amqpBase.connect(config, (err) => {
       this._amqpStateMachine.handle('tpmConnectionComplete', err);
     });
   }

--- a/provisioning/transport/amqp/test/_amqp_test.js
+++ b/provisioning/transport/amqp/test/_amqp_test.js
@@ -71,7 +71,7 @@ describe('Amqp', function () {
     });
 
     fakeAmqpBase = {
-      connect: sinon.stub().callsArg(2),
+      connect: sinon.stub().callsArg(1),
       disconnect: sinon.stub().callsArg(0),
       attachSenderLink: sinon.stub().callsArgWith(2, null, fakeSenderLink),
       attachReceiverLink: sinon.stub().callsArgWith(2, null, fakeReceiverLink),
@@ -107,7 +107,7 @@ describe('Amqp', function () {
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_008: [The `registrationRequest` method shall call its callback with an error if the transport fails to connect.]*/
       it ('calls its callback with an error if it fails to connect', function (testCallback) {
-        fakeAmqpBase.connect = sinon.stub().callsArgWith(2, fakeError);
+        fakeAmqpBase.connect = sinon.stub().callsArgWith(1, fakeError);
 
         amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -213,7 +213,7 @@ describe('Amqp', function () {
 
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_018: [The `queryOperationStatus` method shall call its callback with an error if the transport fails to connect.]*/
       it ('calls its callback with an error if it fails to connect', function (testCallback) {
-        fakeAmqpBase.connect = sinon.stub().callsArgWith(2, fakeError);
+        fakeAmqpBase.connect = sinon.stub().callsArgWith(1, fakeError);
 
         amqp.queryOperationStatus({ registrationId: 'fakeRegistrationId' }, 'fakeOpId', function (err) {
           assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -568,7 +568,7 @@ describe('Amqp', function () {
         var challengeCallback = SaslTpm.firstCall.args[4];
         // return the auth key to the transport.  When it sends us the SAS token, complete the connection.
         challengeCallback(fakeAuthenticationKey, function() {
-          var connectionComplete = fakeAmqpBase.connectWithCustomSasl.firstCall.args[3];
+          var connectionComplete = fakeAmqpBase.connect.firstCall.args[1];
           connectionComplete(null);
         });
       };

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -167,7 +167,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
         connecting: {
           _onEnter: (callback) => {
             const uri = this._getConnectionUri();
-            this._amqp.connect(uri, undefined, (err, result) => {
+            this._amqp.connect({uri: uri}, (err, result) => {
               if (err) {
                 debug('failed to connect' + err.toString());
                 this._fsm.transition('disconnected', err, callback);

--- a/service/test/_amqp_test.js
+++ b/service/test/_amqp_test.js
@@ -31,7 +31,7 @@ describe('Amqp', function() {
 
   beforeEach(function () {
     fakeAmqpBase = new EventEmitter();
-    fakeAmqpBase.connect = sinon.stub().callsArgWith(2, null, new results.Connected());
+    fakeAmqpBase.connect = sinon.stub().callsArgWith(1, null, new results.Connected());
     fakeAmqpBase.initializeCBS = sinon.stub().callsArg(0);
     fakeAmqpBase.putToken = sinon.stub().callsArg(2);
     fakeAmqpBase.disconnect = sinon.stub().callsArg(0);
@@ -122,7 +122,7 @@ describe('Amqp', function() {
     /*Tests_SRS_NODE_IOTHUB_SERVICE_AMQP_16_017: [All asynchronous instance methods shall call the `done` callback with a single parameter that is derived from the standard Javascript `Error` object if the operation failed.]*/
     it('calls its callback with an error if the base transport connect method fails', function(done) {
       var testError = new errors.NotConnectedError('fake error');
-      fakeAmqpBase.connect = sinon.stub().callsArgWith(2, testError);
+      fakeAmqpBase.connect = sinon.stub().callsArgWith(1, testError);
       var amqp = new Amqp(fakeConfig, fakeAmqpBase);
       amqp.connect(function (err) {
         assert.instanceOf(err, Error);
@@ -400,7 +400,7 @@ describe('Amqp', function() {
 
     it('calls its callback with an error if connecting the transport fails', function (testCallback) {
       var amqp = new Amqp(fakeConfig, fakeAmqpBase);
-      fakeAmqpBase.connect = sinon.stub().callsArgWith(2, new Error('fakeError'));
+      fakeAmqpBase.connect = sinon.stub().callsArgWith(1, new Error('fakeError'));
 
       amqp.getFeedbackReceiver(function (err) {
         assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -474,7 +474,7 @@ describe('Amqp', function() {
 
     it('calls its callback with an error if connecting the transport fails', function (testCallback) {
       var amqp = new Amqp(fakeConfig, fakeAmqpBase);
-      fakeAmqpBase.connect = sinon.stub().callsArgWith(2, new Error('fakeError'));
+      fakeAmqpBase.connect = sinon.stub().callsArgWith(1, new Error('fakeError'));
 
       amqp.getFileNotificationReceiver(function (err) {
         assert.isTrue(fakeAmqpBase.connect.calledOnce);
@@ -549,7 +549,7 @@ describe('Amqp', function() {
     /*Tests_SRS_NODE_IOTHUB_SERVICE_AMQP_16_026: [The `send` method shall call its callback with an error if connecting and/or authenticating the transport fails.]*/
     it('calls its callback with an error if connecting the transport fails', function (testCallback) {
       var amqp = new Amqp(fakeConfig, fakeAmqpBase);
-      fakeAmqpBase.connect = sinon.stub().callsArgWith(2, new Error('fakeError'));
+      fakeAmqpBase.connect = sinon.stub().callsArgWith(1, new Error('fakeError'));
 
       amqp.send('fakeDeviceId', new Message('foo'), function (err) {
         assert.isTrue(fakeAmqpBase.connect.calledOnce);

--- a/service/test/_amqp_ws_test.js
+++ b/service/test/_amqp_ws_test.js
@@ -33,8 +33,8 @@ describe('AmqpWs', function() {
 
       sinon.spy(amqpWs._amqp, 'connect');
       amqpWs.connect(function(){});
-      assert.strictEqual(amqpWs._amqp.connect.args[0][0].indexOf('wss://'), 0);
-      assert(amqpWs._amqp.connect.args[0][0].indexOf('$iothub/websocket') > 0);
+      assert.strictEqual(amqpWs._amqp.connect.args[0][0].uri.indexOf('wss://'), 0);
+      assert(amqpWs._amqp.connect.args[0][0].uri.indexOf('$iothub/websocket') > 0);
     });
   });
 });


### PR DESCRIPTION
This is a parallel change to the one I made for MQTT.  I'm doing this to prepare for user agent changes.  Instead of accepting individual parameters, I've adjusted amqpBase.connect to accept a config structure.  

Along the way, I removed the logic to automatically connect.  This mirrors the MQTT protocol and is unused anyway since the AMQP device, service, and provisioning transports all take care of doing this.  