### PR TITLE
fix: last put token should stop timer expiring old put tokens

### DIFF
--- a/common/transport/amqp/src/amqp_cbs.ts
+++ b/common/transport/amqp/src/amqp_cbs.ts
@@ -139,6 +139,12 @@ export class ClaimsBasedSecurityAgent {
                         if (msg.properties.correlationId === this._putToken.outstandingPutTokens[i].correlationId) {
                           const completedPutToken = this._putToken.outstandingPutTokens[i];
                           this._putToken.outstandingPutTokens.splice(i, 1);
+                          //
+                          // If this was the last outstanding put token then get rid of the timer trying to clear out expiring put tokens.
+                          //
+                          if (this._putToken.outstandingPutTokens.length === 0) {
+                            clearTimeout(this._putToken.timeoutTimer);
+                          }
                           if (completedPutToken.putTokenCallback) {
                             /*Codes_SRS_NODE_AMQP_CBS_16_019: [A put token response of 200 will invoke `putTokenCallback` with null parameters.]*/
                             let error = null;


### PR DESCRIPTION
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
If you open and close quite quickly, there will be a 10 second or so delay while a timer in the cbs code is queued to rundown expired put-tokens.

# Description of the solution
If the last put-token is completed stop the timer.  No point in leaving it around.