### PR TITLE
(fix) client Fix path calculation to encode device id (only)

### DIFF
--- a/device/core/src/blob_upload/file_upload_api.ts
+++ b/device/core/src/blob_upload/file_upload_api.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { endpoint, AuthenticationProvider } from 'azure-iot-common';
+import { endpoint, AuthenticationProvider, encodeUriComponentStrict } from 'azure-iot-common';
 import { Http as DefaultHttpTransport } from 'azure-iot-http-base';
 import { UploadParams, FileUpload as FileUploadInterface } from './blob_upload_client';
 import { BlobUploadResult } from './blob_upload_result';
@@ -42,8 +42,8 @@ export class FileUploadApi implements FileUploadInterface {
         if (!blobName) throw new ReferenceError('blobName cannot be \'' + blobName + '\'');
 
         this._authenticationProvider.getDeviceCredentials((err, deviceCredentials) => {
-            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_006: [`getBlobSharedAccessSignature` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files?api-version=<api-version>]*/
-            const path = endpoint.devicePath(deviceCredentials.deviceId) + '/files' + endpoint.versionQueryString();
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_006: [`getBlobSharedAccessSignature` shall create a `POST` HTTP request to a path formatted as the following:`/devices/URI_ENCODED(<deviceId>)/files?api-version=<api-version>]*/
+            const path = endpoint.devicePath(encodeUriComponentStrict(deviceCredentials.deviceId)) + '/files' + endpoint.versionQueryString();
             const body = JSON.stringify({ blobName: blobName });
 
             /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_007: [The `POST` HTTP request shall have the following headers:
@@ -99,8 +99,8 @@ export class FileUploadApi implements FileUploadInterface {
         if (!uploadResult) throw new ReferenceError('uploadResult cannot be \'' + uploadResult + '\'');
 
         this._authenticationProvider.getDeviceCredentials((err, deviceCredentials) => {
-            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_013: [`notifyUploadComplete` shall create a `POST` HTTP request to a path formatted as the following:`/devices/<deviceId>/files/<correlationId>?api-version=<api-version>`]*/
-            const path = endpoint.devicePath(deviceCredentials.deviceId) + '/files/notifications/' + encodeURIComponent(correlationId) + endpoint.versionQueryString();
+            /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_013: [`notifyUploadComplete` shall create a `POST` HTTP request to a path formatted as the following:`/devices/URI_ENCODED(<deviceId>)/files/<correlationId>?api-version=<api-version>`]*/
+            const path = endpoint.devicePath(encodeUriComponentStrict(deviceCredentials.deviceId)) + '/files/notifications/' + encodeURIComponent(correlationId) + endpoint.versionQueryString();
             const body = JSON.stringify(uploadResult);
 
             /*Codes_SRS_NODE_FILE_UPLOAD_ENDPOINT_16_014: [The `POST` HTTP request shall have the following headers:

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -68,8 +68,8 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_DEVICE_HTTP_05_002: [** The `sendEvent` method shall construct an HTTP request using information supplied by the caller, as follows:
 ```
-POST <config.host>/devices/<config.deviceId>/messages/events?api-version=<version> HTTP/1.1
-iothub-to: /devices/<config.deviceId>/messages/events
+POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/events?api-version=<version> HTTP/1.1
+iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/events
 User-Agent: <version string>
 Host: <config.host>
 
@@ -101,8 +101,8 @@ The sendEventBatch method sends a list of events to an IoT hub on behalf of the 
 
 **SRS_NODE_DEVICE_HTTP_05_003: [**The `sendEventBatch` method shall construct an HTTP request using information supplied by the caller, as follows:
 ```
-POST <config.host>/devices/<config.deviceId>/messages/events?api-version=<version> HTTP/1.1
-iothub-to: /devices/<config.deviceId>/messages/events
+POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/events?api-version=<version> HTTP/1.1
+iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/events
 User-Agent: <version string>
 Content-Type: application/vnd.microsoft.iothub.json
 Host: <config.host>
@@ -166,7 +166,7 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_RECEIVER_16_009: [**`abandon` shall construct an HTTP request using information supplied by the caller, as follows:
 ```
-POST <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>/abandon?api-version=<version> HTTP/1.1
+POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>/abandon?api-version=<version> HTTP/1.1
 If-Match: <lockToken>
 Host: <config.host>
 ```
@@ -180,7 +180,7 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_RECEIVER_16_011: [**complete shall construct an HTTP request using information supplied by the caller, as follows:
 ```
-DELETE <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>?api-version=<version> HTTP/1.1
+DELETE <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>?api-version=<version> HTTP/1.1
 If-Match: <lockToken>
 Host: <config.host>
 ```
@@ -195,7 +195,7 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_RECEIVER_16_010: [**`reject` shall construct an HTTP request using information supplied by the caller, as follows:
 ```
-DELETE <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>?api-version=<version>&reject HTTP/1.1
+DELETE <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>?api-version=<version>&reject HTTP/1.1
 If-Match: <lockToken>
 Host: <config.host>
 ```
@@ -209,8 +209,8 @@ Host: <config.host>
 The `receive` method queries the IoT hub for the next message in the indicated device’s cloud-to-device (c2d) message queue. It is a transport-specific method.
 
 **SRS_NODE_DEVICE_HTTP_05_004: [** The receive method shall construct an HTTP request using information supplied by the caller, as follows:
-GET <config.host>/devices/<config.deviceId>/messages/devicebound?api-version=<version> HTTP/1.1
-iothub-to: /devices/<config.deviceId>/messages/devicebound
+GET <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound?api-version=<version> HTTP/1.1
+iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/devicebound
 User-Agent: <version string>
 Host: <config.host>
 **]**

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -9,7 +9,7 @@ const debug = dbg('azure-iot-device-http:Http');
 
 import { EventEmitter } from 'events';
 import { Http as Base } from 'azure-iot-http-base';
-import { endpoint, errors, results, Message, AuthenticationProvider, AuthenticationType, TransportConfig } from 'azure-iot-common';
+import { endpoint, errors, results, Message, AuthenticationProvider, AuthenticationType, TransportConfig, encodeUriComponentStrict } from 'azure-iot-common';
 import { translateError } from './http_errors.js';
 import { IncomingMessage } from 'http';
 import { DeviceMethodResponse, Client, TwinProperties } from 'azure-iot-device';
@@ -139,8 +139,8 @@ export class Http extends EventEmitter implements Client.Transport {
   sendEvent(message: Message, done: (err?: Error, result?: results.MessageEnqueued) => void): void {
     /*Codes_SRS_NODE_DEVICE_HTTP_05_002: [The `sendEvent` method shall construct an HTTP request using information supplied by the caller, as follows:
     ```
-    POST <config.host>/devices/<config.deviceId>/messages/events?api-version=<version> HTTP/1.1
-    iothub-to: /devices/<config.deviceId>/messages/events
+    POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/events?api-version=<version> HTTP/1.1
+    iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/events
     User-Agent: <version string>
     Host: <config.host>
 
@@ -153,7 +153,7 @@ export class Http extends EventEmitter implements Client.Transport {
           /*Codes_SRS_NODE_DEVICE_HTTP_16_033: [if the `getDeviceCredentials` fails with an error, the Http request shall call its callback with that error]*/
           done(err);
         } else {
-          const path = endpoint.eventPath(config.deviceId);
+          const path = endpoint.eventPath(encodeUriComponentStrict(config.deviceId));
           let httpHeaders = {
             'iothub-to': path,
             'User-Agent': this._userAgentString
@@ -275,8 +275,8 @@ export class Http extends EventEmitter implements Client.Transport {
 
           /*Codes_SRS_NODE_DEVICE_HTTP_05_003: [The `sendEventBatch` method shall construct an HTTP request using information supplied by the caller, as follows:
           ```
-          POST <config.host>/devices/<config.deviceId>/messages/events?api-version=<version> HTTP/1.1
-          iothub-to: /devices/<config.deviceId>/messages/events
+          POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/events?api-version=<version> HTTP/1.1
+          iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/events
           User-Agent: <version string>
           Content-Type: application/vnd.microsoft.iothub.json
           Host: <config.host>
@@ -284,7 +284,7 @@ export class Http extends EventEmitter implements Client.Transport {
           {"body":"<Base64 Message1>","properties":{"<key>":"<value>"}},
           {"body":"<Base64 Message1>"}...
           ```]*/
-          const path = endpoint.eventPath(config.deviceId);
+          const path = endpoint.eventPath(encodeUriComponentStrict(config.deviceId));
           let httpHeaders = {
             'iothub-to': path,
             'Content-Type': 'application/vnd.microsoft.iothub.json',
@@ -354,9 +354,9 @@ export class Http extends EventEmitter implements Client.Transport {
    *                  `config` constructor parameter) for the next message in the queue.
    */
   /*Codes_SRS_NODE_DEVICE_HTTP_05_004: [The receive method shall construct an HTTP request using information supplied by the caller, as follows:
-  GET <config.host>/devices/<config.deviceId>/messages/devicebound?api-version=<version> HTTP/1.1
+  GET <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound?api-version=<version> HTTP/1.1
   Authorization: <config.sharedAccessSignature>
-  iothub-to: /devices/<config.deviceId>/messages/devicebound
+  iothub-to: /devices/URI_ENCODED(<config.deviceId>)/messages/devicebound
   User-Agent: <version string>
   Host: <config.host>
   ]*/
@@ -369,7 +369,7 @@ export class Http extends EventEmitter implements Client.Transport {
           debug('Error while receiving: ' + err.toString());
           this.emit('error', err);
         } else {
-          const path = endpoint.messagePath(config.deviceId);
+          const path = endpoint.messagePath(encodeUriComponentStrict(config.deviceId));
           let httpHeaders = {
             'iothub-to': path,
             'User-Agent': this._userAgentString
@@ -618,7 +618,7 @@ export class Http extends EventEmitter implements Client.Transport {
       } else {
         let method;
         let resultConstructor = null;
-        let path = endpoint.feedbackPath(config.deviceId, message.lockToken);
+        let path = endpoint.feedbackPath(encodeUriComponentStrict(config.deviceId), message.lockToken);
         let httpHeaders = {
           'If-Match': message.lockToken,
           'User-Agent': this._userAgentString
@@ -627,7 +627,7 @@ export class Http extends EventEmitter implements Client.Transport {
         this._insertAuthHeaderIfNecessary(httpHeaders, config);
 
         /*Codes_SRS_NODE_DEVICE_HTTP_RECEIVER_16_009: [abandon shall construct an HTTP request using information supplied by the caller, as follows:
-        POST <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>/abandon?api-version=<version> HTTP/1.1
+        POST <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>/abandon?api-version=<version> HTTP/1.1
         Authorization: <config.sharedAccessSignature>
         If-Match: <lockToken>
         Host: <config.host>]
@@ -638,7 +638,7 @@ export class Http extends EventEmitter implements Client.Transport {
           resultConstructor = results.MessageAbandoned;
         } else if (action === 'reject') {
           /*Codes_SRS_NODE_DEVICE_HTTP_RECEIVER_16_010: [reject shall construct an HTTP request using information supplied by the caller, as follows:
-          DELETE <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>?api-version=<version>&reject HTTP/1.1
+          DELETE <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>?api-version=<version>&reject HTTP/1.1
           Authorization: <config.sharedAccessSignature>
           If-Match: <lockToken>
           Host: <config.host>]*/
@@ -647,7 +647,7 @@ export class Http extends EventEmitter implements Client.Transport {
           resultConstructor = results.MessageRejected;
         } else {
           /*Codes_SRS_NODE_DEVICE_HTTP_RECEIVER_16_011: [complete shall construct an HTTP request using information supplied by the caller, as follows:
-          DELETE <config.host>/devices/<config.deviceId>/messages/devicebound/<lockToken>?api-version=<version> HTTP/1.1
+          DELETE <config.host>/devices/URI_ENCODED(<config.deviceId>)/messages/devicebound/<lockToken>?api-version=<version> HTTP/1.1
           Authorization: <config.sharedAccessSignature>
           If-Match: <lockToken>
           Host: <config.host>]*/


### PR DESCRIPTION
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Device Id's with special characters weren't getting through the paths correctly.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Encode the device id in the paths.