### PR TITLE
missed bumping patch version on azure-iot-provisioning-device

### DIFF
--- a/provisioning/device/package.json
+++ b/provisioning/device/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-provisioning-device",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Azure Device Provisioning SDK device client",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/provisioning/device/samples/package.json
+++ b/provisioning/device/samples/package.json
@@ -5,7 +5,7 @@
   "author": "Microsoft Corporation",
   "license": "MIT",
   "dependencies": {
-    "azure-iot-provisioning-device": "1.1.2",
+    "azure-iot-provisioning-device": "1.1.3",
     "azure-iot-provisioning-device-amqp": "1.1.4",
     "azure-iot-provisioning-device-http": "1.1.4",
     "azure-iot-provisioning-device-mqtt": "1.0.5",

--- a/provisioning/e2e/package.json
+++ b/provisioning/e2e/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "async": "^2.6.0",
     "azure-iot-common": "1.5.1",
-    "azure-iot-provisioning-device": "1.1.2",
+    "azure-iot-provisioning-device": "1.1.3",
     "azure-iot-provisioning-device-amqp": "1.1.4",
     "azure-iot-provisioning-device-http": "1.1.4",
     "azure-iot-provisioning-device-mqtt": "1.0.5",

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -10,7 +10,7 @@
     "async": "^2.6.0",
     "azure-iot-amqp-base": "1.5.2",
     "azure-iot-common": "1.5.1",
-    "azure-iot-provisioning-device": "1.1.2",
+    "azure-iot-provisioning-device": "1.1.3",
     "bluebird": "^3.5.0",
     "buffer-builder": "^0.2.0",
     "debug": "^3.0.1",

--- a/provisioning/transport/http/package.json
+++ b/provisioning/transport/http/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "azure-iot-http-base": "1.4.1",
     "azure-iot-common": "1.5.1",
-    "azure-iot-provisioning-device": "1.1.2",
+    "azure-iot-provisioning-device": "1.1.3",
     "debug": "^3.0.1",
     "machina": "^2.0.1"
   },

--- a/provisioning/transport/mqtt/package.json
+++ b/provisioning/transport/mqtt/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "azure-iot-common": "1.5.1",
     "azure-iot-mqtt-base": "1.4.1",
-    "azure-iot-provisioning-device": "1.1.2",
+    "azure-iot-provisioning-device": "1.1.3",
     "debug": "^3.0.1",
     "machina": "^2.0.1",
     "uuid": "^3.1.0"


### PR DESCRIPTION
My last version bump missed the azure-iot-provisioning-device version :(