### PR TITLE
Export ModuleClient

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 - [Need Support?](#need-support)
 - [File a bug](#file-a-bug)
-- [Contribute documentation](#contribute-documentation)
-- [Contribute code](#contribute-code)
+- [Contribute code and/or documentation](#contribute-code-andor-documentation)
 
 # Need Support?
 - **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize

--- a/device/core/device.d.ts
+++ b/device/core/device.d.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 export { Client } from './lib/device_client';
+export { ModuleClient } from './lib/module_client';
 export import ConnectionString = require('./lib/connection_string');
 export import SharedAccessSignature = require('./lib/shared_access_signature');
 export { Message } from 'azure-iot-common';

--- a/device/core/device.js
+++ b/device/core/device.js
@@ -45,6 +45,7 @@ var common = require('azure-iot-common');
 
 module.exports = {
   Client: require('./lib/device_client.js').Client,
+  ModuleClient: require('./lib/module_client.js').ModuleClient,
   ConnectionString: require('./lib/connection_string.js'),
   Message: common.Message,
   SharedAccessSignature: require('./lib/shared_access_signature.js'),

--- a/device/edge-sample/edge_sample_module.js
+++ b/device/edge-sample/edge_sample_module.js
@@ -4,7 +4,7 @@
 'use strict';
 
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-var Client = require('azure-iot-device').Client;
+var Client = require('azure-iot-device').ModuleClient;
 var Message = require('azure-iot-device').Message;
 var fs = require('fs');
 


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
After the split of `Client` into `Client` and `ModuleClient`, the `ModuleClient` is not exported. As a result, the client code cannot import `ModuleClient`.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Export `ModuleClient`