### PR TITLE
Add unix domain socket support to HTTP client

### DIFF
--- a/common/transport/http/devdoc/http_requirements.md
+++ b/common/transport/http/devdoc/http_requirements.md
@@ -23,14 +23,14 @@ request.end();
 ```
 
 ## Public Interface
-### buildRequest(method, path, httpHeaders, host, done)
+### buildRequest(method, path, httpHeaders, host, x509Options, done)
 The buildRequest method receives all the information necessary to make an HTTP request to an IoT hub.  This method should only be called by higher-level Azure IoT Hub libraries, and does not validate input.
 
 **SRS_NODE_HTTP_05_001: [** `buildRequest` shall accept the following arguments:
 - `method` - an HTTP verb, e.g., 'GET', 'POST', 'DELETE'
 - `path` - the path to the resource, not including the hostname
 - `httpHeaders` - an object whose properties represent the names and values of HTTP headers to include in the request
-- `host` - the fully-qualified DNS hostname of the IoT hub
+- `host` - the fully-qualified DNS hostname of the IoT hub or an object containing a unix domain socket path in a property named `socketPath`
 - `x509Options` - *[optional]* the x509 certificate, key and passphrase that are needed to connect to the service using x509 certificate authentication
 - `done` - a callback that will be invoked when a completed response is returned from the server **]**
 
@@ -42,6 +42,14 @@ The buildRequest method receives all the information necessary to make an HTTP r
 - `err` - the standard JavaScript `Error` object if status code >= 300, otherwise null
 - `body` - the body of the HTTP response as a string
 - `response` - the Node.js `http.ServerResponse` object returned by the transport **]**
+
+**SRS_NODE_HTTP_13_002: [** If the `host` argument is a string then assign its value to the `host` property of `httpOptions`. **]**
+
+**SRS_NODE_HTTP_13_003: [** If the `host` argument is an object then assign its `socketPath` property to the `socketPath` property of `httpOptions`. **]**
+
+**SRS_NODE_HTTP_13_004: [** Use the request object from the `https` module when dealing with TCP based HTTP requests. **]**
+
+**SRS_NODE_HTTP_13_005: [** Use the request object from the `http` module when dealing with unix domain socket based HTTP requests. **]**
 
 **SRS_NODE_HTTP_16_001: [** If `x509Options` is specified, the certificate, key and passphrase in the structure shall be used to authenticate the connection. **]**
 

--- a/common/transport/http/devdoc/rest_api_client_requirements.md
+++ b/common/transport/http/devdoc/rest_api_client_requirements.md
@@ -22,7 +22,7 @@ The `RestApiClient` constructor initializes a new instance of a `RestApiClient` 
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_001: [** The `RestApiClient` constructor shall throw a `ReferenceError` if config is falsy. **]**
 
-**SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [** The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property and a `socketPath` property. **]**
+**SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [** The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property. **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_18_001: [** The `RestApiClient` constructor shall throw a `ReferenceError` if `userAgent` is falsy. **]**
 

--- a/common/transport/http/devdoc/rest_api_client_requirements.md
+++ b/common/transport/http/devdoc/rest_api_client_requirements.md
@@ -22,7 +22,7 @@ The `RestApiClient` constructor initializes a new instance of a `RestApiClient` 
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_001: [** The `RestApiClient` constructor shall throw a `ReferenceError` if config is falsy. **]**
 
-**SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [** The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property. **]**
+**SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [** The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property and a `socketPath` property. **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_18_001: [** The `RestApiClient` constructor shall throw a `ReferenceError` if `userAgent` is falsy. **]**
 

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -44,8 +44,8 @@ export class RestApiClient {
   constructor(config: RestApiClient.TransportConfig, userAgent: string, httpRequestBuilder?: HttpBase) {
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_001: [The `RestApiClient` constructor shall throw a `ReferenceError` if config is falsy.]*/
     if (!config) throw new ReferenceError('config cannot be \'' + config + '\'');
-    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property and a `socketPath` property.]*/
-    if (!config.host && !config.socketPath) throw new errors.ArgumentError('config.host and config.socketPath both cannot be unspecified');
+    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property.]*/
+    if (!config.host) throw new errors.ArgumentError('config.host cannot be \'' + config.host + '\'');
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_18_001: [The `RestApiClient` constructor shall throw a `ReferenceError` if `userAgent` is falsy.]*/
     if (!userAgent) throw new ReferenceError('userAgent cannot be \'' + userAgent + '\'');
 
@@ -138,13 +138,12 @@ export class RestApiClient {
     };
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_008: [The `executeApiCall` method shall build the HTTP request using the arguments passed by the caller.]*/
-    const hostOrPath = this._config.host || { socketPath: this._config.socketPath };
     let request: ClientRequest;
     if (!!this._config.x509) {
       /* Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_18_002: [ If an `x509` cert was passed into the constructor via the `config` object, `executeApiCall` shall use it to establish the TLS connection. ] */
-       request = this._http.buildRequest(method, path, httpHeaders, hostOrPath, this._config.x509, requestCallback);
+       request = this._http.buildRequest(method, path, httpHeaders, this._config.host, this._config.x509, requestCallback);
     } else {
-       request = this._http.buildRequest(method, path, httpHeaders, hostOrPath, requestCallback);
+       request = this._http.buildRequest(method, path, httpHeaders, this._config.host, requestCallback);
     }
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_030: [If `timeout` is defined and is not a function, the HTTP request timeout shall be adjusted to match the value of the argument.]*/
@@ -274,8 +273,7 @@ export class RestApiClient {
 
 export namespace RestApiClient {
     export interface TransportConfig {
-        host?: string;
-        socketPath?: string;
+        host: string | { socketPath: string };
         sharedAccessSignature?: string | SharedAccessSignature;
         x509?: X509;
     }

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -44,8 +44,8 @@ export class RestApiClient {
   constructor(config: RestApiClient.TransportConfig, userAgent: string, httpRequestBuilder?: HttpBase) {
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_001: [The `RestApiClient` constructor shall throw a `ReferenceError` if config is falsy.]*/
     if (!config) throw new ReferenceError('config cannot be \'' + config + '\'');
-    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property.]*/
-    if (!config.host) throw new errors.ArgumentError('config.host cannot be \'' + config.host + '\'');
+    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property and a `socketPath` property.]*/
+    if (!config.host && !config.socketPath) throw new errors.ArgumentError('config.host and config.socketPath both cannot be unspecified');
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_18_001: [The `RestApiClient` constructor shall throw a `ReferenceError` if `userAgent` is falsy.]*/
     if (!userAgent) throw new ReferenceError('userAgent cannot be \'' + userAgent + '\'');
 
@@ -138,12 +138,13 @@ export class RestApiClient {
     };
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_008: [The `executeApiCall` method shall build the HTTP request using the arguments passed by the caller.]*/
+    const hostOrPath = this._config.host || { socketPath: this._config.socketPath };
     let request: ClientRequest;
     if (!!this._config.x509) {
       /* Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_18_002: [ If an `x509` cert was passed into the constructor via the `config` object, `executeApiCall` shall use it to establish the TLS connection. ] */
-       request = this._http.buildRequest(method, path, httpHeaders, this._config.host, this._config.x509, requestCallback);
+       request = this._http.buildRequest(method, path, httpHeaders, hostOrPath, this._config.x509, requestCallback);
     } else {
-       request = this._http.buildRequest(method, path, httpHeaders, this._config.host, requestCallback);
+       request = this._http.buildRequest(method, path, httpHeaders, hostOrPath, requestCallback);
     }
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_030: [If `timeout` is defined and is not a function, the HTTP request timeout shall be adjusted to match the value of the argument.]*/
@@ -273,7 +274,8 @@ export class RestApiClient {
 
 export namespace RestApiClient {
     export interface TransportConfig {
-        host: string;
+        host?: string;
+        socketPath?: string;
         sharedAccessSignature?: string | SharedAccessSignature;
         x509?: X509;
     }

--- a/common/transport/http/test/_http_test.js
+++ b/common/transport/http/test/_http_test.js
@@ -2,6 +2,7 @@
 
 var Http = require('../lib/http.js').Http;
 var https = require('https');
+const node_http = require('http');
 var assert = require('chai').assert;
 var sinon = require('sinon');
 var EventEmitter = require('events');
@@ -52,6 +53,28 @@ describe('Http', function() {
       assert(https.request.called);
       var httpOptions = https.request.firstCall.args[0];
       assert.strictEqual(httpOptions.agent, fakeOptions.http.agent);
+      callback();
+    });
+
+    // Tests_SRS_NODE_HTTP_13_004: [ Use the request object from the https module when dealing with TCP based HTTP requests. ]
+    it ('uses https when using tcp', function(callback) {
+      var http = new Http();
+      http.setOptions(fakeOptions);
+      http.buildRequest('GET', fakePath, fakeHeaders, fakeHost, function() {});
+      assert(https.request.called);
+      callback();
+    });
+
+    // // Tests_SRS_NODE_HTTP_13_005: [ Use the request object from the http module when dealing with unix domain socket based HTTP requests. ]
+    it ('uses http when using unix domain socket', function(callback) {
+      after(function() {
+        node_http.request.restore();
+      });
+      sinon.stub(node_http, 'request').returns(new EventEmitter());
+      var http = new Http();
+      http.setOptions(fakeOptions);
+      http.buildRequest('GET', fakePath, fakeHeaders, { socketPath: fakeHost }, function() {});
+      assert(node_http.request.called);
       callback();
     });
 

--- a/common/transport/http/test/_rest_api_client_test.js
+++ b/common/transport/http/test/_rest_api_client_test.js
@@ -10,7 +10,7 @@ var HttpBase = require('../lib/http.js').Http;
 var RestApiClient = require('../lib/rest_api_client.js').RestApiClient;
 
 var fakeConfig = { host: 'host', sharedAccessSignature: 'sas' };
-var socketConfig = { socketPath: '/var/run/foo.sock', sharedAccessSignature: 'sas' };
+var socketConfig = { host: { socketPath: '/var/run/foo.sock' }, sharedAccessSignature: 'sas' };
 var fakeAgent = 'agentString';
 
 describe('RestApiClient', function() {
@@ -33,11 +33,11 @@ describe('RestApiClient', function() {
       });
     });
 
-    /*Tests_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property and a `socketPath` property.]*/
-    ['host', 'socketPath'].forEach(function(badPropName) {
+    /*Tests_SRS_NODE_IOTHUB_REST_API_CLIENT_16_002: [The `RestApiClient` constructor shall throw an `ArgumentError` if config is missing a `host` property.]*/
+    ['host'].forEach(function(badPropName) {
       [undefined, null, ''].forEach(function(badPropValue) {
         it('throws an ArgumentError if config.' + badPropName + ' is \'' + badPropValue + '\'', function() {
-          var badConfig = { sharedAccessSignature: 'sas' };
+          var badConfig = JSON.parse(JSON.stringify(fakeConfig));
           badConfig[badPropName] = badPropValue;
           assert.throws(function() {
             return new RestApiClient(badConfig, fakeAgent);
@@ -191,9 +191,9 @@ describe('RestApiClient', function() {
             assert.equal(headers[testHeaderKey], testHeaderValue);
 
             if (typeof(host) === 'string') {
-              assert.equal(host, transportConfig.host);
+              assert.equal(transportConfig.host, host);
             } else {
-              assert.equal(host.socketPath, transportConfig.socketPath);
+              assert.equal(transportConfig.host.socketPath, host.socketPath);
             }
 
             return {


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [X] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [X] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [X] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

The HTTP wrapper in `common/transport/http` does not support Unix Domain Sockets right now. This is needed in order to be able to communicate with iotedged.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->

This PR adds support Unix Domain Sockets by leveraging the `socketPath` property that the underlying Node HTTP/HTTPS module supports.