### PR TITLE
Add signature provider

### DIFF
--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -11,6 +11,7 @@ export { anHourFromNow, encodeUriComponentStrict } from './lib/authorization';
 export { ConnectionString } from './lib/connection_string';
 export { Message }
 export { SharedAccessSignature } from './lib/shared_access_signature';
+export { SignatureProvider } from './lib/signature_provider';
 export { RetryOperation } from './lib/retry_operation';
 export { RetryPolicy, NoRetry, ExponentialBackOffWithJitter } from './lib/retry_policy';
 export { AuthenticationProvider, AuthenticationType } from './lib/authentication_provider';

--- a/common/core/src/signature_provider.ts
+++ b/common/core/src/signature_provider.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import { SharedAccessSignature } from './shared_access_signature';
+
+/**
+ * Interface that must be implemented by objects that are able to sign some
+ * arbitrary data and yield a SharedAccessSignature.
+ */
+export interface SignatureProvider {
+    sign(keyName: string, data: string, callback: (err: Error, signature: SharedAccessSignature) => void): void;
+}

--- a/device/core/devdoc/sak_authentication_provider_requirements.md
+++ b/device/core/devdoc/sak_authentication_provider_requirements.md
@@ -30,6 +30,8 @@ sakAuthProvider.on('newTokenAvailable', function (credentials) {
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_011: [** The `constructor` shall throw an `ArgumentError` if the `tokenRenewalMarginInSeconds` is less than or equal `tokenValidTimeInSeconds`. **]**
 
+**SRS_NODE_SAK_AUTH_PROVIDER_13_001: [** The `constructor` shall save the supplied signature provider or create a `SharedAccessKeySignatureProvider` object instance by default. **]**
+
 ## getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_003: [** The `getDeviceCredentials` should call its callback with a `null` first parameter and a `TransportConfig` object as a second parameter, containing the latest valid token it generated. **]**
@@ -45,16 +47,3 @@ sakAuthProvider.on('newTokenAvailable', function (credentials) {
 **SRS_NODE_SAK_AUTH_PROVIDER_16_007: [** The `fromConnectionString` method shall throw an `errors.ArgumentError` if the `connectionString` does not have a SharedAccessKey parameter. **]**
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_008: [** The `fromConnectionString` method shall extract the credentials from the `connectionString` argument and create a new `SharedAccessKeyAuthenticationProvider` that uses these credentials to generate security tokens. **]**
-
-# Generated Security Token
-
-**SRS_NODE_SAK_AUTH_PROVIDER_16_009: [** Every token shall be created with a validity period of `tokenValidTimeInSeconds` if specified when the constructor was called, or 1 hour by default. **]**
-
-**SRS_NODE_SAK_AUTH_PROVIDER_16_010: [** Every token shall be created using the `azure-iot-common.SharedAccessSignature.create` method and then serialized as a string, with the arguments to the create methods being:
-```
-resourceUri: <IoT hub host>/devices/<deviceId>
-keyName: the `SharedAccessKeyName` parameter of the connection string or `null`
-key: the `SharedAccessKey` parameter of the connection string
-expiry: the expiration time of the token, which is now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).
-```
-**]**

--- a/device/core/devdoc/sak_signature_provider_requirement.md
+++ b/device/core/devdoc/sak_signature_provider_requirement.md
@@ -1,0 +1,25 @@
+# SharedAccessKeySignatureProvider Requirements
+
+# Overview
+
+The `SharedAccessKeySignatureProvider` class implements the `SignatureProvider` interface by using a shared access key based HMAC algorithm. This is used to provide credentials to transports when the user wants the device to authenticate using security tokens.
+
+# Public API
+
+# constructor(private _sharedAccessKey: string, tokenValidTimeInSeconds?: number)
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_003: [** The `constructor` shall throw an `ArgumentError` if the `_sharedAccessKey` parameter is falsy. **]**
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_004: [** The `constructor` shall save the `tokenValidTimeInSeconds` parameter if supplied. If not, it shall default to 3600 seconds (1 hour). **]**
+
+# sign(keyName: string, data: string, callback: (err: Error, signature: SharedAccessSignature) => void): void
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_005: [** The `sign` method shall throw a `ReferenceError` if the `callback` parameter is falsy or is not a function. **]**
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_006: [** The `sign` method invoke `callback` with a `ReferenceError` if the `data` parameter is falsy. **]**
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_001: [** Every token shall be created with a validity period of `tokenValidTimeInSeconds` if specified when the constructor was called, or 1 hour by default. **]**
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_002: [** Every token shall be created using the azure-iot-common.SharedAccessSignature.create method and then serialized as a string. The the expiration time of the token will be now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC). **]**
+
+**SRS_NODE_SAK_SIG_PROVIDER_13_007: [** `sign` shall invoke the callback with the result of calling `azure-iot-common.SharedAccessSignature.create`. **]**

--- a/device/core/src/sak_authentication_provider.ts
+++ b/device/core/src/sak_authentication_provider.ts
@@ -2,7 +2,11 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 import { EventEmitter } from 'events';
-import { AuthenticationProvider, AuthenticationType, ConnectionString, SharedAccessSignature, errors, TransportConfig, encodeUriComponentStrict } from 'azure-iot-common';
+import {
+  AuthenticationProvider, AuthenticationType, ConnectionString,
+  SignatureProvider, TransportConfig, encodeUriComponentStrict, errors
+} from 'azure-iot-common';
+import { SharedAccessKeySignatureProvider } from './sak_signature_provider';
 
 /**
  * Provides an `AuthenticationProvider` object that can be created simply with a connection string and is then used by the device client and transports to authenticate
@@ -21,6 +25,7 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
   private _renewalTimeout: NodeJS.Timer;
 
   private _credentials: TransportConfig;
+  private _signatureProvider: SignatureProvider;
 
   /**
    * @private
@@ -31,7 +36,7 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
    * @param tokenValidTimeInSeconds        [optional] The number of seconds for which a token is supposed to be valid.
    * @param tokenRenewalMarginInSeconds    [optional] The number of seconds before the end of the validity period during which the `SharedAccessKeyAuthenticationProvider` should renew the token.
    */
-  constructor(credentials: TransportConfig, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number) {
+  constructor(credentials: TransportConfig, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number, signatureProvider?: SignatureProvider) {
     super();
     /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_001: [The `constructor` shall create the initial token value using the `credentials` parameter.]*/
     this._credentials  = credentials;
@@ -44,6 +49,9 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
       throw new errors.ArgumentError('tokenRenewalMarginInSeconds must be less than tokenValidTimeInSeconds');
     }
 
+    // Codes_SRS_NODE_SAK_AUTH_PROVIDER_13_001: [ The constructor shall save the supplied signature provider or create a SharedAccessKeySignatureProvider object instance by default. ]
+    this._signatureProvider = signatureProvider || new SharedAccessKeySignatureProvider(this._credentials.sharedAccessKey, this._tokenValidTimeInSeconds);
+
     /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_002: [The `constructor` shall start a timer that will automatically renew the token every (`tokenValidTimeInSeconds` - `tokenRenewalMarginInSeconds`) seconds if specified, or 45 minutes by default.]*/
     this._renewToken();
   }
@@ -54,12 +62,12 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
    * @param callback function that will be called with either an error or a set of device credentials that can be used to authenticate with the IoT hub.
    */
   getDeviceCredentials(callback: (err: Error, credentials?: TransportConfig) => void): void {
-    if (this._shouldRenewToken()) {
-      this._renewToken();
-    }
-
     /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_003: [The `getDeviceCredentials` should call its callback with a `null` first parameter and a `TransportConfig` object as a second parameter, containing the latest valid token it generated.]*/
-    callback(null, this._credentials);
+    if (this._shouldRenewToken()) {
+      this._renewToken(callback);
+    } else {
+      callback(null, this._credentials);
+    }
   }
 
   private _shouldRenewToken(): boolean {
@@ -67,33 +75,37 @@ export class SharedAccessKeyAuthenticationProvider extends EventEmitter implemen
     return (this._currentTokenExpiryTimeInSeconds - currentTimeInSeconds) < this._tokenRenewalMarginInSeconds;
   }
 
-  private _renewToken(): void {
+  private _renewToken(callback?: (err: Error, credentials?: TransportConfig) => void): void {
     if (this._renewalTimeout) {
       clearTimeout(this._renewalTimeout);
     }
 
-    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_009: [Every token shall be created with a validity period of `tokenValidTimeInSeconds` if specified when the constructor was called, or 1 hour by default.]*/
-    const newExpiry =  Math.floor(Date.now() / 1000) + this._tokenValidTimeInSeconds;
-
-    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_010: [Every token shall be created using the `azure-iot-common.SharedAccessSignature.create` method and then serialized as a string, with the arguments to the create methods being:
-    ```
-    resourceUri: <IoT hub host>/devices/<deviceId>
-    keyName: the `SharedAccessKeyName` parameter of the connection string or `null`
-    key: the `SharedAccessKey` parameter of the connection string
-    expiry: the expiration time of the token, which is now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).
-    ```]*/
     let resourceString = this._credentials.host + '/devices/' + this._credentials.deviceId;
     if (this._credentials.moduleId) {
       resourceString += '/modules/' + this._credentials.moduleId;
     }
     const resourceUri = encodeUriComponentStrict(resourceString);
-    const sas = SharedAccessSignature.create(resourceUri, this._credentials.sharedAccessKeyName, this._credentials.sharedAccessKey, newExpiry);
-    this._credentials.sharedAccessSignature = sas.toString();
 
-    const nextRenewalTimeout = (this._tokenValidTimeInSeconds - this._tokenRenewalMarginInSeconds) * 1000;
-    this._renewalTimeout = setTimeout(() => this._renewToken(), nextRenewalTimeout);
-    /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_005: [Every time a new token is created, the `newTokenAvailable` event shall be fired with the updated credentials.]*/
-    this.emit('newTokenAvailable', this._credentials);
+    this._signatureProvider.sign(this._credentials.sharedAccessKeyName, resourceUri, (err, sas) => {
+      if (err) {
+        this.emit('error', err);
+
+        if (callback) {
+          callback(err, null);
+        }
+      } else {
+        this._credentials.sharedAccessSignature = sas.toString();
+
+        const nextRenewalTimeout = (this._tokenValidTimeInSeconds - this._tokenRenewalMarginInSeconds) * 1000;
+        this._renewalTimeout = setTimeout(() => this._renewToken(), nextRenewalTimeout);
+        /*Codes_SRS_NODE_SAK_AUTH_PROVIDER_16_005: [Every time a new token is created, the `newTokenAvailable` event shall be fired with the updated credentials.]*/
+        this.emit('newTokenAvailable', this._credentials);
+
+        if (callback) {
+          callback(null, this._credentials);
+        }
+      }
+    });
   }
 
   /**

--- a/device/core/src/sak_signature_provider.ts
+++ b/device/core/src/sak_signature_provider.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+import {
+  SignatureProvider,
+  SharedAccessSignature,
+  errors
+} from 'azure-iot-common';
+
+export class SharedAccessKeySignatureProvider implements SignatureProvider {
+  private _tokenValidTimeInSeconds: number = 3600; // 1 hour
+
+  constructor(
+    private _sharedAccessKey: string,
+    tokenValidTimeInSeconds?: number
+  ) {
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_003: [ The constructor shall throw an ArgumentError if the _sharedAccessKey parameter is falsy. ]
+    if (!this._sharedAccessKey) {
+      throw new errors.ArgumentError(
+        '_sharedAccessKey cannot be "' + this._sharedAccessKey + '".'
+      );
+    }
+
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_004: [ The constructor shall save the tokenValidTimeInSeconds parameter if supplied. If not, it shall default to 3600 seconds (1 hour). ]
+    if (tokenValidTimeInSeconds)
+      this._tokenValidTimeInSeconds = tokenValidTimeInSeconds;
+  }
+
+  sign(
+    keyName: string,
+    data: string,
+    callback: (err: Error, signature: SharedAccessSignature) => void
+  ): void {
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_005: [ The sign method shall throw a ReferenceError if the callback parameter is falsy or is not a function. ]
+    if (!callback || typeof callback !== 'function') {
+      throw new ReferenceError('callback cannot be \'' + callback + '\'');
+    }
+
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_006: [ The sign method shall invoke callback with a ReferenceError if the data parameter is falsy. ]
+    if (!data) {
+      callback(new ReferenceError('data cannot be \'' + data + '\''), null);
+      return;
+    }
+
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_001: [ Every token shall be created with a validity period of tokenValidTimeInSeconds if specified when the constructor was called, or 1 hour by default. ]
+    const newExpiry =
+      Math.floor(Date.now() / 1000) + this._tokenValidTimeInSeconds;
+
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_002: [ Every token shall be created using the azure-iot-common.SharedAccessSignature.create method and then serialized as a string. The the expiration time of the token will be now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).]
+    const sas = SharedAccessSignature.create(
+      data,
+      keyName,
+      this._sharedAccessKey,
+      newExpiry
+    );
+
+    // Codes_SRS_NODE_SAK_SIG_PROVIDER_13_007: [ sign shall invoke the callback with the result of calling azure-iot-common.SharedAccessSignature.create. ]
+    callback(null, sas);
+  }
+}

--- a/device/core/test/_sak_authentication_provider_test.js
+++ b/device/core/test/_sak_authentication_provider_test.js
@@ -11,6 +11,7 @@ var SharedAccessKeyAuthenticationProvider = require('../lib/sak_authentication_p
 
 describe('SharedAccessKeyAuthenticationProvider', function () {
   describe('#constructor', function () {
+
     /*Tests_SRS_NODE_SAK_AUTH_PROVIDER_16_001: [The `constructor` shall create the initial token value using the `credentials` parameter.]*/
     it('initializes the credentials', function (testCallback) {
       var fakeCredentials = {

--- a/device/core/test/_sak_signature_provider_test.js
+++ b/device/core/test/_sak_signature_provider_test.js
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var SharedAccessKeySignatureProvider = require('../lib/sak_signature_provider')
+  .SharedAccessKeySignatureProvider;
+var SharedAccessSignature = require('azure-iot-common').SharedAccessSignature;
+var errors = require('azure-iot-common').errors;
+
+describe('SharedAccessKeySignatureProvider', function() {
+  describe('#constructor', function() {
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_003: [ The constructor shall throw an ArgumentError if the _sharedAccessKey parameter is falsy. ]
+    [null, undefined, ''].forEach(function(badKey) {
+      it("throws if the key is '" + badKey + "'", function(testCallback) {
+        assert.throws(function() {
+          new SharedAccessKeySignatureProvider(badKey);
+        }, errors.ArgumentError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_004: [ The constructor shall save the tokenValidTimeInSeconds parameter if supplied. If not, it shall default to 3600 seconds (1 hour). ]
+    it('token expiry defaults to 3600 seconds', function(testCallback) {
+      var provider = new SharedAccessKeySignatureProvider('somekey');
+      assert.equal(provider._tokenValidTimeInSeconds, 3600);
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_004: [ The constructor shall save the tokenValidTimeInSeconds parameter if supplied. If not, it shall default to 3600 seconds (1 hour). ]
+    it('token expiry is saved if supplied', function(testCallback) {
+      var provider = new SharedAccessKeySignatureProvider('somekey', 2000);
+      assert.equal(provider._tokenValidTimeInSeconds, 2000);
+      testCallback();
+    });
+  });
+
+  describe('#sign', function() {
+    before(function() {
+      sinon.spy(SharedAccessSignature, 'create');
+    });
+
+    after(function() {
+      SharedAccessSignature.create.restore();
+    });
+
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_005: [ The sign method shall throw a ReferenceError if the callback parameter is falsy or is not a function. ]
+    [null, undefined, '', 'not a function', 20].forEach(function(badCallback) {
+      it("throws if the callback is '" + badCallback + "'", function(
+        testCallback
+      ) {
+        var provider = new SharedAccessKeySignatureProvider('somekey');
+        assert.throws(function() {
+          provider.sign('key1', 'data', badCallback);
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_006: [ The sign method shall invoke callback with a ReferenceError if the data parameter is falsy. ]
+    [null, undefined, ''].forEach(function(badData) {
+      it(
+        "invokes callback with ReferenceError if data is '" + badData + "'",
+        function(testCallback) {
+          var provider = new SharedAccessKeySignatureProvider('somekey');
+          provider.sign('key1', badData, function(err) {
+            assert.instanceOf(err, ReferenceError);
+            testCallback();
+          });
+        }
+      );
+    });
+
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_007: [ sign shall invoke the callback with the result of calling azure-iot-common.SharedAccessSignature.create. ]
+    // Tests_SRS_NODE_SAK_SIG_PROVIDER_13_002: [ Every token shall be created using the azure-iot-common.SharedAccessSignature.create method and then serialized as a string. The the expiration time of the token will be now + the token validity time, formatted as the number of seconds since Epoch (Jan 1st, 1970, 00:00 UTC).]
+    [null, undefined, '', 'key1'].forEach(function(keyName, index) {
+      it("signs with key name '" + keyName + "'", function(testCallback) {
+        var provider = new SharedAccessKeySignatureProvider('somekey');
+        provider.sign(keyName, 'somedata', function(err, signature) {
+          assert.isNull(err);
+          assert.isNotNull(signature);
+          assert.isNotNull(signature.sig);
+          assert.isAtLeast(signature.se, Math.floor(Date.now() / 1000));
+          assert.equal(
+            SharedAccessSignature.create.getCall(index).args[0],
+            'somedata'
+          );
+          assert.equal(
+            SharedAccessSignature.create.getCall(index).args[1],
+            keyName
+          );
+          assert.equal(
+            SharedAccessSignature.create.getCall(index).args[2],
+            'somekey'
+          );
+
+          testCallback();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Factor out computation of SAS tokens into a separate `SignatureProvider` interface and implementation. This allows for additional flexibility when its time to add support for other kinds of signature providers -- specifically, the one provided by Azure IoT Edge where the signature computation is backed by `iotedged`.