### PR TITLE
feat(provisioning:service): Add iotEdge capability in IndividualEnrollment interface

### DIFF
--- a/provisioning/e2e/_service_create_delete.js
+++ b/provisioning/e2e/_service_create_delete.js
@@ -20,7 +20,10 @@ var enrollment = {
       endorsementKey: "AToAAQALAAMAsgAgg3GXZ0SEs/gakMyNRqXXJP1S124GUgtk8qHaGzMUaaoABgCAAEMAEAgAAAAAAAEAtKEADl/sNRgmYAjP6gXmbccRaJoTnVixisUaek0OwAzFGN70xt9ZOYp6fhIwfcft3fdVKOrKpXYcTe72CGNkGJGlQz5ti9n2pQ0uJhcX8aefh4Onm7lVlUCQAVp1K0r6zI8vkEXWsBIvwvxk0eMJbFaq146kbTkJHIGczb89RkFH2TX+CgXeZOG9oXQzUNwktmTUacspamune5Wywc/ce8HsDFYchyUHogFhrZ/LPnzyTDXO8sSC5z5dvsUBtUME3iRYDyKgZOfBtmRMqQewD+4iH+ZEJjtsyJiWR8hFhyKROnOuqXfNFwjd5IcNU4wtlKO0cLyXmTOfQK6Da1pr5Q=="
     }
   },
-  provisioningStatus: "enabled"
+  provisioningStatus: "enabled",
+  capabilities: {
+    iotEdge: true
+  }
 };
 
 var enrollmentGroup = {

--- a/provisioning/service/package.json
+++ b/provisioning/service/package.json
@@ -31,7 +31,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 77 --branches 72 --lines 77 --functions 72",
+    "check-cover": "istanbul check-coverage --statements 77 --branches 73 --lines 77 --functions 72",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js"
   },
   "engines": {

--- a/provisioning/service/src/interfaces.ts
+++ b/provisioning/service/src/interfaces.ts
@@ -268,6 +268,16 @@ export interface DeviceRegistrationState {
 export type RegistrationStatus = 'unassigned' | 'assigning' | 'assigned' | 'failed' | 'disabled';
 
 /**
+ * Capabilities of the device that will be provisioned using this enrollment record.
+ */
+export interface DeviceCapabilities {
+  /**
+   * Boolean indicating whether the provisioned device is an Azure IoT Edge device.
+   */
+  iotEdge: boolean;
+}
+
+/**
  * The individual enrollment record.
  */
 export interface IndividualEnrollment {
@@ -320,6 +330,11 @@ export interface IndividualEnrollment {
    * could include an update or an actual registration.
    */
   lastUpdatedDateTimeUtc: string;
+
+  /**
+   * The capabilities of the device that will be provisioned using this enrollment record.
+   */
+  capabilities?: DeviceCapabilities;
 }
 
 export type ProvisioningStatus = 'enabled' | 'disabled';

--- a/provisioning/service/src/provisioningserviceclient.ts
+++ b/provisioning/service/src/provisioningserviceclient.ts
@@ -217,7 +217,7 @@ export class ProvisioningServiceClient {
   }
 
   private _versionQueryString(): string {
-    return '?api-version=2017-11-15';
+    return '?api-version=2018-04-01';
   }
 
   private _createOrUpdate(endpointPrefix: string, enrollment: any, callback?: (err: Error, enrollmentResponse?: any, response?: any) => void): void {

--- a/provisioning/service/test/_provisioningserviceclient_test.js
+++ b/provisioning/service/test/_provisioningserviceclient_test.js
@@ -20,7 +20,10 @@ var fakeEnrollment = {
       endorsementKey: 'endorsementkey'
     }
   },
-  initialTwinState: null
+  initialTwinState: null,
+  capabilities: {
+    iotEdge: false
+  }
 };
 
 var fakeEnrollmentNoEtag = {

--- a/provisioning/service/test/_provisioningserviceclient_test.js
+++ b/provisioning/service/test/_provisioningserviceclient_test.js
@@ -58,7 +58,7 @@ var fakeRegistrationNoEtag = {
 };
 
 function _versionQueryString() {
-  return '?api-version=2017-11-15';
+  return '?api-version=2018-04-01';
 }
 
 


### PR DESCRIPTION
# Description of the problem
There is a new capabilities property in the individual enrollment interface to specify if the provisioned device is an IoT Edge device

# Description of the solution
Add the capabilities interface in the IndividiualEnrollment class and bump to the new API version of the service.