### PR TITLE
Add Iot Edge authentication provider

### DIFF
--- a/device/core/devdoc/iotedged_authentication_provider_requirement.md
+++ b/device/core/devdoc/iotedged_authentication_provider_requirement.md
@@ -1,0 +1,63 @@
+# IotEdgeAuthenticationProvider Requirements
+
+# Overview
+
+The `IotEdgeAuthenticationProvider` class implements the `AuthenticationProvider` interface by delegating the token generation process to iotedged.
+
+# Public API
+
+# constructor(private _authConfig: EdgedAuthConfig, credentials: TransportConfig, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number)
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_016: [** The `constructor` shall create the initial token value using the `credentials` parameter. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_017: [** The `constructor` shall throw an `ArgumentError` if the `tokenRenewalMarginInSeconds` is less than or equal `tokenValidTimeInSeconds`. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_018: [** The `constructor` shall start a timer that will automatically renew the token every (`tokenValidTimeInSeconds` - `tokenRenewalMarginInSeconds`) seconds if specified, or 45 minutes by default. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_001: [** The `constructor` shall throw a `ReferenceError` if the `_authConfig` parameter is falsy. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_002: [** The `constructor` shall throw a `ReferenceError` if the `_authConfig.workloadUri` field is falsy. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_003: [** The `constructor` shall throw a `ReferenceError` if the `_authConfig.moduleId` field is falsy. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_004: [** The `constructor` shall throw a `ReferenceError` if the `_authConfig.generationId` field is falsy. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_005: [** The `constructor` shall throw a `TypeError` if the `_authConfig.workloadUri` field is not a valid URI. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_006: [** The `constructor` shall build a unix domain socket path host if the workload URI protocol is `unix`. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_007: [** The `constructor` shall build a string host if the workload URI protocol is not `unix`. **]**
+
+# _sign(resourceUri: string, expiry: number, callback: (err: Error, signature?: string) => void): void
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_009: [** The `_sign` method shall throw a `ReferenceError` if the `callback` parameter is falsy or is not a function. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_010: [** The `_sign` method invoke `callback` with a `ReferenceError` if the `resourceUri` parameter is falsy. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_011: [** The `_sign` method shall build the HTTP request path in the format `/modules/<module id>/genid/<generation id>/sign?api-version=2018-06-28`. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_019: [** The `_sign` method shall invoke `this._restApiClient.executeApiCall` to make the REST call on iotedged using the POST method. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_014: [** The `_sign` method shall build an object with the following schema as the HTTP request body as the sign request:
+
+```typescript
+interface SignRequest {
+  keyId: string;
+  algo: string;
+  data: string;
+}
+```
+**]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_013: [** The `_sign` method shall build the sign request using the following values:
+
+```typescript
+const signRequest = {
+  keyId: "primary"
+  algo: "HMACSHA256"
+  data: `${data}\n${expiry}`
+};
+```
+**]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_015: [** The `_sign` method shall invoke `callback` when the signature is available. **]**

--- a/device/core/device.d.ts
+++ b/device/core/device.d.ts
@@ -10,6 +10,7 @@ export { DeviceMethodRequest, DeviceMethodResponse } from './lib/device_method';
 export { X509AuthenticationProvider } from './lib/x509_authentication_provider';
 export { SharedAccessSignatureAuthenticationProvider } from './lib/sas_authentication_provider';
 export { SharedAccessKeyAuthenticationProvider } from './lib/sak_authentication_provider';
+export { EdgedAuthConfig, IotEdgeAuthenticationProvider } from './lib/iotedge_authentication_provider';
 export { Twin, TwinProperties } from './lib/twin';
 export { DeviceClientOptions, HttpReceiverOptions, AmqpTransportOptions, HttpTransportOptions, MqttTransportOptions } from './lib/interfaces';
 export { getUserAgentString } from './lib/utils';

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --lines 96 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 85 --lines 96 --functions 90"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/iotedge_authentication_provider.ts
+++ b/device/core/src/iotedge_authentication_provider.ts
@@ -1,0 +1,149 @@
+import { AuthenticationProvider, TransportConfig, encodeUriComponentStrict } from 'azure-iot-common';
+import { SharedAccessKeyAuthenticationProvider } from './sak_authentication_provider';
+import { RestApiClient } from 'azure-iot-http-base';
+import * as url from 'url';
+
+// tslint:disable-next-line:no-var-requires
+const packageJson = require('../package.json');
+
+/**
+ * @private
+ *
+ * The iotedged HTTP API version this code is built to work with.
+ */
+export const WORKLOAD_API_VERSION = '2018-06-28';
+const DEFAULT_SIGN_ALGORITHM = 'HMACSHA256';
+const DEFAULT_KEY_ID = 'primary';
+
+/**
+ * @private
+ *
+ * This interface defines the configuration information that this class needs in order to be able to communicate with iotedged.
+ */
+export interface EdgedAuthConfig {
+  workloadUri: string;
+  deviceId: string;
+  moduleId: string;
+  iothubHostName: string;
+  authScheme: string;
+  gatewayHostName?: string;
+  generationId: string;
+}
+
+interface SignRequest {
+  keyId: string;
+  algo: string;
+  data: string;
+}
+
+interface SignResponse {
+  digest: string;
+}
+
+/**
+ * Provides an `AuthenticationProvider` implementation that delegates token generation to iotedged. This implementation is meant to be used when using the module client with Azure IoT Edge.
+ *
+ * This type inherits from `SharedAccessKeyAuthenticationProvider` and is functionally identical to that type except for the token generation part which it overrides by implementing the `_sign` method.
+ */
+export class IotEdgeAuthenticationProvider extends SharedAccessKeyAuthenticationProvider implements AuthenticationProvider {
+  private _restApiClient: RestApiClient;
+
+  /**
+   * @private
+   *
+   * Initializes a new instance of the IotEdgeAuthenticationProvider.
+   *
+   * @param _authConfig                    iotedged connection configuration information.
+   * @param credentials                    Credentials to be used by the device to connect to the IoT hub.
+   * @param tokenValidTimeInSeconds        [optional] The number of seconds for which a token is supposed to be valid.
+   * @param tokenRenewalMarginInSeconds    [optional] The number of seconds before the end of the validity period during which the `IotEdgeAuthenticationProvider` should renew the token.
+   */
+  constructor(private _authConfig: EdgedAuthConfig, credentials: TransportConfig, tokenValidTimeInSeconds?: number, tokenRenewalMarginInSeconds?: number) {
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_016: [ The constructor shall create the initial token value using the credentials parameter. ]
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_017: [ The constructor shall throw an ArgumentError if the tokenRenewalMarginInSeconds is less than or equal tokenValidTimeInSeconds. ]
+    super(credentials, tokenValidTimeInSeconds, tokenRenewalMarginInSeconds, true);
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_001: [ The constructor shall throw a ReferenceError if the _authConfig parameter is falsy. ]
+    if (!this._authConfig) {
+      throw new ReferenceError('_authConfig cannot be \'' + _authConfig + '\'');
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_002: [ The constructor shall throw a ReferenceError if the _authConfig.workloadUri field is falsy. ]
+    if (!this._authConfig.workloadUri) {
+      throw new ReferenceError('_authConfig.workloadUri cannot be \'' + this._authConfig.workloadUri + '\'');
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_003: [ The constructor shall throw a ReferenceError if the _authConfig.moduleId field is falsy. ]
+    if (!this._authConfig.moduleId) {
+      throw new ReferenceError('_authConfig.moduleId cannot be \'' + this._authConfig.moduleId + '\'');
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_004: [ The constructor shall throw a ReferenceError if the _authConfig.generationId field is falsy. ]
+    if (!this._authConfig.generationId) {
+      throw new ReferenceError('_authConfig.generationId cannot be \'' + this._authConfig.generationId + '\'');
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_005: [ The constructor shall throw a TypeError if the _authConfig.workloadUri field is not a valid URI. ]
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_006: [ The constructor shall build a unix domain socket path host if the workload URI protocol is unix. ]
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_007: [ The constructor shall build a string host if the workload URI protocol is not unix. ]
+    let workloadUri = url.parse(this._authConfig.workloadUri);
+    const config: RestApiClient.TransportConfig = {
+      host: workloadUri.protocol === 'unix:' ? { socketPath: workloadUri.pathname } : workloadUri.host
+    };
+
+    this._restApiClient = new RestApiClient(config, `${packageJson.name}/${packageJson.version}`);
+  }
+
+  protected _sign(resourceUri: string, expiry: number, callback: (err: Error, signature?: string) => void): void {
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_009: [ The _sign method shall throw a ReferenceError if the callback parameter is falsy or is not a function. ]
+    if (!callback || typeof callback !== 'function') {
+      throw new ReferenceError('callback cannot be \'' + callback + '\'');
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_010: [ The _sign method invoke callback with a ReferenceError if the resourceUri parameter is falsy. ]
+    if (!resourceUri) {
+      callback(new ReferenceError('resourceUri cannot be \'' + resourceUri + '\''), null);
+      return;
+    }
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_011: [ The _sign method shall build the HTTP request path in the format /modules/<module id>/genid/<generation id>/sign?api-version=2018-06-28. ]
+
+    // the request path needs to look like this:
+    //  /modules/<module id>/genid/<generation id>/sign?api-version=2018-06-28
+    const path = `/modules/${encodeUriComponentStrict(this._authConfig.moduleId)}/genid/${encodeUriComponentStrict(
+      this._authConfig.generationId
+    )}/sign?api-version=${encodeUriComponentStrict(WORKLOAD_API_VERSION)}`;
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_014: [ The _sign method shall build an object with the following schema as the HTTP request body as the sign request:
+    //   interface SignRequest {
+    //     keyId: string;
+    //     algo: string;
+    //     data: string;
+    //   }
+    //   ]
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_013: [ The _sign method shall build the sign request using the following values:
+    //   const signRequest = {
+    //     keyId: "primary"
+    //     algo: "HMACSHA256"
+    //     data: `${data}\n${expiry}`
+    //   };
+    //   ]
+    const signRequest: SignRequest = {
+      keyId: DEFAULT_KEY_ID,
+      algo: DEFAULT_SIGN_ALGORITHM,
+      // the data to be signed needs to have the expiry value appended with a newline
+      data: `${resourceUri}\n${expiry}`
+    };
+
+    // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_019: [ The _sign method shall invoke this._restApiClient.executeApiCall to make the REST call on iotedged using the POST method. ]
+    this._restApiClient.executeApiCall('POST', path, null, signRequest, (err, body: SignResponse, response) => {
+      if (err) {
+        callback(err, null);
+      } else {
+        // Codes_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_015: [ The _sign method shall invoke callback when the signature is available. ]
+        callback(null, body.digest);
+      }
+    });
+  }
+}

--- a/device/core/test/_iotedge_authentication_provider_test.js
+++ b/device/core/test/_iotedge_authentication_provider_test.js
@@ -1,0 +1,338 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var errors = require('azure-iot-common').errors;
+var IotEdgeAuthenticationProvider = require('../lib/iotedge_authentication_provider').IotEdgeAuthenticationProvider;
+var WORKLOAD_API_VERSION = require('../lib/iotedge_authentication_provider').WORKLOAD_API_VERSION;
+var RestApiClient = require('azure-iot-http-base').RestApiClient;
+
+describe('IotEdgeAuthenticationProvider', function() {
+  describe('#constructor', function() {
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_016: [ The constructor shall create the initial token value using the credentials parameter. ]
+    it('creates initial token value using credentials param', function(testCallback) {
+      let provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+      assert.equal(provider._credentials.host, 'h1');
+      assert.equal(provider._credentials.deviceId, 'd1');
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_017: [ The constructor shall throw an ArgumentError if the tokenRenewalMarginInSeconds is less than or equal tokenValidTimeInSeconds. ]
+    it('throws if tokenRenewalMarginInSeconds is equal to tokenValidTimeInSeconds', function(testCallback) {
+      assert.throws(function() {
+        new IotEdgeAuthenticationProvider(
+          {
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: 'm1',
+            generationId: 'g1'
+          },
+          {
+            host: 'h1',
+            deviceId: 'd1'
+          },
+          10,
+          10
+        );
+      }, errors.ArgumentError);
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_017: [ The constructor shall throw an ArgumentError if the tokenRenewalMarginInSeconds is less than or equal tokenValidTimeInSeconds. ]
+    it('throws if tokenRenewalMarginInSeconds is less than tokenValidTimeInSeconds', function(testCallback) {
+      assert.throws(function() {
+        new IotEdgeAuthenticationProvider(
+          {
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: 'm1',
+            generationId: 'g1'
+          },
+          {
+            host: 'h1',
+            deviceId: 'd1'
+          },
+          8,
+          10
+        );
+      }, errors.ArgumentError);
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_001: [ The constructor shall throw a ReferenceError if the _authConfig parameter is falsy. ]
+    [null, undefined, ''].forEach(function(authConfig) {
+      it("throws if the key is '" + authConfig + "'", function(testCallback) {
+        assert.throws(function() {
+          new IotEdgeAuthenticationProvider(authConfig);
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_002: [ The constructor shall throw a ReferenceError if the _authConfig.workloadUri field is falsy. ]
+    [null, undefined, ''].forEach(function(workloadUri) {
+      it("throws if authConfig.workloadUri is '" + workloadUri + "'", function(testCallback) {
+        assert.throws(function() {
+          new IotEdgeAuthenticationProvider({ workloadUri: workloadUri });
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_003: [ The constructor shall throw a ReferenceError if the _authConfig.moduleId field is falsy. ]
+    [null, undefined, ''].forEach(function(moduleId) {
+      it("throws if authConfig.moduleId is '" + moduleId + "'", function(testCallback) {
+        assert.throws(function() {
+          new IotEdgeAuthenticationProvider({
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: moduleId
+          });
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_004: [ The constructor shall throw a ReferenceError if the _authConfig.generationId field is falsy. ]
+    [null, undefined, ''].forEach(function(generationId) {
+      it("throws if authConfig.generationId is '" + generationId + "'", function(testCallback) {
+        assert.throws(function() {
+          new IotEdgeAuthenticationProvider({
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: 'm1',
+            generationId: generationId
+          });
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_005: [ The constructor shall throw a TypeError if the _authConfig.workloadUri field is not a valid URI. ]
+    it('throws if authConfig.workloadUri is not a valid URI', function(testCallback) {
+      assert.throws(function() {
+        new IotEdgeAuthenticationProvider({
+          workloadUri: 10,
+          moduleId: 'm1',
+          generationId: 'g1'
+        });
+      }, TypeError);
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_006: [ The constructor shall build a unix domain socket path host if the workload URI protocol is unix. ]
+    it('builds a unix domain socket url', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+
+      assert.equal(provider._restApiClient._config.host.socketPath, '/var/run/iotedged.w.sock');
+
+      testCallback();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_007: [ The constructor shall build a string host if the workload URI protocol is not unix. ]
+    it('builds a http url', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'http://localhost:8081',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+
+      assert.equal(provider._restApiClient._config.host, 'localhost:8081');
+
+      testCallback();
+    });
+  });
+
+  describe('#sign', function() {
+    before(function() {
+      this.clock = sinon.useFakeTimers();
+    });
+
+    after(function() {
+      this.clock.restore();
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_009: [ The _sign method shall throw a ReferenceError if the callback parameter is falsy or is not a function. ]
+    [null, undefined, '', 'not a function', 20].forEach(function(badCallback) {
+      it("throws if the callback is '" + badCallback + "'", function(testCallback) {
+        var provider = new IotEdgeAuthenticationProvider(
+          {
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: 'm1',
+            generationId: 'g1'
+          },
+          {
+            host: 'h1',
+            deviceId: 'd1'
+          }
+        );
+        assert.throws(function() {
+          provider._sign(
+            'data',
+            100000,
+            {
+              host: 'h1',
+              deviceId: 'd1'
+            },
+            badCallback
+          );
+        }, ReferenceError);
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_010: [ The _sign method invoke callback with a ReferenceError if the data parameter is falsy. ]
+    [null, undefined, ''].forEach(function(badData) {
+      it("invokes callback with ReferenceError if data is '" + badData + "'", function(testCallback) {
+        var provider = new IotEdgeAuthenticationProvider(
+          {
+            workloadUri: 'unix:///var/run/iotedged.w.sock',
+            moduleId: 'm1',
+            generationId: 'g1'
+          },
+          {
+            host: 'h1',
+            deviceId: 'd1'
+          }
+        );
+        provider._sign(badData, 100000, function(err) {
+          assert.instanceOf(err, ReferenceError);
+          testCallback();
+        });
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_011: [ The _sign method shall build the HTTP request path in the format /modules/<module id>/genid/<generation id>/sign?api-version=2018-06-28. ]
+    it('builds request path in expected format', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+      sinon.stub(provider._restApiClient, 'executeApiCall').callsFake(function(method, path, headers, body, callback) {
+        assert.equal(path, '/modules/m1/genid/g1/sign?api-version=' + WORKLOAD_API_VERSION);
+        callback(null, { digest: 'digest1' });
+      });
+
+      provider._sign('data', 100000, function(err) {
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_014: [ The _sign method shall build an object with the following schema as the HTTP request body as the sign request:
+    //   interface SignRequest {
+    //     keyId: string;
+    //     algo: string;
+    //     data: string;
+    //   }
+    //   ]
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_013: [ The _sign method shall build the sign request using the following values:
+    //   const signRequest = {
+    //     keyId: "primary"
+    //     algo: "HMACSHA256"
+    //     data: `${data}\n${expiry}`
+    //   };
+    //   ]
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_014: [ The _sign method shall invoke this._restApiClient.executeApiCall to make the REST call on iotedged using the POST method. ]
+    it('sign request is as expected', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+      sinon.stub(provider._restApiClient, 'executeApiCall').callsFake(function(method, path, headers, body, callback) {
+        assert.equal(method, 'POST');
+        assert.equal(body.keyId, 'primary');
+        assert.equal(body.algo, 'HMACSHA256');
+        assert.equal(body.data, 'data\n2000');
+        callback(null, { digest: 'digest1' });
+      });
+
+      provider._sign('data', 2000, function(err) {
+        testCallback();
+      });
+    });
+
+    it('request error is handled', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+      sinon.stub(provider._restApiClient, 'executeApiCall').callsFake(function(method, path, headers, body, callback) {
+        callback('whoops');
+      });
+
+      provider._sign('data', 2000, function(err) {
+        assert.equal(err, 'whoops');
+        testCallback();
+      });
+    });
+
+    // Tests_SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_015: [ The _sign method shall invoke callback when the signature is available. ]
+    it('creates sas', function(testCallback) {
+      var provider = new IotEdgeAuthenticationProvider(
+        {
+          workloadUri: 'unix:///var/run/iotedged.w.sock',
+          moduleId: 'm1',
+          generationId: 'g1'
+        },
+        {
+          host: 'h1',
+          deviceId: 'd1'
+        }
+      );
+      sinon.stub(provider._restApiClient, 'executeApiCall').callsFake(function(method, path, headers, body, callback) {
+        callback(null, { digest: 'digest1' });
+      });
+
+      provider._sign('data', 2000, function(err, sig) {
+        assert.equal(sig, 'digest1');
+        testCallback();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This commit adds a new authentication provider that produces SAS tokens by delegating the call to the HTTP service implemented by Azure IoT Edge.