### PR TITLE
Update registry_addUpdateRemoveDevicesSample.js

### DIFF
--- a/service/samples/registry_addUpdateRemoveDevicesSample.js
+++ b/service/samples/registry_addUpdateRemoveDevicesSample.js
@@ -14,7 +14,6 @@ var registry = iothub.Registry.fromConnectionString(connectionString);
 var deviceAddArray = [
   {
     deviceId: 'Device1',
-    status: 'disabled',
     authentication: {
       symmetricKey: {
         primaryKey: new Buffer(uuid.v4()).toString('base64'),
@@ -24,7 +23,6 @@ var deviceAddArray = [
   },
   {
     deviceId: 'Device2',
-    status: 'disabled',
     authentication: {
       symmetricKey: {
         primaryKey: new Buffer(uuid.v4()).toString('base64'),
@@ -34,7 +32,6 @@ var deviceAddArray = [
   },
   {
     deviceId: 'Device3',
-    status: 'disabled',
     authentication: {
       symmetricKey: {
         primaryKey: new Buffer(uuid.v4()).toString('base64'),


### PR DESCRIPTION
Status & authentication is now deprecated in the device description according to https://docs.microsoft.com/en-us/javascript/api/azure-iothub/device?view=azure-node-latest && https://docs.microsoft.com/en-us/javascript/api/azure-iothub/registry.devicedescription?view=azure-node-latest. However, from my testing, authentication is still accepted and commits the information passed by the client, but status is does not commit a change to the IoT Hub. The Device class, upon which this file is based, appears to be deprecated.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

Sample code does not match the API in the documentation on Microsoft's website.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->

Modified the sample code.
