### PR TITLE
Update ADM configuration objects

### DIFF
--- a/e2etests/test/configurations.js
+++ b/e2etests/test/configurations.js
@@ -21,17 +21,19 @@ var registry = Registry.fromConnectionString(hubConnectionString);
 // Test of applyConfigurationContentToDevice
 // Test to verify that config applies to device based on targetCondition
 
-describe.skip('device configuration', function() {
+describe('device configuration', function() {
   var deviceConfig;
 
-  this.timeout(46000);
+  this.timeout(60000);
 
   beforeEach(function() {
     deviceConfig = {
       id: 'node_e2e_' + uuid.v4(),
-      labels: {},
+      labels: {
+        key: 'value'
+      },
       content: {
-        moduleContent: {
+        modulesContent: {
           fakeModule: {
             'properties.desired': {
               prop1: 'foo'
@@ -226,5 +228,3 @@ describe.skip('device configuration', function() {
     ], done);
   });
 });
-
-

--- a/service/package.json
+++ b/service/package.json
@@ -38,7 +38,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 97 --branches 92  --lines 97 --functions 93",
+    "check-cover": "istanbul check-coverage --statements 97 --branches 93  --lines 98 --functions 94",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js"
   },
   "engines": {

--- a/service/src/configuration.ts
+++ b/service/src/configuration.ts
@@ -31,11 +31,6 @@ export interface Configuration {
   content?: ConfigurationContent;
 
   /**
-   * Type of content.  Will always be "assignment"
-   */
-  contentType?: string;
-
-  /**
    * The target condition is continuously evaluated to include any new devices that meet the requirements or remove devices that no longer do through the life time of the deployment.
    * Use any Boolean condition on device twins tags or deviceId to select the target devices, e.g. tags.environment='prod' or deviceId='linuxprod' or tags.environment = 'prod' AND tags.location = 'westus'.
    */
@@ -57,9 +52,14 @@ export interface Configuration {
   priority?: number;
 
   /**
-   * All the statistics that are emitted by the deployment.
+   * System configuration metrics
    */
-  statistics?: ConfigurationStatistics;
+  systemMetrics?: ConfigurationMetrics;
+
+  /**
+   * Custom configuration metrics
+   */
+  metrics?: ConfigurationMetrics;
 
   /**
    * A string used for protecting opportunistic concurrency updates by the caller. This gets updated when deployment is update
@@ -67,48 +67,52 @@ export interface Configuration {
   etag?: string;
 }
 
-export interface ConfigurationStatistics {
+/**
+ * Metrics used to report the results of applying a configuration.
+ *
+ * The `results` and `queries` dictionaries should have the same keys, each key matching a particular query in the `queries` dictionary with the associated results in the `results` dictionary
+ */
+export interface ConfigurationMetrics {
   /**
-   * [read-only] Count of devices in targetCondition
+   * Dictionary containing, for each metric, the number of devices or modules on which the configuration was applied
    */
-  targetedCount?: number;
-
+  results: { [key: string]: number };
   /**
-   * [read-only] Count of devices that have a desired module defined in this configuration.
+   * Dictionary containing the queries used to compute each result in the `results` property.
    */
- appliedCount?: number;
-
-  /**
-   * [read-only] Count of devices that have a desired module defined in this configuration, for which the device reported a successful statusForLastDesired.
-   */
- reportedSuccessfulCount?: number;
-
-  /**
-   * [read-only] Count of devices that have a desired module defined in this configuration, for which the device reported a failure statusForLastDesired.
-   */
- reportedFailedCount?: number;
-
-  /**
-   * [read-only] Count of devices that have a reported module defined in this configuration with an unhealthy status (i.e. <> running).
-   */
- unhealthyModulesCount?: number;
-
- /**
-  * Other values
-  */
- [key: string]: any;
+  queries: { [key: string]: string };
 }
 
+/**
+ * Content of the configuration that needs to be applied to devices and/or modules on a device.
+ */
 export interface ConfigurationContent {
   /**
-   * The configuration for all the modules.
+   * Configuration used by devices
    */
-  moduleContent: {[key: string]: TwinContent};
+  deviceContent?: TwinContent;
+  /**
+   * Configuration used by modules on Edge devices
+   */
+  modulesContent?: {
+    /**
+     * The key shall be the module name, and the value the `TwinContent` for this module.
+     */
+    [key: string]: TwinContent
+  };
 }
 
+/**
+ *
+ */
 export interface TwinContent {
   /**
-   * Desired properties for this module
+   * Desired properties for this module or device twin
    */
   'properties.desired': any;
+
+  /**
+   * Free-form properties where the key format is "properties.desired.<subpath>"
+   */
+  [key: string]: any;
 }


### PR DESCRIPTION
# Description of the problem
ADM/Configuration APIs are being updated for the GA API version

# Description of the solution
Update the objects.

Please note:
- still missing an e2e test
- CRUD e2e tests for configurations are still disabled
- the new API version change itself will happen only when it is deployed
