### PR TITLE
Add trust bundle support

### DIFF
--- a/common/core/devdoc/shared_access_signature.md
+++ b/common/core/devdoc/shared_access_signature.md
@@ -65,7 +65,7 @@ SRS_NODE_COMMON_SAS_05_020: [The skn segment is not part of the returned string 
 Creates a `SharedAccessSignature` utilizing the supplied `signingFunction`.  If the signing operation is successful the results will be made available via the `callback`
 
 **SRS_NODE_COMMON_SAS_06_001: [** If `credentials`, `expiry`, `signingFunction`, or `callback` are falsy, `createWithSigningFunction` shall throw `ReferenceError`. **]**
-**SRS_NODE_COMMON_SAS_06_002: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId`. **]**
+**SRS_NODE_COMMON_SAS_06_002: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId` + `/modules/` + `credentials.moduleId`. **]**
 **SRS_NODE_COMMON_SAS_06_003: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `se` property containing the value of the parameter `expiry`. **]**
 **SRS_NODE_COMMON_SAS_06_004: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an optional property `skn`, if the `credentials.sharedAccessKeyName` is not falsy,  The value of the `skn` property will be the url encoded value of `credentials.sharedAccessKeyName`. **]**
 **SRS_NODE_COMMON_SAS_06_005: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with a `sig` property with the SHA256 hash of the string sr + `\n` + se.  The `sig` value will first be base64 encoded THEN url encoded. **]**

--- a/common/core/package.json
+++ b/common/core/package.json
@@ -29,7 +29,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 99 --branches 96 --functions 98 --lines 99"
+    "check-cover": "istanbul check-coverage --statements 99 --branches 96 --functions 99 --lines 99"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/core/src/shared_access_signature.ts
+++ b/common/core/src/shared_access_signature.ts
@@ -130,8 +130,12 @@ static createWithSigningFunction(credentials: authorization.TransportConfig, exp
   if (!signingFunction) throwRef('signingFunction', signingFunction);
   if (!callback) throwRef('callback', callback);
   let sas = new SharedAccessSignature();
-  /*Codes_SRS_NODE_COMMON_SAS_06_002: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId`.] */
-  sas.sr = authorization.encodeUriComponentStrict(credentials.host + '/devices/' + credentials.deviceId);
+  /*Codes_SRS_NODE_COMMON_SAS_06_002: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId` + `/modules/` + `credentials.moduleId`.] */
+  let resource = credentials.host + '/devices/' + credentials.deviceId;
+  if (credentials.moduleId) {
+    resource += `/modules/${credentials.moduleId}`;
+  }
+  sas.sr = authorization.encodeUriComponentStrict(resource);
   /*Codes_SRS_NODE_COMMON_SAS_06_003: [** The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `se` property containing the value of the parameter `expiry`.] */
   sas.se = expiry;
   /*Codes_SRS_NODE_COMMON_SAS_06_004: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an optional property `skn`, if the `credentials.sharedAccessKeyName` is not falsy,  The value of the `skn` property will be the url encoded value of `credentials.sharedAccessKeyName`.] */

--- a/common/core/test/_shared_access_signature_test.js
+++ b/common/core/test/_shared_access_signature_test.js
@@ -219,8 +219,8 @@ describe('SharedAccessSignature', function () {
       [undefined, null, '', 0].forEach(throws);
     }
 
-    /*Tests_SRS_NODE_COMMON_SAS_06_002: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId`.] */
-    it('creates a valid sr value', function(callback) {
+    /*Tests_SRS_NODE_COMMON_SAS_06_002: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId` + `/modules/` + `credentials.moduleId`.] */
+    it('creates a valid sr value for device id', function(callback) {
       var fakeCredentials = {
         host: 'fakeHostName',
         deviceId: 'fakeDeviceId'
@@ -229,6 +229,22 @@ describe('SharedAccessSignature', function () {
       var fakeSigningFunction = sinon.stub().callsArgWith(1, null, fakeSignedValue);
       SharedAccessSignature.createWithSigningFunction(fakeCredentials, 1, fakeSigningFunction, (err, newSas) => {
         assert.strictEqual(newSas.sr, 'fakeHostName%2Fdevices%2FfakeDeviceId', 'Invalid scope create for sas token');
+        assert.isUndefined(newSas.skn, 'Skn is improperly included');
+        callback();
+      });
+    });
+
+    /*Tests_SRS_NODE_COMMON_SAS_06_002: [The `createWithSigningFunction` shall create a `SharedAccessSignature` object with an `sr` property formed by url encoding `credentials.host` + `/devices/` + `credentials.deviceId` + `/modules/` + `credentials.moduleId`.] */
+    it('creates a valid sr value for device id and module id', function(callback) {
+      var fakeCredentials = {
+        host: 'fakeHostName',
+        deviceId: 'fakeDeviceId',
+        moduleId: 'fakeModuleId'
+      };
+      var fakeSignedValue = Buffer.from('abcd');
+      var fakeSigningFunction = sinon.stub().callsArgWith(1, null, fakeSignedValue);
+      SharedAccessSignature.createWithSigningFunction(fakeCredentials, 1, fakeSigningFunction, (err, newSas) => {
+        assert.strictEqual(newSas.sr, 'fakeHostName%2Fdevices%2FfakeDeviceId%2Fmodules%2FfakeModuleId', 'Invalid scope create for sas token');
         assert.isUndefined(newSas.skn, 'Skn is improperly included');
         callback();
       });

--- a/common/transport/http/devdoc/http_requirements.md
+++ b/common/transport/http/devdoc/http_requirements.md
@@ -23,7 +23,7 @@ request.end();
 ```
 
 ## Public Interface
-### buildRequest(method, path, httpHeaders, host, x509Options, done)
+### buildRequest(method, path, httpHeaders, host, options, done)
 The buildRequest method receives all the information necessary to make an HTTP request to an IoT hub.  This method should only be called by higher-level Azure IoT Hub libraries, and does not validate input.
 
 **SRS_NODE_HTTP_05_001: [** `buildRequest` shall accept the following arguments:
@@ -31,10 +31,10 @@ The buildRequest method receives all the information necessary to make an HTTP r
 - `path` - the path to the resource, not including the hostname
 - `httpHeaders` - an object whose properties represent the names and values of HTTP headers to include in the request
 - `host` - the fully-qualified DNS hostname of the IoT hub or an object containing a unix domain socket path in a property named `socketPath`
-- `x509Options` - *[optional]* the x509 certificate, key and passphrase that are needed to connect to the service using x509 certificate authentication
+- `options` - *[optional]* the x509 certificate options or HTTP request options
 - `done` - a callback that will be invoked when a completed response is returned from the server **]**
 
-**SRS_NODE_HTTP_05_002: [** `buildRequest` shall return a Node.js https.ClientRequest object, upon which the caller must invoke the end method in order to actually send the request. **]**
+**SRS_NODE_HTTP_05_002: [** `buildRequest` shall return a Node.js https.ClientRequest/http.ClientRequest object, upon which the caller must invoke the end method in order to actually send the request. **]**
 
 **SRS_NODE_HTTP_05_003: [** If `buildRequest` encounters an error before it can send the request, it shall invoke the `done` callback function and pass the standard JavaScript `Error` object with a text description of the error (err.message). **]**
 
@@ -45,13 +45,15 @@ The buildRequest method receives all the information necessary to make an HTTP r
 
 **SRS_NODE_HTTP_13_002: [** If the `host` argument is a string then assign its value to the `host` property of `httpOptions`. **]**
 
+**SRS_NODE_HTTP_13_006: [** If the `options` object has a `port` property set then assign that to the `port` property on `httpOptions`. **]**
+
 **SRS_NODE_HTTP_13_003: [** If the `host` argument is an object then assign its `socketPath` property to the `socketPath` property of `httpOptions`. **]**
 
-**SRS_NODE_HTTP_13_004: [** Use the request object from the `https` module when dealing with TCP based HTTP requests. **]**
+**SRS_NODE_HTTP_13_004: [** Use the request object from the `options` object if one has been provided or default to HTTPS request. **]**
 
 **SRS_NODE_HTTP_13_005: [** Use the request object from the `http` module when dealing with unix domain socket based HTTP requests. **]**
 
-**SRS_NODE_HTTP_16_001: [** If `x509Options` is specified, the certificate, key and passphrase in the structure shall be used to authenticate the connection. **]**
+**SRS_NODE_HTTP_16_001: [** If `options` has x509 properties, the certificate, key and passphrase in the structure shall be used to authenticate the connection. **]**
 
 **SRS_NODE_HTTP_18_001: [** If the `options` object passed into `setOptions` has a value in `http.agent`, that value shall be passed into the `request` function as `httpOptions.agent` **]**
 

--- a/common/transport/http/devdoc/rest_api_client_requirements.md
+++ b/common/transport/http/devdoc/rest_api_client_requirements.md
@@ -30,14 +30,18 @@ The `RestApiClient` constructor initializes a new instance of a `RestApiClient` 
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_004: [** The `RestApiClient` constructor shall use the value of the `httpBase` argument as the internal HTTP client if present. **]**
 
-### executeApiCall(method, path, headers, requestBody, timeout, done)
+### executeApiCall(method, path, headers, requestBody, timeout, requestOptions, done)
 The `executeApiCall` method builds the HTTP request using the passed arguments and calls the `done` callback with the result of the API call.
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_005: [** The `executeApiCall` method shall throw a `ReferenceError` if the `method` argument is falsy. **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_006: [** The `executeApiCall` method shall throw a `ReferenceError` if the `path` argument is falsy. **]**
 
-**SRS_NODE_IOTHUB_REST_API_CLIENT_16_029: [** If `done` is `undefined` and the `timeout` argument is a function, `timeout` should be used as the callback. **]**
+**SRS_NODE_IOTHUB_REST_API_CLIENT_16_029: [** If `done` is `undefined` and the `timeout` argument is a function, `timeout` should be used as the callback and mark `requestOptions` and `timeout` as `undefined`. **]**
+
+**SRS_NODE_IOTHUB_REST_API_CLIENT_13_001: [** If `done` is `undefined` and the `requestOptions` argument is a function, then `requestOptions` should be used as the callback and mark `requestOptions` as `undefined`. **]**
+
+**SRS_NODE_IOTHUB_REST_API_CLIENT_13_002: [** If `timeout` is an object and `requestOptions` is `undefined`, then assign `timeout` to `requestOptions` and mark `timeout` as `undefined`. **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_030: [** If `timeout` is defined and is not a function, the HTTP request timeout shall be adjusted to match the value of the argument. **]**
 
@@ -49,6 +53,8 @@ The `executeApiCall` method builds the HTTP request using the passed arguments a
 - User-Agent: <version string> **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_008: [** The `executeApiCall` method shall build the HTTP request using the arguments passed by the caller. **]**
+
+**SRS_NODE_IOTHUB_REST_API_CLIENT_13_003: [** If `requestOptions` is not falsy then it shall be passed to the `buildRequest` function. **]**
 
 **SRS_NODE_IOTHUB_REST_API_CLIENT_16_009: [** If the HTTP request is successful the `executeApiCall` method shall parse the JSON response received and call the `done` callback with a `null` first argument, the parsed result as a second argument and the HTTP response object itself as a third argument. **]**
 

--- a/common/transport/http/index.d.ts
+++ b/common/transport/http/index.d.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-export { Http } from './lib/http';
+export { Http, HttpRequestOptions } from './lib/http';
 export { RestApiClient } from './lib/rest_api_client';
 export { HttpTransportError } from './lib/rest_api_client';
 

--- a/common/transport/http/package.json
+++ b/common/transport/http/package.json
@@ -30,7 +30,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 86 --branches 80 --functions 76 --lines 86"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 86 --functions 100 --lines 94"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/http/src/http.ts
+++ b/common/transport/http/src/http.ts
@@ -21,6 +21,25 @@ export type HttpCallback = (err: Error, body?: string, response?: IncomingMessag
 
 /**
  * @private
+ *
+ * This interface defines optional HTTP request options that one can set on a per request basis.
+ */
+export interface HttpRequestOptions {
+  /**
+   * The TCP port to use when connecting to the HTTP server. Defaults to 80 for HTTP
+   * traffic and 443 for HTTPS traffic.
+   */
+  port?: number;
+
+  /**
+   * The request function to use when connecting to the HTTP server. Must be the 'request'
+   * function from either the 'http' Node.js package or the 'https' Node.js package.
+   */
+  request?: (options: RequestOptions | string, callback?: (res: IncomingMessage) => void) => ClientRequest;
+}
+
+/**
+ * @private
  * @class           module:azure-iot-http-base.Http
  * @classdesc       Basic HTTP request/response functionality used by higher-level IoT Hub libraries.
  *                  You generally want to use these higher-level objects (such as [azure-iot-device-http.Http]{@link module:azure-iot-device-http.Http}) rather than this one.
@@ -36,6 +55,7 @@ export class Http {
    * @param {String}      path            The section of the URI that should be appended after the hostname.
    * @param {Object}      httpHeaders     An object containing the headers that should be used for the request.
    * @param {String}      host            Fully-Qualified Domain Name of the server to which the request should be sent to.
+   * @param {Object}      options         X509 options or HTTP request options
    * @param {Function}    done            The callback to call when a response or an error is received.
    *
    * @returns An HTTP request object.
@@ -45,19 +65,37 @@ export class Http {
       path - the path to the resource, not including the hostname
       httpHeaders - an object whose properties represent the names and values of HTTP headers to include in the request
       host - the fully-qualified DNS hostname of the IoT hub
-      x509Options - [optional] the x509 certificate, key and passphrase that are needed to connect to the service using x509 certificate authentication
+      options - [optional] the x509 certificate options or HTTP request options
       done - a callback that will be invoked when a completed response is returned from the server]*/
-
   buildRequest (method: HttpMethod,
                 path: string,
                 httpHeaders: { [key: string]: string | string[] | number },
                 host: string | { socketPath: string },
-                x509Options: X509 | HttpCallback,
+                options: X509 | HttpRequestOptions | HttpCallback,
                 done?: HttpCallback): ClientRequest {
 
-    if (!done && (typeof x509Options === 'function')) {
-      done = x509Options;
-      x509Options = undefined;
+    // NOTE: The `options` parameter above, the way its structured prevents
+    // this function from being called with *both* X509 options AND
+    // HttpRequestOptions simultaneously. This is not strictly required at
+    // this time. But when it is required, we may need to split the request
+    // options out as its own parameter and then appropriately modify the
+    // overload detection logic below.
+
+    if (!done && (typeof options === 'function')) {
+      done = options;
+      options = undefined;
+    }
+
+    let requestOptions: HttpRequestOptions = null;
+    if (options && this.isHttpRequestOptions(options)) {
+      requestOptions = options as HttpRequestOptions;
+      options = undefined;
+    }
+
+    let x509Options: X509 = null;
+    if (options && this.isX509Options(options)) {
+      x509Options = options as X509;
+      options = undefined;
     }
 
     let httpOptions: RequestOptions = {
@@ -66,11 +104,20 @@ export class Http {
       headers: httpHeaders
     };
 
-    // Codes_SRS_NODE_HTTP_13_004: [ Use the request object from the https module when dealing with TCP based HTTP requests. ]
+    // Codes_SRS_NODE_HTTP_13_004: [ Use the request object from the `options` object if one has been provided or default to HTTPS request. ]
     let request = https_request;
+    if (requestOptions && requestOptions.request) {
+      request = requestOptions.request;
+    }
+
     if (typeof(host) === 'string') {
       // Codes_SRS_NODE_HTTP_13_002: [ If the host argument is a string then assign its value to the host property of httpOptions. ]
       httpOptions.host = host;
+
+      // Codes_SRS_NODE_HTTP_13_006: [ If the options object has a port property set then assign that to the port property on httpOptions. ]
+      if (requestOptions && requestOptions.port) {
+        httpOptions.port = requestOptions.port;
+      }
     } else {
       // Codes_SRS_NODE_HTTP_13_003: [ If the host argument is an object then assign its socketPath property to the socketPath property of httpOptions. ]
 
@@ -90,7 +137,7 @@ export class Http {
       httpOptions.agent = this._options.http.agent;
     }
 
-    /*Codes_SRS_NODE_HTTP_16_001: [If `x509Options` is specified, the certificate, key and passphrase in the structure shall be used to authenticate the connection.]*/
+    /*Codes_SRS_NODE_HTTP_16_001: [If `options` has x509 properties, the certificate, key and passphrase in the structure shall be used to authenticate the connection.]*/
     if (x509Options) {
       httpOptions.cert = (x509Options as X509).cert;
       httpOptions.key = (x509Options as X509).key;
@@ -119,7 +166,7 @@ export class Http {
 
     /*Codes_SRS_NODE_HTTP_05_003: [If buildRequest encounters an error before it can send the request, it shall invoke the done callback function and pass the standard JavaScript Error object with a text description of the error (err.message).]*/
     httpReq.on('error', done);
-    /*Codes_SRS_NODE_HTTP_05_002: [buildRequest shall return a Node.js https.ClientRequest object, upon which the caller must invoke the end method in order to actually send the request.]*/
+    /*Codes_SRS_NODE_HTTP_05_002: [buildRequest shall return a Node.js https.ClientRequest/http.ClientRequest object, upon which the caller must invoke the end method in order to actually send the request.]*/
     return httpReq;
   }
 
@@ -172,6 +219,23 @@ export class Http {
    */
   setOptions(options: any): void {
     this._options = options;
+  }
+
+  /**
+   * @private
+   */
+  isX509Options(options: any): boolean {
+    return !!options && typeof(options) === 'object' &&
+      (options.cert || options.key || options.passphrase ||
+        options.certFile || options.keyFile);
+  }
+
+  /**
+   * @private
+   */
+  isHttpRequestOptions(options: any): boolean {
+    return !!options && typeof(options) === 'object' &&
+      (typeof(options.port) === 'number' || typeof(options.request) === 'function');
   }
 
   /**

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { anHourFromNow, errors, SharedAccessSignature, X509 } from 'azure-iot-common';
-import { Http as HttpBase } from './http';
+import { Http as HttpBase, HttpRequestOptions } from './http';
 import  * as uuid from 'uuid';
 import { ClientRequest } from 'http';
 import dbg = require('debug');
@@ -71,15 +71,34 @@ export class RestApiClient {
    * @throws {ReferenceError} If the method or path arguments are falsy.
    * @throws {TypeError}      If the type of the requestBody is not a string when Content-Type is text/plain
    */
-  executeApiCall(method: HttpMethodVerb, path: string, headers: { [key: string]: any }, requestBody: any, timeout?: number | RestApiClient.ResponseCallback, done?: RestApiClient.ResponseCallback): void {
+  executeApiCall(
+    method: HttpMethodVerb,
+    path: string,
+    headers: { [key: string]: any },
+    requestBody: any,
+    timeout?: number | HttpRequestOptions | RestApiClient.ResponseCallback,
+    requestOptions?: HttpRequestOptions | number | RestApiClient.ResponseCallback,
+    done?: RestApiClient.ResponseCallback): void {
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_005: [The `executeApiCall` method shall throw a `ReferenceError` if the `method` argument is falsy.]*/
     if (!method) throw new ReferenceError('method cannot be \'' + method + '\'');
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_006: [The `executeApiCall` method shall throw a `ReferenceError` if the `path` argument is falsy.]*/
     if (!path) throw new ReferenceError('path cannot be \'' + path + '\'');
 
-    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_029: [If `done` is `undefined` and the `timeout` argument is a function, `timeout` should be used as the callback.]*/
+    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_029: [If `done` is `undefined` and the `timeout` argument is a function, `timeout` should be used as the callback and mark `requestOptions` and `timeout` as `undefined`.]*/
     if (done === undefined && typeof(timeout) === 'function') {
       done = timeout;
+      requestOptions = timeout = undefined;
+    }
+
+    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_13_001: [** If `done` is `undefined` and the `requestOptions` argument is a function, then `requestOptions` should be used as the callback and mark `requestOptions` as `undefined`.*/
+    if (done === undefined && typeof(requestOptions) === 'function') {
+      done = requestOptions;
+      requestOptions = undefined;
+    }
+
+    /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_13_002: [** If `timeout` is an object and `requestOptions` is `undefined`, then assign `timeout` to `requestOptions` and mark `timeout` as `undefined`.*/
+    if (typeof(timeout) === 'object' && requestOptions === undefined) {
+      requestOptions = timeout;
       timeout = undefined;
     }
 
@@ -143,7 +162,15 @@ export class RestApiClient {
       /* Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_18_002: [ If an `x509` cert was passed into the constructor via the `config` object, `executeApiCall` shall use it to establish the TLS connection. ] */
        request = this._http.buildRequest(method, path, httpHeaders, this._config.host, this._config.x509, requestCallback);
     } else {
-       request = this._http.buildRequest(method, path, httpHeaders, this._config.host, requestCallback);
+      /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_13_003: [** If `requestOptions` is not falsy then it shall be passed to the `buildRequest` function.*/
+      if (requestOptions) {
+        request = this._http.buildRequest(
+          method, path, httpHeaders, this._config.host,
+          requestOptions as HttpRequestOptions, requestCallback
+        );
+      } else {
+        request = this._http.buildRequest(method, path, httpHeaders, this._config.host, requestCallback);
+      }
     }
 
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_030: [If `timeout` is defined and is not a function, the HTTP request timeout shall be adjusted to match the value of the argument.]*/

--- a/device/core/devdoc/iotedged_authentication_provider_requirement.md
+++ b/device/core/devdoc/iotedged_authentication_provider_requirement.md
@@ -28,6 +28,18 @@ The `IotEdgeAuthenticationProvider` class implements the `AuthenticationProvider
 
 **SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_007: [** The `constructor` shall build a string host if the workload URI protocol is not `unix`. **]**
 
+# public getTrustBundle(callback: (err?: Error, ca?: string) => void): void
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_020: [** The `getTrustBundle` method shall throw a ReferenceError if the callback parameter is falsy or is not a function. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_023: [** The `getTrustBundle` method shall set the HTTP request option's `request` property to use the `http.request` object. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_024: [** The `getTrustBundle` method shall set the HTTP request option's `port` property to use the workload URI's port if available. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_021: [** The `getTrustBundle` method shall invoke `this._restApiClient.executeApiCall` to make the REST call on iotedged using the GET method. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_022: [** The `getTrustBundle` method shall build the HTTP request path in the format `/trust-bundle?api-version=2018-06-28`. **]**
+
 # _sign(resourceUri: string, expiry: number, callback: (err: Error, signature?: string) => void): void
 
 **SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_009: [** The `_sign` method shall throw a `ReferenceError` if the `callback` parameter is falsy or is not a function. **]**
@@ -35,6 +47,12 @@ The `IotEdgeAuthenticationProvider` class implements the `AuthenticationProvider
 **SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_010: [** The `_sign` method invoke `callback` with a `ReferenceError` if the `resourceUri` parameter is falsy. **]**
 
 **SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_011: [** The `_sign` method shall build the HTTP request path in the format `/modules/<module id>/genid/<generation id>/sign?api-version=2018-06-28`. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_025: [** The `_sign` method shall set the HTTP request option's `request` property to use the `http.request` object. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_026: [** The `_sign` method shall set the HTTP request option's `port` property to use the workload URI's port if available. **]**
+
+**SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_027: [** The `_sign` method shall use the `SharedAccessSignature.createWithSigningFunction` function to build the data buffer which is to be signed by iotedged. **]**
 
 **SRS_NODE_IOTEDGED_AUTHENTICATION_PROVIDER_13_019: [** The `_sign` method shall invoke `this._restApiClient.executeApiCall` to make the REST call on iotedged using the POST method. **]**
 

--- a/device/core/devdoc/module_client_requirements.md
+++ b/device/core/devdoc/module_client_requirements.md
@@ -7,14 +7,20 @@ azure-iot-device.ModuleClient is a type that captures the functionality needed t
 
 #### fromEnvironment
 
-**SRS_NODE_MODULE_CLIENT_13_026: [** The `fromEnvironment` method shall throw a `ReferenceError` if the `transportCtor` argument is falsy. **]**
+**SRS_NODE_MODULE_CLIENT_13_033: [** The `fromEnvironment` method shall throw a `ReferenceError` if the `callback` argument is falsy or is not a function. **]**
+
+**SRS_NODE_MODULE_CLIENT_13_026: [** The `fromEnvironment` method shall invoke callback with a `ReferenceError` if the `transportCtor` argument is falsy. **]**
 
 **SRS_NODE_MODULE_CLIENT_13_028: [** The `fromEnvironment` method shall delegate to `ModuleClient.fromConnectionString` if an environment variable called `EdgeHubConnectionString` or `IotHubConnectionString` exists. **]**
+
+**SRS_NODE_MODULE_CLIENT_13_034: [** If the client is running in a non-edge mode and an environment variable named `EdgeModuleCACertificateFile` exists then its value shall be set as the CA cert for the transport via the transport's `setOptions` method passing in the CA as the value for the `ca` property in the options object. **]**
+
+**SRS_NODE_MODULE_CLIENT_13_035: [** If the client is running in edge mode then the `IotEdgeAuthenticationProvider.getTrustBundle` method shall be invoked to retrieve the CA cert and the returned value shall be set as the CA cert for the transport via the transport's `setOptions` method passing in the CA value for the `ca` property in the options object. **]**
 
 **SRS_NODE_MODULE_CLIENT_13_029: [** If environment variables `EdgeHubConnectionString` and `IotHubConnectionString` do not exist then the following environment variables must be defined: `IOTEDGE_WORKLOADURI`, `IOTEDGE_DEVICEID`, `IOTEDGE_MODULEID`, `IOTEDGE_IOTHUBHOSTNAME`, `IOTEDGE_AUTHSCHEME` and `IOTEDGE_MODULEGENERATIONID`. **]**
 
 **SRS_NODE_MODULE_CLIENT_13_030: [** The value for the environment variable `IOTEDGE_AUTHSCHEME` must be `SasToken`. **]**
 
-**SRS_NODE_MODULE_CLIENT_13_031: [** The `fromEnvironment` method shall return a new instance of the `ModuleClient` object. **]**
+**SRS_NODE_MODULE_CLIENT_13_031: [** The `fromEnvironment` method shall invoke the callback with a new instance of the `ModuleClient` object. **]**
 
 **SRS_NODE_MODULE_CLIENT_13_032: [** The `fromEnvironment` method shall create a new `IotEdgeAuthenticationProvider` object and pass this to the transport constructor. **]**

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 86 --lines 96 --functions 91"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 86 --lines 97 --functions 91"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/sak_authentication_provider.ts
+++ b/device/core/src/sak_authentication_provider.ts
@@ -14,13 +14,12 @@ import { AuthenticationProvider, AuthenticationType, ConnectionString, SharedAcc
 export class SharedAccessKeyAuthenticationProvider extends EventEmitter implements AuthenticationProvider {
   type: AuthenticationType = AuthenticationType.Token;
 
+  protected _credentials: TransportConfig;
   protected _tokenValidTimeInSeconds: number = 3600;   // 1 hour
   private _tokenRenewalMarginInSeconds: number = 900; // 15 minutes
 
   private _currentTokenExpiryTimeInSeconds: number;
   private _renewalTimeout: NodeJS.Timer;
-
-  private _credentials: TransportConfig;
 
   /**
    * @private

--- a/device/core/test/_internal_client_test.js
+++ b/device/core/test/_internal_client_test.js
@@ -201,7 +201,7 @@ describe('InternalClient', function () {
       });
     });
 
-    /*Tests_SRS_NODE_INTERNAL_CLIENT_16_025: [The ‘setTransportOptions’ method shall throw a ‘NotImplementedError’ if the transport doesn’t implement a ‘setOption’ method.]*/
+    /*Tests_SRS_NODE_INTERNAL_CLIENT_16_025: [The ‘setTransportOptions’ method shall throw a ‘NotImplementedError’ if the transport doesn’t implement a ‘setOptions’ method.]*/
     it('throws a NotImplementedError if the setOptions method is not implemented on the transport', function () {
       var client = new InternalClient(new EventEmitter());
 

--- a/device/core/test/_module_client_test.js
+++ b/device/core/test/_module_client_test.js
@@ -3,21 +3,29 @@
 
 'use strict';
 
-var EventEmitter = require('events');
 var assert = require('chai').assert;
-var errors = require('azure-iot-common').errors;
 var sinon = require('sinon');
 var ModuleClient = require('../lib/module_client').ModuleClient;
 var IotEdgeAuthenticationProvider = require('../lib/iotedge_authentication_provider').IotEdgeAuthenticationProvider;
+var SharedAccessSignature = require('azure-iot-common').SharedAccessSignature;
 
 describe('ModuleClient', function() {
   describe('#fromEnvironment', function() {
-    // Tests_SRS_NODE_MODULE_CLIENT_13_026: [ The fromEnvironment method shall throw a ReferenceError if the transportCtor argument is falsy. ]
-    [null, undefined].forEach(function(badTransport) {
-      it('throws if the transportCtor is falsy', function() {
+    // Tests_SRS_NODE_MODULE_CLIENT_13_033: [ The fromEnvironment method shall throw a ReferenceError if the callback argument is falsy or is not a function. ]
+    [null, undefined, 'not a function', 20].forEach(function(badCallback) {
+      it('throws if callback is falsy or not a function', function() {
         assert.throws(function() {
-          return ModuleClient.fromEnvironment(badTransport);
+          return ModuleClient.fromEnvironment(null, badCallback);
         }, ReferenceError);
+      });
+    });
+
+    // Tests_SRS_NODE_MODULE_CLIENT_13_026: [ The fromEnvironment method shall invoke callback with a ReferenceError if the transportCtor argument is falsy. ]
+    [null, undefined].forEach(function(badTransport) {
+      it('fails if the transportCtor is falsy', function() {
+        ModuleClient.fromEnvironment(badTransport, function(err) {
+          assert.instanceOf(err, ReferenceError);
+        });
       });
     });
 
@@ -36,10 +44,52 @@ describe('ModuleClient', function() {
         });
 
         it('if env ' + envName + ' is defined', function() {
-          var client = ModuleClient.fromEnvironment(function() {});
-          assert.strictEqual(client, 42);
-          assert.strictEqual(stub.called, true);
-          assert.strictEqual(stub.args[0][0], 'cs');
+          ModuleClient.fromEnvironment(function() {}, function(err, client) {
+            assert.isNotOk(err);
+            assert.strictEqual(client, 42);
+            assert.strictEqual(stub.called, true);
+            assert.strictEqual(stub.args[0][0], 'cs');
+          });
+        });
+      });
+    });
+
+    // Tests_SRS_NODE_MODULE_CLIENT_13_034: [ If the client is running in a non-edge mode and an environment variable named EdgeModuleCACertificateFile exists then its value shall be set as the CA cert for the transport via the transport's setOptions method passing in the CA as the value for the ca property in the options object. ]
+    ['EdgeHubConnectionString', 'IotHubConnectionString'].forEach(function(envName) {
+      describe('sets CA cert in non-edge mode', function() {
+        var stub;
+        
+        var transport = {
+          setOptions: function() {}
+        };
+        var setOptionsStub = sinon.stub(transport, 'setOptions');
+
+        beforeEach(function() {
+          stub = sinon.stub(ModuleClient, 'fromConnectionString')
+            .callsArgWith(1, 'auth provider')
+            .returns(42);
+          process.env[envName] = 'cs';
+          process.env.EdgeModuleCACertificateFile = 'ca cert';
+        });
+
+        afterEach(function() {
+          stub.restore();
+          delete process.env[envName];
+          delete process.env['EdgeModuleCACertificateFile'];
+        });
+
+        it('if env ' + envName + ' is defined', function() {
+          ModuleClient.fromEnvironment(function(authProvider) {
+            assert.strictEqual(authProvider, 'auth provider');
+            return transport;
+          }, function(err, client) {
+            assert.isNotOk(err);
+            assert.strictEqual(client, 42);
+            assert.strictEqual(stub.called, true);
+            assert.strictEqual(stub.args[0][0], 'cs');
+            assert.strictEqual(setOptionsStub.called, true);
+            assert.strictEqual(setOptionsStub.args[0][0].ca, 'ca cert');
+          });
         });
       });
     });
@@ -75,10 +125,11 @@ describe('ModuleClient', function() {
       });
 
       requiredVars.forEach(function(_, index) {
-        it('throws if env var ' + requiredVars[index] + ' is not defined', function() {
-          assert.throws(function() {
-            ModuleClient.fromEnvironment(function() {});
-          }, errors.ReferenceError);
+        it('fails if env var ' + requiredVars[index] + ' is not defined', function() {
+          ModuleClient.fromEnvironment(function() {}, function(err) {
+            assert.isOk(err);
+            assert.instanceOf(err, ReferenceError);
+          });
         });
       });
     });
@@ -101,11 +152,12 @@ describe('ModuleClient', function() {
         delete process.env['IOTEDGE_AUTHSCHEME'];
       });
 
-      it('throws if value is not SasToken', function() {
-        assert.throws(function() {
-          process.env['IOTEDGE_AUTHSCHEME'] = 'NotSasToken';
-          ModuleClient.fromEnvironment(function() {});
-        }, errors.ReferenceError);
+      it('fails if value is not SasToken', function() {
+        process.env['IOTEDGE_AUTHSCHEME'] = 'NotSasToken';
+        ModuleClient.fromEnvironment(function() {}, function(err) {
+          assert.isOk(err);
+          assert.instanceOf(err, ReferenceError);
+        });
       });
     });
 
@@ -120,35 +172,171 @@ describe('ModuleClient', function() {
         ['IOTEDGE_MODULEGENERATIONID', 'g1']
       ];
 
+      var getTrustBundleStub;
+      var createWithSigningFunctionStub;
+
       beforeEach(function() {
         env.forEach(function(e) {
           process.env[e[0]] = e[1];
         });
+
+        getTrustBundleStub = sinon.stub(IotEdgeAuthenticationProvider.prototype, 'getTrustBundle')
+          .callsArgWith(0, null, 'ca cert');
+
+        createWithSigningFunctionStub = sinon.stub(SharedAccessSignature, 'createWithSigningFunction')
+          .callsArgWith(3, null, 'sas token');
       });
 
       afterEach(function() {
         env.forEach(function(e) {
           delete process.env[e[0]];
         });
+
+        getTrustBundleStub.restore();
+        createWithSigningFunctionStub.restore();
       });
 
       // Tests_SRS_NODE_MODULE_CLIENT_13_032: [ The fromEnvironment method shall create a new IotEdgeAuthenticationProvider object and pass this to the transport constructor. ]
-      // Tests_SRS_NODE_MODULE_CLIENT_13_031: [ The fromEnvironment method shall return a new instance of the ModuleClient object. ]
-      it('creates IotEdgeAuthenticationProvider', function() {
-        var transportStub = sinon.stub().returns(new EventEmitter());
-        var client = ModuleClient.fromEnvironment(transportStub);
-        assert.strictEqual(transportStub.called, true);
-        var provider = transportStub.args[0][0];
-        assert.isOk(provider);
-        assert.strictEqual(provider._authConfig.workloadUri, 'unix:///var/run/iotedge.w.sock');
-        assert.strictEqual(provider._authConfig.deviceId, 'd1');
-        assert.strictEqual(provider._authConfig.moduleId, 'm1');
-        assert.strictEqual(provider._authConfig.iothubHostName, 'host1');
-        assert.strictEqual(provider._authConfig.authScheme, 'SasToken');
-        assert.strictEqual(provider._authConfig.gatewayHostName, 'gwhost');
-        assert.strictEqual(provider._authConfig.generationId, 'g1');
-        assert.instanceOf(provider, IotEdgeAuthenticationProvider);
-        assert.instanceOf(client, ModuleClient);
+      // Tests_SRS_NODE_MODULE_CLIENT_13_031: [ The fromEnvironment method shall invoke the callback with a new instance of the ModuleClient object. ]
+      it('creates IotEdgeAuthenticationProvider', function(testCallback) {
+        var transport = {
+          on: sinon.stub(),
+          setOptions: sinon.stub()
+        };
+        var transportStub = sinon.stub().returns(transport);
+        ModuleClient.fromEnvironment(transportStub, function(err, client) {
+          assert.isNotOk(err);
+          assert.strictEqual(transportStub.called, true);
+          var provider = transportStub.args[0][0];
+          assert.isOk(provider);
+          assert.strictEqual(provider._authConfig.workloadUri, 'unix:///var/run/iotedge.w.sock');
+          assert.strictEqual(provider._authConfig.deviceId, 'd1');
+          assert.strictEqual(provider._authConfig.moduleId, 'm1');
+          assert.strictEqual(provider._authConfig.iothubHostName, 'host1');
+          assert.strictEqual(provider._authConfig.authScheme, 'SasToken');
+          assert.strictEqual(provider._authConfig.gatewayHostName, 'gwhost');
+          assert.strictEqual(provider._authConfig.generationId, 'g1');
+          assert.instanceOf(provider, IotEdgeAuthenticationProvider);
+          assert.instanceOf(client, ModuleClient);
+
+          testCallback();
+        });
+      });
+    });
+
+    describe('trust bundle', function() {
+      var env = [
+        ['IOTEDGE_WORKLOADURI', 'unix:///var/run/iotedge.w.sock'],
+        ['IOTEDGE_DEVICEID', 'd1'],
+        ['IOTEDGE_MODULEID', 'm1'],
+        ['IOTEDGE_IOTHUBHOSTNAME', 'host1'],
+        ['IOTEDGE_AUTHSCHEME', 'SasToken'],
+        ['IOTEDGE_GATEWAYHOSTNAME', 'gwhost'],
+        ['IOTEDGE_MODULEGENERATIONID', 'g1']
+      ];
+
+      var getTrustBundleStub;
+      var createWithSigningFunctionStub;
+  
+      beforeEach(function() {
+        env.forEach(function(e) {
+          process.env[e[0]] = e[1];
+        });
+
+        getTrustBundleStub = sinon.stub(IotEdgeAuthenticationProvider.prototype, 'getTrustBundle')
+          .callsArgWith(0, null, 'ca cert');
+
+        createWithSigningFunctionStub = sinon.stub(SharedAccessSignature, 'createWithSigningFunction')
+          .callsArgWith(3, null, 'sas token');
+      });
+  
+      afterEach(function() {
+        env.forEach(function(e) {
+          delete process.env[e[0]];
+        });
+
+        getTrustBundleStub.restore();
+        createWithSigningFunctionStub.restore();
+      });
+  
+      // Tests_SRS_NODE_MODULE_CLIENT_13_035: [ If the client is running in edge mode then the IotEdgeAuthenticationProvider.getTrustBundle method shall be invoked to retrieve the CA cert and the returned value shall be set as the CA cert for the transport via the transport's setOptions method passing in the CA value for the ca property in the options object. ]
+      it('sets cert on transport', function(testCallback) {
+        var transport = {
+          on: sinon.stub(),
+          setOptions: sinon.stub()
+        };
+        var transportStub = sinon.stub().returns(transport);
+        ModuleClient.fromEnvironment(transportStub, function(err, client) {
+          assert.isNotOk(err);
+          assert.strictEqual(transportStub.called, true);
+          var provider = transportStub.args[0][0];
+          assert.isOk(provider);
+          assert.strictEqual(getTrustBundleStub.called, true);
+          assert.strictEqual(transport.setOptions.called, true);
+          assert.strictEqual(transport.setOptions.args[0][0].ca, 'ca cert');
+          assert.strictEqual(provider._authConfig.workloadUri, 'unix:///var/run/iotedge.w.sock');
+          assert.strictEqual(provider._authConfig.deviceId, 'd1');
+          assert.strictEqual(provider._authConfig.moduleId, 'm1');
+          assert.strictEqual(provider._authConfig.iothubHostName, 'host1');
+          assert.strictEqual(provider._authConfig.authScheme, 'SasToken');
+          assert.strictEqual(provider._authConfig.gatewayHostName, 'gwhost');
+          assert.strictEqual(provider._authConfig.generationId, 'g1');
+          assert.instanceOf(provider, IotEdgeAuthenticationProvider);
+          assert.instanceOf(client, ModuleClient);
+
+          testCallback();
+        });
+      });
+    });
+
+    describe('trust bundle', function() {
+      var env = [
+        ['IOTEDGE_WORKLOADURI', 'unix:///var/run/iotedge.w.sock'],
+        ['IOTEDGE_DEVICEID', 'd1'],
+        ['IOTEDGE_MODULEID', 'm1'],
+        ['IOTEDGE_IOTHUBHOSTNAME', 'host1'],
+        ['IOTEDGE_AUTHSCHEME', 'SasToken'],
+        ['IOTEDGE_GATEWAYHOSTNAME', 'gwhost'],
+        ['IOTEDGE_MODULEGENERATIONID', 'g1']
+      ];
+
+      var getTrustBundleStub;
+      var createWithSigningFunctionStub;
+  
+      beforeEach(function() {
+        env.forEach(function(e) {
+          process.env[e[0]] = e[1];
+        });
+
+        getTrustBundleStub = sinon.stub(IotEdgeAuthenticationProvider.prototype, 'getTrustBundle')
+          .callsArgWith(0, 'whoops');
+        
+        createWithSigningFunctionStub = sinon.stub(SharedAccessSignature, 'createWithSigningFunction')
+          .callsArgWith(3, null, 'sas token');
+      });
+  
+      afterEach(function() {
+        env.forEach(function(e) {
+          delete process.env[e[0]];
+        });
+
+        getTrustBundleStub.restore();
+        createWithSigningFunctionStub.restore();
+      });
+  
+      it('fails if getTrustBundle fails', function(testCallback) {
+        var transport = {
+          on: sinon.stub(),
+          setOptions: sinon.stub()
+        };
+        var transportStub = sinon.stub().returns(transport);
+        ModuleClient.fromEnvironment(transportStub, function(err, client) {
+          assert.isOk(err);
+          assert.strictEqual(err, 'whoops');
+          assert.strictEqual(getTrustBundleStub.called, true);
+
+          testCallback();
+        });
       });
     });
   });

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -80,6 +80,8 @@ The `connect` method establishes a connection with the Azure IoT Hub instance.
 
 **SRS_NODE_DEVICE_AMQP_06_009: [** If `putToken` is not successful then the client will remain disconnected and the callback will be called with an error per SRS_NODE_DEVICE_AMQP_16_009. **]**
 
+**SRS_NODE_DEVICE_AMQP_13_002: [** The `connect` method shall set the CA cert on the options object when calling the underlying connection object's connect method if it was supplied. **]**
+
 ### disconnect(done)
 The `disconnect` method terminates the connection with the Azure IoT Hub instance.
 
@@ -144,6 +146,8 @@ This method is deprecated. The `AmqpReceiver` object and pattern is going away a
 **SRS_NODE_DEVICE_AMQP_06_004: [** The AMQP transport should use the x509 settings passed in the `options` object to connect to the service if present.**]**
 
 **SRS_NODE_DEVICE_AMQP_16_053: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called while using token-based authentication. **]**
+
+**SRS_NODE_DEVICE_AMQP_13_001: [** The `setOptions` method shall save the options passed in. **]**
 
 ### abandon(message, done)
 

--- a/device/transport/amqp/src/amqp_ws.ts
+++ b/device/transport/amqp/src/amqp_ws.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 import { Amqp } from './amqp.js';
-import { AuthenticationProvider } from 'azure-iot-common';
+import { AuthenticationProvider, TransportConfig } from 'azure-iot-common';
 
 /**
  * Constructs a transport object that can be used by the device {@link azure-iot-device.Client} to send and receive messages to and from an IoT Hub instance, using the AMQP protocol over secure websockets.
@@ -22,7 +22,7 @@ export class AmqpWs extends Amqp {
     super(authenticationProvider);
   }
 
-  protected _getConnectionUri(host: string): string {
-    return 'wss://' + host + ':443/$iothub/websocket';
+  protected _getConnectionUri(credentials: TransportConfig): string {
+    return 'wss://' + (credentials.gatewayHostName || credentials.host) + ':443/$iothub/websocket';
   }
 }


### PR DESCRIPTION
  - Add CA cert support for AMQP
  - Turn fromEnvironment into an async function
  - Add trust bundle support in edge auth provider + amqp support for gateway host name
  - Add support for CA cert from environment and trust bundle support in ModuleClient
