### PR TITLE
ModuleClient.invokeMethod (works only with Edge)

### DIFF
--- a/common/transport/http/package.json
+++ b/common/transport/http/package.json
@@ -30,7 +30,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 94 --branches 86 --functions 100 --lines 94"
+    "check-cover": "istanbul check-coverage --statements 94 --branches 87 --functions 100 --lines 94"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/http/src/http.ts
+++ b/common/transport/http/src/http.ts
@@ -144,6 +144,10 @@ export class Http {
       httpOptions.passphrase = (x509Options as X509).passphrase;
     }
 
+    if (this._options && this._options.ca) {
+      httpOptions.ca = this._options.ca;
+    }
+
     let httpReq = request(httpOptions, (response: IncomingMessage): void => {
       let responseBody = '';
       response.on('error', (err: Error): void => {

--- a/common/transport/http/test/_http_test.js
+++ b/common/transport/http/test/_http_test.js
@@ -119,6 +119,15 @@ describe('Http', function() {
       assert.strictEqual(https.request.args[0][0].passphrase, 'pass1');
       callback();
     });
+
+    it('populates the ca if provided in the options', function (callback) {
+      var http = new Http();
+      var fakeCA = 'ca';
+      http.setOptions({ ca: fakeCA });
+      http.buildRequest('GET', fakePath, fakeHeaders, fakeHost, null, function() {});
+      assert.strictEqual(https.request.args[0][0].ca, fakeCA);
+      callback();
+    });
   });
 
   describe('#buildRequest', function() {
@@ -140,7 +149,7 @@ describe('Http', function() {
           callback(fakeResponse);
           return new EventEmitter();
         });
-      
+
       sinon.stub(fakeResponse, 'on')
         .callsFake(function(eventName, callback) {
           if (eventName === 'error') {
@@ -184,7 +193,7 @@ describe('Http', function() {
           callback(fakeResponse);
           return new EventEmitter();
         });
-      
+
       sinon.stub(fakeResponse, 'on')
         .callsFake(function(eventName, callback) {
           if (eventName === 'data') {
@@ -238,7 +247,7 @@ describe('Http', function() {
           callback(fakeResponse);
           return new EventEmitter();
         });
-      
+
       sinon.stub(fakeResponse, 'on')
         .callsFake(function(eventName, callback) {
           if (eventName === 'end') {

--- a/device/core/devdoc/device_method/method_client_requirements.md
+++ b/device/core/devdoc/device_method/method_client_requirements.md
@@ -1,0 +1,49 @@
+# DirectMethodClient requirements
+
+The `DirectMethodClient` class is in charge of making edgeHub method API calls. It is a private class that shall be used by the `ModuleClient` to make method calls and the SDK user should only use the `ModuleClient` object.
+
+## Overview
+```typescript
+export class DirectMethodClient {
+  constructor(authProvider: AuthenticationProvider);
+  invokeMethod(deviceId: string, moduleId: string, methodParams: DirectMethodParams, callback: DirectMethodCallback): void;
+  setOptions(options: any): void;
+  updateSharedAccessSignature(sharedAccessSignature: string, callback: (err?: Error) => void): void;
+}
+```
+
+## API
+*Note: this API is internal only and is used solely by the `ModuleClient` object.*
+
+### invokeMethod(deviceId: string, moduleId: string, methodParams: DirectMethodParams, callback: DirectMethodCallback): void
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_006: [** The `invokeMethod` method shall get the latest credentials by calling `getDeviceCredentials` on the `AuthenticationProvider` object. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_007: [** The `invokeMethod` method shall create a `RestApiClient` object if it does not exist. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_015: [** The `invokeMethod` method shall update the shared access signature of the `RestApiClient` by using its `updateSharedAccessSignature` method and the credentials obtained with the call to `getDeviceCredentials` (see `SRS_NODE_DEVICE_METHOD_CLIENT_16_006`). **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_008: [** The `invokeMethod` method shall call its callback with an `Error` if it fails to get the latest credentials from the `AuthenticationProvider` object. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_009: [** The `invokeMethod` method shall call the `setOptions` method on the `RestApiClient` with its options as argument to make sure the CA certificate is populated. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_010: [** The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/methods` if the target is a device. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_011: [** The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/modules/encodeUriComponentStrict(<targetModuleId>)/methods` if the target is a module. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_012: [** The `invokeMethod` method shall call `RestApiClient.executeApiCall` with:
+- `POST` for the HTTP method argument.
+- `path` as defined in `SRS_NODE_DEVICE_METHOD_CLIENT_16_010` and `SRS_NODE_DEVICE_METHOD_CLIENT_16_011`
+- 2 custom headers:
+  - `Content-Type` shall be set to `application/json`
+  - `x-ms-edge-moduleId` shall be set to `<deviceId>/<moduleId>` with `deviceId` and `moduleId` being the identifiers for the current module (as opposed to the target module)
+- the stringified version of the `MethodParams` object as the body of the request
+- a timeout value in milliseconds that is the sum of the `connectTimeoutInSeconds` and `responseTimeoutInSeconds` parameters of the `MethodParams` object. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_013: [** The `invokeMethod` method shall call its callback with an error if `RestApiClient.executeApiCall` fails. **]**
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_014: [** The `invokeMethod` method shall call its callback with the result object if the call to `RestApiClient.executeApiCall` succeeds. **]**
+
+### setOptions(options: any): void
+
+**SRS_NODE_DEVICE_METHOD_CLIENT_16_001: [** The `setOptions` method shall merge the options passed in argument with the existing set of options used by the `MethodClient`. **]**

--- a/device/core/devdoc/module_client_requirements.md
+++ b/device/core/devdoc/module_client_requirements.md
@@ -82,8 +82,32 @@ class ModuleClient extends InternalClient {
 
 **SRS_NODE_MODULE_CLIENT_18_022: [** The `sendOutputEventBatch` method shall not throw if the `callback` is not passed. **]**
 
+### setOptions
+**SRS_NODE_MODULE_CLIENT_16_042: [** The `setOptions` method shall throw a `ReferenceError` if the options object is falsy. **]**
 
-**SRS_NODE_MODULE_CLIENT_16_096: [** The `setRetryPolicy` method shall call the `setRetryPolicy` method on the twin if it is set and pass it the `policy` object. **]**
+**SRS_NODE_MODULE_CLIENT_16_043: [** The `done` callback shall be invoked with no parameters when it has successfully finished setting the client and/or transport options. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_044: [** The `done` callback shall be invoked with a standard javascript `Error` object and no result object if the client could not be configured as requested. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_098: [** The `setOptions` method shall call the `setOptions` method with the `options` argument on the `MethodClient` object of the `ModuleClient`. **]**
+
+### invokeMethod(deviceId: string, moduleIdOrMethodParams: string | DirectMethodParams, methodParamsOrCallback: DirectMethodParams | DirectMethodCallback, callback?: DirectMethodCallback): void
+
+**Other valid signatures:**
+```typescript
+invokeMethod(deviceId: string, methodParams: DirectMethodParams, callback: DirectMethodCallback): void;
+invokeMethod(deviceId: string, moduleId: string, methodParams: DirectMethodParams, callback: DirectMethodCallback): void;
+```
+
+**SRS_NODE_MODULE_CLIENT_16_093: [** `invokeMethod` shall throw a `ReferenceError` if the `deviceId` argument is falsy. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_094: [** `invokeMethod` shall throw a `ReferenceError` if the `moduleIdOrMethodParams` argument is falsy. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_095: [** `invokeMethod` shall throw a `ReferenceError` if the `deviceId` and `moduleIdOrMethodParams` are strings and the `methodParamsOrCallback` argument is falsy. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_096: [** `invokeMethod` shall throw a `ArgumentError` if the `methodName` property of the `MethodParams` argument is falsy. **]**
+
+**SRS_NODE_MODULE_CLIENT_16_097: [** `invokeMethod` shall call the `invokeMethod` API of the `MethodClient` API that was created for the `ModuleClient` instance. **]**
 
 ### on('inputMessage', msgHandler)
 

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -37,7 +37,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec \"test/**/_*_test*.js\"",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 86 --lines 97 --functions 92"
+    "check-cover": "istanbul check-coverage --statements 95 --branches 87 --lines 97 --functions 92"
   },
   "engines": {
     "node": ">= 0.10"

--- a/device/core/src/device_client.ts
+++ b/device/core/src/device_client.ts
@@ -153,17 +153,14 @@ export class Client extends InternalClient {
   }
 
   /**
-   * @method            module:azure-iot-device.Client.fromConnectionString
-   * @description       Creates an IoT Hub device client from the given
-   *                    connection string using the given transport type.
+   * Creates an IoT Hub device client from the given connection string using the given transport type.
    *
-   * @param {String}    connStr       A connection string which encapsulates "device
-   *                                  connect" permissions on an IoT hub.
-   * @param {Function}  Transport     A transport constructor.
+   * @param {String}    connStr        A connection string which encapsulates "device connect" permissions on an IoT hub.
+   * @param {Function}  transportCtor  A transport constructor.
    *
    * @throws {ReferenceError}         If the connStr parameter is falsy.
    *
-   * @returns {module:azure-iothub.Client}
+   * @returns {module:azure-iot-device.Client}
    */
   static fromConnectionString(connStr: string, transportCtor: any): any {
     /*Codes_SRS_NODE_DEVICE_CLIENT_05_003: [The fromConnectionString method shall throw ReferenceError if the connStr argument is falsy.]*/

--- a/device/core/src/device_method/index.ts
+++ b/device/core/src/device_method/index.ts
@@ -5,3 +5,18 @@
 
 export { DeviceMethodRequest } from './device_method_request';
 export { DeviceMethodResponse } from './device_method_response';
+export { MethodClient } from './method_client';
+
+export interface MethodParams {
+  methodName: string;
+  payload: any;
+  connectTimeoutInSeconds: number;
+  responseTimeoutInSeconds: number;
+}
+
+export interface MethodResult {
+  status: number;
+  payload: any;
+}
+
+export type MethodCallback = (err?: Error, result?: MethodResult) => void;

--- a/device/core/src/device_method/method_client.ts
+++ b/device/core/src/device_method/method_client.ts
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+import { AuthenticationProvider, encodeUriComponentStrict } from 'azure-iot-common';
+import { MethodParams, MethodCallback, MethodResult } from '.';
+import { RestApiClient } from 'azure-iot-http-base';
+import { getUserAgentString } from '../utils';
+import * as _ from 'lodash';
+
+/**
+ * @private
+ */
+export class MethodClient {
+  private _authProvider: AuthenticationProvider;
+  private _restApiClient: RestApiClient;
+  private _options: any;
+  private _httpHeaders: { [key: string]: string };
+
+  constructor(authProvider: AuthenticationProvider) {
+    this._authProvider = authProvider;
+    this._options = {};
+    this._httpHeaders = {
+      'Content-Type': 'application/json'
+    };
+  }
+
+  invokeMethod(deviceId: string, moduleId: string, methodParams: MethodParams, callback: MethodCallback): void {
+    /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_006: [The `invokeMethod` method shall get the latest credentials by calling `getDeviceCredentials` on the `AuthenticationProvider` object.]*/
+    /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_007: [The `invokeMethod` method shall create a `RestApiClient` object if it does not exist.]*/
+    this._init((err) => {
+      if (err) {
+        /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_008: [The `invokeMethod` method shall call its callback with an `Error` if it fails to get the latest credentials from the `AuthenticationProvider` object.]*/
+        callback(err);
+      } else {
+        /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_009: [The `invokeMethod` method shall call the `setOptions` method on the `RestApiClient` with its options as argument to make sure the CA certificate is populated.]*/
+        this._restApiClient.setOptions(this._options);
+        /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_010: [The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/methods` if the target is a device.]*/
+        let path = `/twins/${encodeUriComponentStrict(deviceId)}`;
+        /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_011: [The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/modules/encodeUriComponentStrict(<targetModuleId>)/methods` if the target is a module.]*/
+        if (moduleId) {
+          path += `/modules/${encodeUriComponentStrict(moduleId)}`;
+        }
+        path += '/methods';
+
+        /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_012: [The `invokeMethod` method shall call `RestApiClient.executeApiCall` with:
+          - `POST` for the HTTP method argument.
+          - `path` as defined in `SRS_NODE_DEVICE_METHOD_CLIENT_16_010` and `SRS_NODE_DEVICE_METHOD_CLIENT_16_011`
+          - 2 custom headers:
+            - `Content-Type` shall be set to `application/json`
+            - `x-ms-edge-moduleId` shall be set to `<deviceId>/<moduleId>` with `deviceId` and `moduleId` being the identifiers for the current module (as opposed to the target module)
+          - the stringified version of the `MethodParams` object as the body of the request
+          - a timeout value in milliseconds that is the sum of the `connectTimeoutInSeconds` and `responseTimeoutInSeconds` parameters of the `MethodParams` object.]*/
+        const body = JSON.stringify(methodParams);
+        const methodTimeout = 1000 * (methodParams.connectTimeoutInSeconds + methodParams.responseTimeoutInSeconds);
+        this._restApiClient.executeApiCall('POST', path, this._httpHeaders, body, methodTimeout, (err, result) => {
+          if (err) {
+            /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_013: [The `invokeMethod` method shall call its callback with an error if `RestApiClient.executeApiCall` fails.]*/
+            callback(err);
+          } else {
+            /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_014: [The `invokeMethod` method shall call its callback with the result object if the call to `RestApiClient.executeApiCall` succeeds.]*/
+            callback(null, result as MethodResult);
+          }
+        });
+      }
+    });
+  }
+
+  setOptions(options: any): void {
+    /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_001: [The `setOptions` method shall merge the options passed in argument with the existing set of options used by the `MethodClient`.]*/
+    this._options = _.merge(this._options, options);
+  }
+
+  private _init(callback: (err?: Error) => void): void {
+    this._authProvider.getDeviceCredentials((err, creds) => {
+      if (err) {
+        callback(err);
+      } else {
+        this._httpHeaders['x-ms-edge-moduleId'] = creds.deviceId + '/' + creds.moduleId;
+
+        if (this._restApiClient) {
+          /*Codes_SRS_NODE_DEVICE_METHOD_CLIENT_16_015: [The `invokeMethod` method shall update the shared access signature of the `RestApiClient` by using its `updateSharedAccessSignature` method and the credentials obtained with the call to `getDeviceCredentials` (see `SRS_NODE_DEVICE_METHOD_CLIENT_16_006`).]*/
+          this._restApiClient.updateSharedAccessSignature(creds.sharedAccessSignature);
+          callback();
+        } else {
+          getUserAgentString((userAgentString) => {
+            const transportConfig: RestApiClient.TransportConfig = {
+              host: creds.gatewayHostName,
+              sharedAccessSignature: creds.sharedAccessSignature
+            };
+
+            this._restApiClient = new RestApiClient(transportConfig, userAgentString);
+            callback();
+          });
+        }
+      }
+    });
+  }
+}

--- a/device/core/src/internal_client.ts
+++ b/device/core/src/internal_client.ts
@@ -210,6 +210,11 @@ export abstract class InternalClient extends EventEmitter {
     });
   }
 
+  /**
+   * Passes options to the `Client` object that can be used to configure the transport.
+   * @param options   A {@link DeviceClientOptions} object.
+   * @param done      The callback to call once the options have been set.
+   */
   setOptions(options: DeviceClientOptions, done?: (err?: Error, result?: results.TransportConfigured) => void): void {
     /*Codes_SRS_NODE_INTERNAL_CLIENT_16_042: [The `setOptions` method shall throw a `ReferenceError` if the options object is falsy.]*/
     if (!options) throw new ReferenceError('options cannot be falsy.');

--- a/device/core/test/_internal_client_test.js
+++ b/device/core/test/_internal_client_test.js
@@ -33,12 +33,6 @@ var ModuleClient = require('../lib/module_client').ModuleClient;
           }, ReferenceError, 'transport is \'' + transport + '\'');
         });
       });
-
-      it('throws if a connection string is passed', function () {
-        assert.throws(function () {
-          return new ClientCtor(EventEmitter, 'fakeconnectionstring');
-        }, errors.InvalidOperationError);
-      })
     });
 
     describe('#fromConnectionString', function () {
@@ -167,38 +161,6 @@ var ModuleClient = require('../lib/module_client').ModuleClient;
         assert.throws(function () {
           client.setTransportOptions({ foo: 42 }, function () { });
         }, errors.NotImplementedError);
-      });
-    });
-
-    describe('#setOptions', function () {
-      /*Tests_SRS_NODE_INTERNAL_CLIENT_16_042: [The `setOptions` method shall throw a `ReferenceError` if the options object is falsy.]*/
-      [null, undefined].forEach(function (options) {
-        it('throws is options is ' + options, function () {
-          var client = new ClientCtor(new EventEmitter());
-          assert.throws(function () {
-            client.setOptions(options, function () { });
-          }, ReferenceError);
-        });
-      });
-
-      /*Tests_SRS_NODE_INTERNAL_CLIENT_16_043: [The `done` callback shall be invoked no parameters when it has successfully finished setting the client and/or transport options.]*/
-      it('calls the done callback with no parameters when it has successfully configured the transport', function (done) {
-        var client = new ClientCtor(new FakeTransport());
-        client.setOptions({}, done);
-      });
-
-      /*Tests_SRS_NODE_INTERNAL_CLIENT_16_044: [The `done` callback shall be invoked with a standard javascript `Error` object and no result object if the client could not be configured as requested.]*/
-      it('calls the done callback with an error when it failed to configured the transport', function (done) {
-        var failingTransport = new FakeTransport();
-        sinon.stub(failingTransport, 'setOptions').callsFake(function (options, done) {
-          done(new Error('dummy error'));
-        });
-
-        var client = new ClientCtor(failingTransport);
-        client.setOptions({}, function (err) {
-          assert.instanceOf(err, Error);
-          done();
-        });
       });
     });
 

--- a/device/core/test/device_method/_device_method_request_test.js
+++ b/device/core/test/device_method/_device_method_request_test.js
@@ -14,7 +14,7 @@ describe('DeviceMethodRequest', function() {
     { val: null, err: ReferenceError },
     { val: '', err: Error }
   ];
-  
+
   // Tests_SRS_NODE_DEVICE_METHOD_REQUEST_13_001: [ DeviceMethodRequest shall throw a ReferenceError if requestId is falsy or is not a string. ]
   // Tests_SRS_NODE_DEVICE_METHOD_REQUEST_13_002: [ DeviceMethodRequest shall throw an Error if requestId is an empty string. ]
   inputs.forEach(function(inp) {

--- a/device/core/test/device_method/_method_client_test.js
+++ b/device/core/test/device_method/_method_client_test.js
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+var assert = require('chai').assert;
+var sinon = require('sinon');
+var encodeUriComponentStrict = require('azure-iot-common').encodeUriComponentStrict;
+var MethodClient = require('../../lib/device_method').MethodClient;
+
+
+describe('MethodClient', function () {
+  var fakeAuthProvider, fakeRestApiClient;
+  var fakeCredentials = {
+    gatewayHostName: 'gateway',
+    sharedAccessSignature: 'sas',
+    deviceId: 'deviceId',
+    moduleId: 'moduleId'
+  };
+  var fakeMethodParams = {
+    methodName: 'fakeMethod',
+    payload: 'fakePayload',
+    responseTimeoutInSeconds: 4,
+    connectTimeoutInSeconds: 2
+  };
+  var fakeMethodResult = {
+    status: 200,
+    payload: {
+      fakeKey: 'fakeValue'
+    }
+  };
+
+  beforeEach(function () {
+    fakeAuthProvider = {
+      getDeviceCredentials: sinon.stub().callsArgWith(0, null, fakeCredentials)
+    };
+    fakeRestApiClient = {
+      setOptions: sinon.stub(),
+      updateSharedAccessSignature: sinon.stub(),
+      executeApiCall: sinon.stub().callsArgWith(5, null, fakeMethodResult)
+    };
+  })
+
+  describe('#invokeMethod', function () {
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_006: [The `invokeMethod` method shall get the latest credentials by calling `getDeviceCredentials` on the `AuthenticationProvider` object.]*/
+    it('calls getDeviceCredentials on the authentication provider and use received credentials', function (testCallback) {
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function () {
+        assert.isTrue(fakeAuthProvider.getDeviceCredentials.calledOnce);
+        assert.strictEqual(fakeRestApiClient.executeApiCall.firstCall.args[2]['x-ms-edge-moduleId'], fakeCredentials.deviceId + '/' + fakeCredentials.moduleId);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_007: [The `invokeMethod` method shall create a `RestApiClient` object if it does not exist.]*/
+    it('instantiates a RestApiClient with the proper parameters if it has not been created yet', function (testCallback) {
+      var client = new MethodClient(fakeAuthProvider);
+      var restApiClientStub = sinon.stub(require('azure-iot-http-base'), 'RestApiClient').callsFake(function (config, userAgent) {
+        assert.strictEqual(config.host, fakeCredentials.gatewayHostName);
+        assert.strictEqual(config.sharedAccessSignature, fakeCredentials.sharedAccessSignature);
+        assert.isString(userAgent);
+        restApiClientStub.restore();
+        testCallback();
+      });
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function () {});
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_015: [The `invokeMethod` method shall update the shared access signature of the `RestApiClient` by using its `updateSharedAccessSignature` method and the credentials obtained with the call to `getDeviceCredentials` (see `SRS_NODE_DEVICE_METHOD_CLIENT_16_006`).]*/
+    it('calls updateSharedAccessSignature on the RestApiClient if it has already been instantiated', function (testCallback) {
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function () {
+        assert.isTrue(fakeRestApiClient.updateSharedAccessSignature.calledWith(fakeCredentials.sharedAccessSignature));
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_009: [The `invokeMethod` method shall call the `setOptions` method on the `RestApiClient` with its options as argument to make sure the CA certificate is populated.]*/
+    it('calls setOptions on the RestApiClient to make sure the CA cert parameter is set', function (testCallback) {
+      var fakeOptions = { ca: 'ca' };
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      client._options = fakeOptions;
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function () {
+        assert.isTrue(fakeRestApiClient.setOptions.calledOnce);
+        assert.isTrue(fakeRestApiClient.setOptions.calledWith(fakeOptions));
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_008: [The `invokeMethod` method shall call its callback with an `Error` if it fails to get the latest credentials from the `AuthenticationProvider` object.]*/
+    it('calls its callback with an error if the authentication provider fails to provide credentials', function (testCallback) {
+      var fakeError = new Error('fake');
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      fakeAuthProvider.getDeviceCredentials = sinon.stub().callsArgWith(0, fakeError);
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_011: [The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/modules/encodeUriComponentStrict(<targetModuleId>)/methods` if the target is a module.]*/
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_012: [The `invokeMethod` method shall call `RestApiClient.executeApiCall` with:
+      - `POST` for the HTTP method argument.
+      - `path` as defined in `SRS_NODE_DEVICE_METHOD_CLIENT_16_010` and `SRS_NODE_DEVICE_METHOD_CLIENT_16_011`
+      - 2 custom headers:
+        - `Content-Type` shall be set to `application/json`
+        - `x-ms-edge-moduleId` shall be set to `<deviceId>/<moduleId>` with `deviceId` and `moduleId` being the identifiers for the current module (as opposed to the target module)
+      - the stringified version of the `MethodParams` object as the body of the request
+      - a timeout value in milliseconds that is the sum of the `connectTimeoutInSeconds` and `responseTimeoutInSeconds` parameters of the `MethodParams` object.]*/
+    it('calls executeApiCall on the RestApiClient with the correct HTTP request parameters for a module target', function (testCallback) {
+      var targetDeviceId = 'target#DeviceId';
+      var targetModuleId = 'targetModule/Id';
+      var expectedPath = '/twins/' + encodeUriComponentStrict(targetDeviceId) + '/modules/' + encodeUriComponentStrict(targetModuleId) + '/methods';
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      client.invokeMethod(targetDeviceId, targetModuleId, fakeMethodParams, function () {
+        /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_014: [The `invokeMethod` method shall call its callback with the result object if the call to `RestApiClient.executeApiCall` succeeds.]*/
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[0], 'POST');
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[1], expectedPath);
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[2]['Content-Type'], 'application/json');
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[2]['x-ms-edge-moduleId'], fakeCredentials.deviceId + '/' + fakeCredentials.moduleId);
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[3], JSON.stringify(fakeMethodParams));
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[4], 1000 * (fakeMethodParams.responseTimeoutInSeconds + fakeMethodParams.connectTimeoutInSeconds));
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_010: [The `invokeMethod` method shall construct the HTTP request path as `/twins/encodeUriComponentStrict(<targetDeviceId>)/methods` if the target is a device.]*/
+    it('calls executeApiCall on the RestApiClient with the correct HTTP request parameters for a device target', function (testCallback) {
+      var targetDeviceId = 'target#DeviceId';
+      var expectedPath = '/twins/' + encodeUriComponentStrict(targetDeviceId) + '/methods';
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient;
+      client.invokeMethod(targetDeviceId, undefined, fakeMethodParams, function () {
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[0], 'POST');
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[1], expectedPath);
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[2]['Content-Type'], 'application/json');
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[2]['x-ms-edge-moduleId'], fakeCredentials.deviceId + '/' + fakeCredentials.moduleId);
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[3], JSON.stringify(fakeMethodParams));
+        assert.strictEqual(client._restApiClient.executeApiCall.firstCall.args[4], 1000 * (fakeMethodParams.responseTimeoutInSeconds + fakeMethodParams.connectTimeoutInSeconds));
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_013: [The `invokeMethod` method shall call its callback with an error if `RestApiClient.executeApiCall` fails.]*/
+    it('calls its callback with an error if the call to RestApiClient.executeApiCall fails', function (testCallback) {
+      var fakeError = new Error('fake');
+      var client = new MethodClient(fakeAuthProvider);
+      fakeRestApiClient.executeApiCall = sinon.stub().callsArgWith(5, fakeError);
+      client._restApiClient = fakeRestApiClient;
+      client.invokeMethod('targetDeviceId', 'targetModuleId', fakeMethodParams, function (err) {
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+    });
+  });
+
+  describe('#setOptions', function () {
+    /*Tests_SRS_NODE_DEVICE_METHOD_CLIENT_16_001: [The `setOptions` method shall merge the options passed in argument with the existing set of options used by the `MethodClient`.]*/
+    it('sets the CA option to be used by the RestApiClient', function (testCallback) {
+      var client = new MethodClient(fakeAuthProvider);
+      client._restApiClient = fakeRestApiClient
+      client.setOptions({ ca : 'fakeCa' });
+      client.invokeMethod('targetDevice', 'targetModule', fakeMethodParams, function (err, result) {
+        assert.strictEqual(fakeRestApiClient.setOptions.firstCall.args[0].ca, 'fakeCa');
+        testCallback();
+      });
+    });
+  });
+});

--- a/device/samples/module_invoke_method.js
+++ b/device/samples/module_invoke_method.js
@@ -1,0 +1,27 @@
+'use strict';
+
+
+var Client = require('azure-iot-device').ModuleClient;
+var Mqtt = require('azure-iot-device-mqtt').Mqtt;
+
+Client.fromEnvironment(Mqtt, (err, client) => {
+    if (err) {
+        console.error(err.toString());
+        process.exit(-1);
+    } else {
+        client.invokeMethod('pierreca-edge-test', 'methodTarget', {
+            methodName: 'doSomethingInteresting',
+            payload: 'foo',
+            responseTimeoutInSeconds: 5,
+            connectTimeoutInSeconds: 2
+        }, (err, resp) => {
+            if (err) {
+                console.error(err.toString());
+                process.exit(-1);
+            } else {
+                console.log(JSON.stringify(resp, null, 2));
+                process.exit(0);
+            }
+        });
+    }
+});


### PR DESCRIPTION
- Added a new object `MethodClient` in the `azure-iot-device` package
- Introduce the new public API `ModuleClient.invokeMethod`
- Use the new `MethodClient` in `ModuleClient.invokeMethod`
- Override `InternalClient.setOptions` in `ModuleClient` so that it updates the `MethodClient` too
- Add the ability for the `RestApiClient` to use a custom CA cert

@avranju FYI - you don't actually have to review if you don't have the time :)