### PR TITLE
fix(service): Fold invokeModuleMethod into invokeDeviceMethod

### DIFF
--- a/e2etests/test/module_methods.js
+++ b/e2etests/test/module_methods.js
@@ -69,8 +69,8 @@ describe('module methods', function() {
         debug('waiting for links before invoking method');
         setTimeout(function() {
           debug('invoking method');
-          testModule.serviceClient.invokeModuleMethod(testModule.deviceId, testModule.moduleId, methodParams, function(err, response) {
-            debug('invokeModuleMethod returned ' + (err ? err : 'success'));
+          testModule.serviceClient.invokeDeviceMethod(testModule.deviceId, testModule.moduleId, methodParams, function(err, response) {
+            debug('invokeDeviceMethod returned ' + (err ? err : 'success'));
             if (err) {
               done(err);
             } else {

--- a/service/devdoc/iothub_client_requirements.md
+++ b/service/devdoc/iothub_client_requirements.md
@@ -147,8 +147,15 @@ The `close` method closes the connection opened by open.
 
 **SRS_NODE_IOTHUB_CLIENT_16_005: [** The `close` method should not throw if the `done` callback is not specified. **]**
 
-### invokeDeviceMethod(deviceId, methodParams, done)
-The `invokeDeviceMethod` method calls a device method on a specific device and calls back with the result of this method's execution.
+### invokeDeviceMethod(deviceId: string, moduleIdOrMethodParams: string | DeviceMethodParams, methodParamsOrDone?: DeviceMethodParams | Callback<any>, done?: Callback<any>): void;
+The `invokeDeviceMethod` method calls a device method on a specific device or module and calls back with the result of this method's execution.
+
+#### Valid prototypes:
+```typescript
+invokeDeviceMethod(deviceId: string, methodParams: DeviceMethodParams, done?: Callback<any>): void;
+invokeDeviceMethod(deviceId: string, moduleId: string, methodParams: DeviceMethodParams, done?: Callback<any>): void;
+invokeDeviceMethod(deviceId: string, moduleIdOrMethodParams: string | DeviceMethodParams, methodParamsOrDone?: DeviceMethodParams | Callback<any>, done?: Callback<any>): void;
+```
 
 **SRS_NODE_IOTHUB_CLIENT_16_014: [** The `invokeDeviceMethod` method shall throw a `ReferenceError` if `deviceId` is `null`, `undefined` or an empty string. **]**
 
@@ -166,20 +173,7 @@ The `invokeDeviceMethod` method calls a device method on a specific device and c
 
 **SRS_NODE_IOTHUB_CLIENT_16_026: [** The `invokeDeviceMethod` method shall use the retry policy defined either by default or by a call to `setRetryPolicy` if necessary to send the method request. **]**
 
-### invokeModuleMethod(deviceId: string, moduleId: string, methodParams: DeviceMethodParams, done?: Callback<any>): void;
-
-**SRS_NODE_IOTHUB_CLIENT_18_001: [** The `invokeModuleMethod` shall throw a `ReferenceError` if `deviceId` or `moduleId`   is falsy. **]**
-
-**SRS_NODE_IOTHUB_CLIENT_18_002: [** The `invokeModuleMethod` method shall initialize a new `DeviceMethod` instance with `methodParams` values passed in the arguments. **]**
-
-**SRS_NODE_IOTHUB_CLIENT_18_003: [** The `invokeModuleMethod` method shall call `invokeOnModule` on the new `DeviceMethod` instance. **]**
-
-**SRS_NODE_IOTHUB_CLIENT_18_004: [** The `invokeModuleMethod` method shall call the `done` callback with a standard javascript `Error` object if the request failed. **]**
-
-**SRS_NODE_IOTHUB_CLIENT_18_005: [** The `invokeModuleMethod` method shall call the `done` callback with a `null` first argument, the result of the method execution in the second argument, and the transport-specific response object as a third argument. **]**
-
-**SRS_NODE_IOTHUB_CLIENT_18_006: [** The `invokeModuleMethod` method shall use the retry policy defined either by default or by a call to `setRetryPolicy` if necessary to send the method request. **]**
-
+**SRS_NODE_IOTHUB_CLIENT_18_003: [** If `moduleIdOrMethodParams` is a string the `invokeDeviceMethod` method shall call `invokeOnModule` on the new `DeviceMethod` instance. **]**
 
 ### setRetryPolicy(policy)
 

--- a/service/package.json
+++ b/service/package.json
@@ -38,7 +38,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run unittest",
-    "check-cover": "istanbul check-coverage --statements 97 --branches 92  --lines 97 --functions 93",
+    "check-cover": "istanbul check-coverage --statements 97 --branches 93  --lines 98 --functions 93",
     "cover": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js"
   },
   "engines": {

--- a/service/samples/module_method.js
+++ b/service/samples/module_method.js
@@ -17,7 +17,7 @@ var methodParams = {
 
 var client = Client.fromConnectionString(connectionString);
 
-client.invokeModuleMethod(deviceId, moduleId, methodParams, function (err, result) {
+client.invokeDeviceMethod(deviceId, moduleId, methodParams, function (err, result) {
   if (err) {
     console.error('Failed to invoke method \'' + methodParams.methodName + '\': ' + err.message);
   } else {

--- a/service/test/_client_test.js
+++ b/service/test/_client_test.js
@@ -201,39 +201,15 @@ describe('Client', function () {
     });
   });
 
-  describe('#invokeModuleMethod', function() {
-    /*Tests_SRS_NODE_IOTHUB_CLIENT_18_001: [The `invokeModuleMethod` shall throw a `ReferenceError` if `deviceId` or `methodId` is falsy. ]*/
-    [undefined, null, ''].forEach(function(badArg) {
-      it('throws if deviceId is ' + badArg, function() {
-        var client = new Client({}, {});
-        assert.throws(function() {
-          client.invokeModuleMethod(badArg, 'moduleId', { }, 42, function() {});
-        }, ReferenceError);
-      });
-    });
-
-    /*Tests_SRS_NODE_IOTHUB_CLIENT_18_001: [The `invokeModuleMethod` shall throw a `ReferenceError` if `deviceId` or `methodId` is falsy. ]*/
-    [undefined, null, ''].forEach(function(badArg) {
-      it('throws if moduleId is ' + badArg, function() {
-        var client = new Client({}, {});
-        assert.throws(function() {
-          client.invokeModuleMethod('deviceId', badArg, {}, 42, function() {});
-        }, ReferenceError);
-      });
-    });
-  });
-
   [
-    { name: 'invokeDeviceMethod', functionUnderTest: function(client, param, callback) { client.invokeDeviceMethod('deviceId', param, callback); } },
-    { name: 'invokeModuleMethod', functionUnderTest: function(client, param, callback) { client.invokeModuleMethod('deviceId', 'moduleId', param, callback); } },
+    { functionUnderTest: function(client, param, callback) { client.invokeDeviceMethod('deviceId', param, callback); } },
+    { functionUnderTest: function(client, param, callback) { client.invokeDeviceMethod('deviceId', 'moduleId', param, callback); } },
   ].forEach(function(testConfig) {
-    describe('#' + testConfig.name, function() {
+    describe('#invokeDeviceMethod', function() {
       /*Tests_SRS_NODE_IOTHUB_CLIENT_16_009: [The `invokeDeviceMethod` method shall initialize a new instance of `DeviceMethod` with the `methodName` and `timeout` values passed in the arguments.]*/
       /*Tests_SRS_NODE_IOTHUB_CLIENT_16_010: [The `invokeDeviceMethod` method shall use the newly created instance of `DeviceMethod` to invoke the method with the `payload` argument on the device specified with the `deviceid` argument .]*/
       /*Tests_SRS_NODE_IOTHUB_CLIENT_16_013: [The `invokeDeviceMethod` method shall call the `done` callback with a `null` first argument, the result of the method execution in the second argument, and the transport-specific response object as a third argument.]*/
-      /*Tests_SRS_NODE_IOTHUB_CLIENT_18_002: [The `invokeModuleMethod` method shall initialize a new `DeviceMethod` instance with `methodParams` values passed in the arguments. ]*/
-      /*Tests_SRS_NODE_IOTHUB_CLIENT_18_003: [The `invokeModuleMethod` method shall call `invokeOnModule` on the new `DeviceMethod` instance. ]*/
-      /*Tests_SRS_NODE_IOTHUB_CLIENT_18_005: [The `invokeModuleMethod` method shall call the `done` callback with a `null` first argument, the result of the method execution in the second argument, and the transport-specific response object as a third argument. ]*/
+      /*Tests_SRS_NODE_IOTHUB_CLIENT_18_003: [If `moduleIdOrMethodParams` is a string the `invokeDeviceMethod` method shall call `invokeOnModule` on the new `DeviceMethod` instance. ]*/
       it('uses the DeviceMethod client to invoke the method', function(testCallback) {
         var fakeMethodParams = {
           methodName: 'method',
@@ -259,7 +235,6 @@ describe('Client', function () {
       });
 
       /*Tests_SRS_NODE_IOTHUB_CLIENT_16_012: [The `invokeDeviceMethod` method shall call the `done` callback with a standard javascript `Error` object if the request failed.]*/
-      /*Tests_SRS_NODE_IOTHUB_CLIENT_18_004: [The `invokeModuleMethod` method shall call the `done` callback with a standard javascript `Error` object if the request failed. ]*/
       it('works when payload and timeout are omitted', function(testCallback) {
         var fakeError = new Error('fake error');
         var fakeRestClientFails = {

--- a/service/test/_device_method_test.js
+++ b/service/test/_device_method_test.js
@@ -112,7 +112,7 @@ describe('DeviceMethod', function() {
       expectedPath: '/twins/' + fakeDeviceId + '/methods' + endpoint.versionQueryString()
     },
     {
-      name: 'invokeModuleMethod',
+      name: 'invokeDeviceMethod',
       functionUnderTest: function(method, callback) { method.invokeOnModule(fakeDeviceId, fakeModuleId, callback); },
       expectedPath: '/twins/' + fakeDeviceId + '/modules/' + fakeModuleId + '/methods' + endpoint.versionQueryString()
     },


### PR DESCRIPTION
During the API review it was decided that there would be no invokeModuleMethod on the service client and instead the invokeDeviceMethod would be overloaded to also address the case of modules.