### PR TITLE
fix(mqtt-base): Fix #307: error event sometimes emitted after mqttClient.removeAllListeners() is called

### DIFF
--- a/common/transport/mqtt/package-lock.json
+++ b/common/transport/mqtt/package-lock.json
@@ -124,6 +124,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw=="
     },
+    "buffer-from": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -255,16 +260,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
-      }
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -747,40 +742,90 @@
       }
     },
     "mqtt": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-2.15.2.tgz",
-      "integrity": "sha512-TCJqn32KBoz+vIjtEH4JHHe/4beYFoEiebQ33H4GHn4q6Hq55TvwC3GY5Jf4JURrcgvqylEmR/j+rY5IUwURNg==",
+      "version": "2.18.3",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-2.18.3.tgz",
+      "integrity": "sha512-BXCUugFgA6FOWJGxhvUWtVLOdt6hYTmiMGPksEyKuuF1FQ0ji7UJBJ/0kVRMUtUWCAtPGnt4mZZZgJpzNLcuQg==",
       "requires": {
         "commist": "1.0.0",
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "end-of-stream": "1.4.1",
         "help-me": "1.1.0",
         "inherits": "2.0.3",
         "minimist": "1.2.0",
-        "mqtt-packet": "5.4.0",
-        "pump": "2.0.1",
-        "readable-stream": "2.3.4",
+        "mqtt-packet": "5.6.0",
+        "pump": "3.0.0",
+        "readable-stream": "2.3.6",
         "reinterval": "1.1.0",
         "split2": "2.2.0",
-        "websocket-stream": "5.1.1",
+        "websocket-stream": "5.1.2",
         "xtend": "4.0.1"
-      }
-    },
-    "mqtt-packet": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-5.4.0.tgz",
-      "integrity": "sha512-ziN7uVysLdn7fYbOhEaKOhcZC3yIRTTakY4TFd2w+UvZIx9dPr8NCqbBYoC4WYDlzWHTn5EqR5x20pC+K24Ymg==",
-      "requires": {
-        "bl": "1.2.1",
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1"
       },
       "dependencies": {
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "1.1.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "typedarray": "0.0.6"
+          }
+        },
+        "mqtt-packet": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-5.6.0.tgz",
+          "integrity": "sha512-QECe2ivqcR1LRsPobRsjenEKAC3i1a5gmm+jNKJLrsiq9PaSQ18LlKFuxvhGxWkvGEPadWv6rKd31O4ICqS1Xw==",
+          "requires": {
+            "bl": "1.2.1",
+            "inherits": "2.0.3",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "websocket-stream": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.1.2.tgz",
+          "integrity": "sha512-lchLOk435iDWs0jNuL+hiU14i3ERSrMA0IKSiJh7z6X/i4XNsutBZrtqu2CPOZuA4G/zabiqVAos0vW+S7GEVw==",
+          "requires": {
+            "duplexify": "3.5.3",
+            "inherits": "2.0.3",
+            "readable-stream": "2.3.6",
+            "safe-buffer": "5.1.1",
+            "ws": "3.3.3",
+            "xtend": "4.0.1"
+          }
         }
       }
     },
@@ -1211,19 +1256,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
-    },
-    "websocket-stream": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.1.1.tgz",
-      "integrity": "sha512-ypQ50zVCnikSvJcRFWaZh7xeCufSje5+mbJRq3mdvdNx+06TD98C+bQsSKc7FkI6y1PVuNbzkenGywxlFiQeUQ==",
-      "requires": {
-        "duplexify": "3.5.3",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "safe-buffer": "5.1.1",
-        "ws": "3.3.3",
-        "xtend": "4.0.1"
-      }
     },
     "which": {
       "version": "1.3.0",

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -10,7 +10,7 @@
     "azure-iot-common": "1.7.1",
     "debug": "^3.1.0",
     "machina": "^2.0.1",
-    "mqtt": "^2.15.2"
+    "mqtt": "^2.18.3"
   },
   "devDependencies": {
     "@types/node": "^8.0.28",
@@ -31,7 +31,7 @@
     "alltest": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 93 --branches 81 --functions 83 --lines 95"
+    "check-cover": "istanbul check-coverage --statements 93 --branches 81 --functions 85 --lines 95"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/mqtt/test/_fake_mqtt.js
+++ b/common/transport/mqtt/test/_fake_mqtt.js
@@ -28,13 +28,7 @@ var FakeMqtt = function() {
     return this;
   });
 
-  this.subscribe = sinon.stub().callsFake(function(topicName, param, done) {
-    if (this.subscribeShouldFail) {
-      done (new Error('Not authorized'));
-    } else {
-      done(null, 'fake_object');
-    }
-  });
+  this.subscribe = sinon.stub().callsArgWith(2, null, 'fake_object');
 
   this.unsubscribe = sinon.stub().callsFake(function(topicName, done) {
     done();


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#307 

# Description of the problem
Because we call `mqttClient.removeAllListeners` before we call `mqttClient.end()` there is a possibility for an error to be emitted while/after the call to end() has finished, which leads to unhandled error exceptions.

# Description of the solution
The solution is in multiple parts:
- we need to keep listening to errors until we know no error can be emitted anymore, which means when the socket has been closed: which materializes itself with a `close` event which we don't monitor once we're connected: so we need to start handling this
- because we are leaving events "attached" to an `mqttClient` that we are disconnecting, there is a possibility, if there is a bug in the MQTT library, that the `close` event is never called and we end up with a leak or worse: that we reconnect successfully with a new mqttClient but that the old client emits an event after that: because of that we need to separate the event handlers fired after we call end() from the event handlers called while the mqttClient is actively monitored by the FSM.