### PR TITLE
Update /lib -> /src

### DIFF
--- a/service/readme.md
+++ b/service/readme.md
@@ -63,7 +63,7 @@ Service SDK subfolders:
 
 Development requirements documentation
 
-### /lib
+### /src
 
 Code for the library
 


### PR DESCRIPTION
/lib folder name no longer exists.

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!
Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
Previous description had /lib as a folder but it is now /src in the structure.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Update /lib to /src
