### PR TITLE
Enable e2e tests for modules over MQTT

### DIFF
--- a/e2etests/test/module_messaging.js
+++ b/e2etests/test/module_messaging.js
@@ -10,10 +10,10 @@ var assert = require('chai').assert;
 var debug = require('debug')('e2etests:module-messaging');
 var Amqp = require('azure-iot-device-amqp').Amqp;
 var AmqpWs = require('azure-iot-device-amqp').AmqpWs;
-//var Mqtt = require('azure-iot-device-mqtt').Mqtt;
-//var MqttWs = require('azure-iot-device-mqtt').MqttWs;
+var Mqtt = require('azure-iot-device-mqtt').Mqtt;
+var MqttWs = require('azure-iot-device-mqtt').MqttWs;
 
-var transportsToTest = [ Amqp, AmqpWs ];
+var transportsToTest = [ Amqp, AmqpWs, Mqtt, MqttWs ];
 
 describe('module messaging', function() {
   this.timeout(46000);
@@ -53,7 +53,7 @@ describe('module messaging', function() {
           } else {
             debug('adding handler for \'message\' event on ehReceiver');
             ehReceiver.on('message', function(msg) {
-              if (msg.properties.to === '/devices/' + testModule.deviceId + '/modules/' + testModule.moduleId + '/messages/events') {
+              if (msg.annotations['iothub-connection-device-id'] === testModule.deviceId && msg.annotations['iothub-connection-module-id'] === testModule.moduleId) {
                 assert.strictEqual(msg.body.toString('ascii'), testOutputText);
                 done();
               }

--- a/e2etests/test/module_methods.js
+++ b/e2etests/test/module_methods.js
@@ -8,10 +8,10 @@ var assert = require('chai').assert;
 var debug = require('debug')('e2etests:module-methods');
 var Amqp = require('azure-iot-device-amqp').Amqp;
 var AmqpWs = require('azure-iot-device-amqp').AmqpWs;
-//var Mqtt = require('azure-iot-device-mqtt').Mqtt;
-//var MqttWs = require('azure-iot-device-mqtt').MqttWs;
+var Mqtt = require('azure-iot-device-mqtt').Mqtt;
+var MqttWs = require('azure-iot-device-mqtt').MqttWs;
 
-var transportsToTest = [ Amqp, AmqpWs ];
+var transportsToTest = [ Amqp, AmqpWs, Mqtt, MqttWs ];
 
 describe('module methods', function() {
   this.timeout(46000);

--- a/e2etests/test/module_twin.js
+++ b/e2etests/test/module_twin.js
@@ -8,10 +8,10 @@ var assert = require('chai').assert;
 var debug = require('debug')('e2etests:module-twin');
 var Amqp = require('azure-iot-device-amqp').Amqp;
 var AmqpWs = require('azure-iot-device-amqp').AmqpWs;
-//var Mqtt = require('azure-iot-device-mqtt').Mqtt;
-//var MqttWs = require('azure-iot-device-mqtt').MqttWs;
+var Mqtt = require('azure-iot-device-mqtt').Mqtt;
+var MqttWs = require('azure-iot-device-mqtt').MqttWs;
 
-var transportsToTest = [ Amqp, AmqpWs ];
+var transportsToTest = [ Amqp, AmqpWs, Mqtt, MqttWs ];
 
 describe('module twin', function() {
   this.timeout(46000);
@@ -62,11 +62,14 @@ describe('module twin', function() {
             debug('no match.  Continuing to wait.  Looking for ' + props.fake_key + ' got ' + patch.properties.desired.fake_key);
           }
         });
-        debug('sending desired properties');
-        testModule.serviceTwin.update(patch, function(err) {
-          debug('twin.update returned ' + (err ? err : 'success'));
-          assert(!err);
-        });
+
+        setTimeout(function () {
+          debug('sending desired properties');
+          testModule.serviceTwin.update(patch, function(err) {
+            debug('twin.update returned ' + (err ? err : 'success'));
+            assert(!err);
+          });
+        }, 3000);
       });
 
       it('can send reported properties', function(done) {


### PR DESCRIPTION
# Description of the problem
Some modules features were only tested over AMQP - adding MQTT for completeness.

# Description of the solution
Found a couple of things in the tests:
1. the way the originated device/module was discriminated was using an AMQP-specific property, switched it to message annotations
2. in MQTT the subscription for twin events sometimes took longer and tests were hitting a race condition. introduced a small timeout to counteract this (not a great solution so we'll see how stable this is over time: it's a test framework issue though, not an SDK API issue)
