### PR TITLE
update package-lock.json to fix problem in canary verification on vsts

### DIFF
--- a/edge-e2e/wrapper/nodejs-server-server/package-lock.json
+++ b/edge-e2e/wrapper/nodejs-server-server/package-lock.json
@@ -1,6 +1,8 @@
 {
-	"requires": true,
+	"name": "iot-sdk-device-client-rest-api",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"ajv": {
 			"version": "5.5.2",
@@ -25,14 +27,6 @@
 				"lodash": "^4.17.2",
 				"node-int64": "^0.4.0",
 				"stately.js": "^1.3.0"
-			}
-		},
-		"amqp10-transport-ws": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/amqp10-transport-ws/-/amqp10-transport-ws-0.0.5.tgz",
-			"integrity": "sha1-sPgnwkrU4YFSi8uy3s63H0oTKZk=",
-			"requires": {
-				"nodejs-websocket": "^1.7.0"
 			}
 		},
 		"append-field": {
@@ -111,70 +105,50 @@
 			}
 		},
 		"azure-iot-amqp-base": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-amqp-base/-/azure-iot-amqp-base-1.7.1.tgz",
-			"integrity": "sha512-bVGsuDmThBEoYwUbnDkiEmwrWBYJJoN2tTP7Vx38gluvy5QUp5TWywDgtWBMcHDb0Nf4OWADMDfcgZ2TH6bMYg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/azure-iot-amqp-base/-/azure-iot-amqp-base-2.0.0.tgz",
+			"integrity": "sha512-/3jtEDHiWp0CzrFJdcCs8CJ6vMt/YQZVKZ4s0NCNwBE+MBs2L3/8jr1ke0S3NuDTxAu1HpAoaaB4hnDRY4hM8w==",
 			"requires": {
-				"amqp10": "^3.6.0",
-				"amqp10-transport-ws": "^0.0.5",
 				"async": "^2.5.0",
-				"azure-iot-common": "1.7.1",
-				"bluebird": "^3.5.0",
+				"azure-iot-common": "1.7.4",
 				"debug": "^3.0.1",
 				"lodash.merge": "^4.6.1",
 				"machina": "^2.0.1",
-				"uuid": "^3.0.1"
+				"rhea": "^0.2.18",
+				"uuid": "^3.0.1",
+				"ws": "^6.0.0"
 			},
 			"dependencies": {
-				"amqp10": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/amqp10/-/amqp10-3.6.0.tgz",
-					"integrity": "sha512-o8Agnjuf4ve+aT1IExkTLeL5/rAqxvL4gqDkO06AfRlL9SRSklMMMzKqmPsVjcV5ySOVEQqyFUOAhI3wm3KT1A==",
+				"debug": {
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"bl": "^1.1.2",
-						"bluebird": "^3.4.6",
-						"buffer-builder": "^0.2.0",
-						"debug": "^2.3.3",
-						"lodash": "^4.17.2",
-						"node-int64": "^0.4.0",
-						"stately.js": "^1.3.0"
-					},
-					"dependencies": {
-						"debug": {
-							"version": "2.6.9",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-							"requires": {
-								"ms": "2.0.0"
-							}
-						}
+						"ms": "^2.1.1"
 					}
 				},
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-common": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-common/-/azure-iot-common-1.7.1.tgz",
-			"integrity": "sha512-qpUnGCAB5F7RsS6QQp/SXX5OUx59L4wY4cHnJrfa8e8Wwv6S+Kewe3l1OZvuIx36jQnOnclwJy2Dyyhw5na/hA==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-common/-/azure-iot-common-1.7.4.tgz",
+			"integrity": "sha512-1Covd+yxjsjlm1Glj/is7CDwgQeISnvGi11RiPoYVkMl4tJSrLdbT1DfMp4HMP0Ek1cnsYTvdyGNHpPsWVfdJQ==",
 			"requires": {
 				"getos": "^3.1.0"
 			}
 		},
 		"azure-iot-device": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-device/-/azure-iot-device-1.7.1.tgz",
-			"integrity": "sha512-XWe00ojLi7PmFhgKIQn/zIS2BQSBId12lo9Tm4bTaO69MR5AsCXc+TJzFFUeVhEuP9L8KOaItZvIoo0FSDYV0g==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-device/-/azure-iot-device-1.7.4.tgz",
+			"integrity": "sha512-lG+/s5Odnj8sK/UcxKGHRtq6ViZAoVLZw9MK/l6lwXMaJZhe1K8QOHwW1zYosW/tvPqP8WRGFMaX81/XhewmGg==",
 			"requires": {
-				"azure-iot-common": "1.7.1",
-				"azure-iot-http-base": "1.7.1",
+				"azure-iot-common": "1.7.4",
+				"azure-iot-http-base": "1.7.4",
 				"azure-storage": "^2.8.1",
 				"debug": "^3.1.0",
 				"lodash": "^4.17.10",
@@ -183,146 +157,183 @@
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-device-amqp": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-device-amqp/-/azure-iot-device-amqp-1.7.1.tgz",
-			"integrity": "sha512-1e+QL+lvgaR8qBrv2BrsS4lvtigaw9noqF6D4SfZda8IWWkTQo0riBMZeRylR78JigFJNNxOOX5q75vm2bj/NA==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-device-amqp/-/azure-iot-device-amqp-1.7.4.tgz",
+			"integrity": "sha512-JrYHsNPXiGi++2nKVm/S0ksVVFSFjcX7INrrMP8/jfCuwl9HR817hhMBpd+osAg7X3r6vQv5q5a+l77cLBkxjQ==",
 			"requires": {
 				"async": "^2.5.0",
-				"azure-iot-amqp-base": "1.7.1",
-				"azure-iot-common": "1.7.1",
-				"azure-iot-device": "1.7.1",
-				"debug": "^3.0.1",
+				"azure-iot-amqp-base": "2.0.0",
+				"azure-iot-common": "1.7.4",
+				"azure-iot-device": "1.7.4",
+				"debug": "^3.1.0",
 				"machina": "^2.0.1",
+				"rhea": "^0.2.18",
 				"uuid": "^3.0.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-device-http": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-device-http/-/azure-iot-device-http-1.7.1.tgz",
-			"integrity": "sha512-ijU+QafBkwTPF7Rb8mQqxegbuopRJeZcWiFnmK2qc5+Tck43U1FVnzi+6gIfHLo5O7P4Soxk6x8CAIrKAqLrfA==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-device-http/-/azure-iot-device-http-1.7.4.tgz",
+			"integrity": "sha512-J39MN7gqiQ2hik+vj5YFYtJkPIwzaCWp3/9ZA1t6dlgxr6rcFFLu/yJICAuv7i7Vl9PkfIbIg8h0+Ko/Oaabjg==",
 			"requires": {
-				"azure-iot-common": "1.7.1",
-				"azure-iot-device": "1.7.1",
-				"azure-iot-http-base": "1.7.1",
+				"azure-iot-common": "1.7.4",
+				"azure-iot-device": "1.7.4",
+				"azure-iot-http-base": "1.7.4",
 				"debug": "^3.1.0",
 				"node-crontab": "^0.0.8"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-device-mqtt": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-device-mqtt/-/azure-iot-device-mqtt-1.7.1.tgz",
-			"integrity": "sha512-iok6XzPpMlpt7imu1/Jk1PAlpcWA/v6IyiIHQBd+HLygctUXjJaNzXbNFEWuJMpNRQpXz8nwWK/UB8I5qjfpPw==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-device-mqtt/-/azure-iot-device-mqtt-1.7.4.tgz",
+			"integrity": "sha512-70W6iuqMv4WX2fhkE5kV0QdZMpH0Dk1vYfnOsh0ZJbJdvaJWY86JLLTiSDbOpo0NWrL1OWVUa/PMyL8273I3Fg==",
 			"requires": {
-				"azure-iot-common": "1.7.1",
-				"azure-iot-device": "1.7.1",
-				"azure-iot-mqtt-base": "1.7.1",
+				"azure-iot-common": "1.7.4",
+				"azure-iot-device": "1.7.4",
+				"azure-iot-mqtt-base": "1.7.4",
 				"debug": "^3.0.1",
 				"machina": "^2.0.1",
 				"uuid": "^3.0.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-http-base": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-http-base/-/azure-iot-http-base-1.7.1.tgz",
-			"integrity": "sha512-g/LYmq4FytUyfBcEVLQpi0nwtwgYbrv6WqUXVjx4c+WjletIGXb9LqyDJ0ZWZW3zDt2NeWYxPYJL8B5tr18VBA==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-http-base/-/azure-iot-http-base-1.7.4.tgz",
+			"integrity": "sha512-uBILyrmaQr7Ef8SZF6r6TvzKTdm2DV/XSYRxxXZp8HegVgnv8aVwfFxfirk9Q5Cgs5WjUtVwKAAbnspjFm+K6A==",
 			"requires": {
-				"azure-iot-common": "1.7.1",
+				"azure-iot-common": "1.7.4",
 				"debug": "^3.1.0",
 				"uuid": "^3.2.1"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iot-mqtt-base": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iot-mqtt-base/-/azure-iot-mqtt-base-1.7.1.tgz",
-			"integrity": "sha512-kqr8dRebvTnquyTNPXiOT9eNv1/plHX+W2QKHeukXe4oBua4CUi6LCiBjAjlaOaQ6JbUAFvlWPcHwc6kSLsykg==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iot-mqtt-base/-/azure-iot-mqtt-base-1.7.4.tgz",
+			"integrity": "sha512-9qsdvClB9n7qKYBISusS/sv+O15bFHGIhBlFRTIfz3zD8+kYAheP3PtvGHpK9zlVqChAWDXFg7/G0GTxKYNA4Q==",
 			"requires": {
-				"azure-iot-common": "1.7.1",
+				"azure-iot-common": "1.7.4",
 				"debug": "^3.1.0",
 				"machina": "^2.0.1",
 				"mqtt": "^2.15.2"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
 		"azure-iothub": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/azure-iothub/-/azure-iothub-1.7.1.tgz",
-			"integrity": "sha512-290cRwnNsZ8YoAMxp0sv7GtuYVmkUi8CZOBC/fhD0DfgxSOhTiRhBEP34Isa3ut1RPvUIF/rcrv451bFUfasHA==",
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/azure-iothub/-/azure-iothub-1.7.4.tgz",
+			"integrity": "sha512-nBKfekCjEfDBZR0u7mTIQhmT6RHVCZrr5vTB4MtZtxNRiAjTS3mbkdLlHIoY9ehPSI2kf4bBbH8eE0ZufZp96A==",
 			"requires": {
 				"async": "^2.6.1",
-				"azure-iot-amqp-base": "1.7.1",
-				"azure-iot-common": "1.7.1",
-				"azure-iot-http-base": "1.7.1",
+				"azure-iot-amqp-base": "2.0.0",
+				"azure-iot-common": "1.7.4",
+				"azure-iot-http-base": "1.7.4",
 				"debug": "^3.1.0",
 				"lodash": "^4.17.10",
-				"machina": "^2.0.1"
+				"machina": "^2.0.1",
+				"rhea": "^0.2.17"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"version": "3.2.5",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+					"integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
 				}
 			}
 		},
@@ -356,7 +367,7 @@
 				},
 				"readable-stream": {
 					"version": "2.0.6",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
 					"integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
 					"requires": {
 						"core-util-is": "~1.0.0",
@@ -374,7 +385,7 @@
 				},
 				"validator": {
 					"version": "9.4.1",
-					"resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+					"resolved": "http://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
 					"integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
 				}
 			}
@@ -531,10 +542,27 @@
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
+		"cli": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+			"dev": true,
+			"requires": {
+				"exit": "0.1.2",
+				"glob": "^7.1.1"
+			}
+		},
 		"co": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
 			"integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+		},
+		"colors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"dev": true,
+			"optional": true
 		},
 		"combined-stream": {
 			"version": "1.0.6",
@@ -560,7 +588,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -597,6 +625,15 @@
 				"utils-merge": "1.0.1"
 			}
 		},
+		"console-browserify": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+			"dev": true,
+			"requires": {
+				"date-now": "^0.1.4"
+			}
+		},
 		"content-type": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
@@ -622,6 +659,13 @@
 			"resolved": "https://registry.npmjs.org/crypto/-/crypto-0.0.3.tgz",
 			"integrity": "sha1-RwqBuGvkxe4XrMggeh9TFa4g27A="
 		},
+		"cycle": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+			"dev": true,
+			"optional": true
+		},
 		"d": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
@@ -637,6 +681,12 @@
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
+		},
+		"date-now": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+			"integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+			"dev": true
 		},
 		"debug": {
 			"version": "2.6.9",
@@ -693,6 +743,55 @@
 				}
 			}
 		},
+		"dom-serializer": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "~1.1.1",
+				"entities": "~1.1.1"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+					"integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+					"dev": true
+				},
+				"entities": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+					"integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+					"dev": true
+				}
+			}
+		},
+		"domelementtype": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+			"integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+			"dev": true
+		},
+		"domhandler": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1"
+			}
+		},
+		"domutils": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+			"dev": true,
+			"requires": {
+				"dom-serializer": "0",
+				"domelementtype": "1"
+			}
+		},
 		"duplexify": {
 			"version": "3.6.0",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
@@ -732,6 +831,12 @@
 				"once": "^1.4.0"
 			}
 		},
+		"entities": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+			"dev": true
+		},
 		"es5-ext": {
 			"version": "0.10.46",
 			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
@@ -764,6 +869,13 @@
 				"es6-symbol": "~3.1.1",
 				"event-emitter": "~0.3.5"
 			}
+		},
+		"es6-promise": {
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+			"integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
+			"dev": true,
+			"optional": true
 		},
 		"es6-set": {
 			"version": "0.1.5",
@@ -810,15 +922,41 @@
 				"es5-ext": "~0.10.14"
 			}
 		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
+		"extract-zip": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"concat-stream": "1.6.2",
+				"debug": "2.6.9",
+				"mkdirp": "0.5.1",
+				"yauzl": "2.4.1"
+			}
+		},
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"eyes": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+			"dev": true,
+			"optional": true
 		},
 		"fast-deep-equal": {
 			"version": "1.1.0",
@@ -829,6 +967,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
 			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+		},
+		"fd-slicer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"pend": "~1.2.0"
+			}
 		},
 		"finalhandler": {
 			"version": "1.1.0",
@@ -869,6 +1017,18 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
 			"integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
 		},
+		"fs-extra": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.2",
+				"jsonfile": "^2.1.0",
+				"klaw": "^1.0.0"
+			}
+		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -901,9 +1061,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -939,6 +1099,13 @@
 				"unique-stream": "^2.0.2"
 			}
 		},
+		"graceful-fs": {
+			"version": "4.1.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+			"integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+			"dev": true,
+			"optional": true
+		},
 		"graphlib": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.5.tgz",
@@ -970,6 +1137,17 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"hasha": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+			"integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"is-stream": "^1.0.1",
+				"pinkie-promise": "^2.0.0"
+			}
+		},
 		"help-me": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/help-me/-/help-me-1.1.0.tgz",
@@ -979,6 +1157,45 @@
 				"glob-stream": "^6.1.0",
 				"through2": "^2.0.1",
 				"xtend": "^4.0.0"
+			}
+		},
+		"htmlparser2": {
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+			"dev": true,
+			"requires": {
+				"domelementtype": "1",
+				"domhandler": "2.3",
+				"domutils": "1.5",
+				"entities": "1.0",
+				"readable-stream": "1.1"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"dev": true,
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+					"dev": true
+				}
 			}
 		},
 		"http-errors": {
@@ -1068,6 +1285,13 @@
 				"is-unc-path": "^1.0.0"
 			}
 		},
+		"is-stream": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true,
+			"optional": true
+		},
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -1091,6 +1315,13 @@
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
+		"isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+			"dev": true,
+			"optional": true
+		},
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -1110,6 +1341,25 @@
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"optional": true
+		},
+		"jshint": {
+			"version": "2.9.6",
+			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.6.tgz",
+			"integrity": "sha512-KO9SIAKTlJQOM4lE64GQUtGBRpTOuvbrRrSZw3AhUxMNG266nX9hK2cKA4SBhXOj0irJGyNyGSLT62HGOVDEOA==",
+			"dev": true,
+			"requires": {
+				"cli": "~1.0.0",
+				"console-browserify": "1.1.x",
+				"exit": "0.1.x",
+				"htmlparser2": "3.8.x",
+				"lodash": "~4.17.10",
+				"minimatch": "~3.0.2",
+				"phantom": "~4.0.1",
+				"phantomjs-prebuilt": "~2.1.7",
+				"shelljs": "0.3.x",
+				"strip-json-comments": "1.0.x",
+				"unicode-5.2.0": "^0.7.5"
+			}
 		},
 		"json-edm-parser": {
 			"version": "0.1.2",
@@ -1156,6 +1406,16 @@
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
+		"jsonfile": {
+			"version": "2.4.0",
+			"resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -1175,6 +1435,23 @@
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
+			}
+		},
+		"kew": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+			"integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s=",
+			"dev": true,
+			"optional": true
+		},
+		"klaw": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"graceful-fs": "^4.1.9"
 			}
 		},
 		"leven": {
@@ -1441,7 +1718,7 @@
 			"dependencies": {
 				"lodash": {
 					"version": "3.10.1",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+					"resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
 					"integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
 				}
 			}
@@ -1505,9 +1782,9 @@
 			}
 		},
 		"mqtt": {
-			"version": "2.18.7",
-			"resolved": "https://registry.npmjs.org/mqtt/-/mqtt-2.18.7.tgz",
-			"integrity": "sha512-P5VB4/AVM7Brcs1iA144ZfQFfJLYPPzNoACZ4vr56hGcRMqi530ysZH+HINm40QKV07G/BQqdfRy4QrwpRs17g==",
+			"version": "2.18.8",
+			"resolved": "https://registry.npmjs.org/mqtt/-/mqtt-2.18.8.tgz",
+			"integrity": "sha512-3h6oHlPY/yWwtC2J3geraYRtVVoRM6wdI+uchF4nvSSafXPZnaKqF8xnX+S22SU/FcgEAgockVIlOaAX3fkMpA==",
 			"requires": {
 				"commist": "^1.0.0",
 				"concat-stream": "^1.6.2",
@@ -1527,7 +1804,7 @@
 			"dependencies": {
 				"minimist": {
 					"version": "1.2.0",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
@@ -1585,11 +1862,6 @@
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
 			"integrity": "sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs="
-		},
-		"nodejs-websocket": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/nodejs-websocket/-/nodejs-websocket-1.7.1.tgz",
-			"integrity": "sha1-zM+7qCO/HPqWgPFoq3q1MSHkhBA="
 		},
 		"oauth-sign": {
 			"version": "0.9.0",
@@ -1696,15 +1968,76 @@
 				}
 			}
 		},
+		"pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+			"dev": true,
+			"optional": true
+		},
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
+		"phantom": {
+			"version": "4.0.12",
+			"resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+			"integrity": "sha512-Tz82XhtPmwCk1FFPmecy7yRGZG2btpzY2KI9fcoPT7zT9det0CcMyfBFPp1S8DqzsnQnm8ZYEfdy528mwVtksA==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"phantomjs-prebuilt": "^2.1.16",
+				"split": "^1.0.1",
+				"winston": "^2.4.0"
+			}
+		},
+		"phantomjs-prebuilt": {
+			"version": "2.1.16",
+			"resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+			"integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"es6-promise": "^4.0.3",
+				"extract-zip": "^1.6.5",
+				"fs-extra": "^1.0.0",
+				"hasha": "^2.2.0",
+				"kew": "^0.7.0",
+				"progress": "^1.1.8",
+				"request": "^2.81.0",
+				"request-progress": "^2.0.1",
+				"which": "^1.2.10"
+			}
+		},
+		"pinkie": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+			"integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+			"dev": true,
+			"optional": true
+		},
+		"pinkie-promise": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"pinkie": "^2.0.0"
+			}
+		},
 		"process-nextick-args": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+		},
+		"progress": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+			"dev": true,
+			"optional": true
 		},
 		"psl": {
 			"version": "1.1.29",
@@ -1835,6 +2168,24 @@
 				}
 			}
 		},
+		"request-progress": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+			"integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"throttleit": "^1.0.0"
+			}
+		},
+		"rhea": {
+			"version": "0.2.20",
+			"resolved": "https://registry.npmjs.org/rhea/-/rhea-0.2.20.tgz",
+			"integrity": "sha512-BQUUsPfNwJCoAwJ9xr6a8Ci9VCgLTs7CN09P3WAA0TNQPeLms5SbAXMcFIHKQGo64tUCR8i+iFnPGEei3UTBgg==",
+			"requires": {
+				"debug": ">=0.8.0"
+			}
+		},
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1847,7 +2198,7 @@
 		},
 		"sax": {
 			"version": "0.5.8",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+			"resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
 			"integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
 		},
 		"send": {
@@ -1903,6 +2254,12 @@
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
 			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
 		},
+		"shelljs": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+			"integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+			"dev": true
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -1912,6 +2269,16 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-1.0.1.tgz",
 			"integrity": "sha1-xLmo1Bz3sIRUI6ghgk+N/6D1G3w="
+		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"through": "2"
+			}
 		},
 		"split2": {
 			"version": "2.2.0",
@@ -1941,6 +2308,13 @@
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
 			}
+		},
+		"stack-trace": {
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"dev": true,
+			"optional": true
 		},
 		"stately.js": {
 			"version": "1.3.0",
@@ -1974,6 +2348,12 @@
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
+		},
+		"strip-json-comments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+			"integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+			"dev": true
 		},
 		"superagent": {
 			"version": "1.8.5",
@@ -2096,6 +2476,20 @@
 				}
 			}
 		},
+		"throttleit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+			"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+			"dev": true,
+			"optional": true
+		},
+		"through": {
+			"version": "2.3.8",
+			"resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+			"dev": true,
+			"optional": true
+		},
 		"through2": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -2187,6 +2581,12 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
 			"integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
 		},
+		"unicode-5.2.0": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/unicode-5.2.0/-/unicode-5.2.0-0.7.5.tgz",
+			"integrity": "sha512-KVGLW1Bri30x00yv4HNM8kBxoqFXr0Sbo55735nvrlsx4PYBZol3UtoWgO492fSwmsetzPEZzy73rbU8OGXJcA==",
+			"dev": true
+		},
 		"unique-stream": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
@@ -2250,6 +2650,52 @@
 				"safe-buffer": "^5.1.1",
 				"ws": "^3.2.0",
 				"xtend": "^4.0.0"
+			},
+			"dependencies": {
+				"ws": {
+					"version": "3.3.3",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+					"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+					"requires": {
+						"async-limiter": "~1.0.0",
+						"safe-buffer": "~5.1.0",
+						"ultron": "~1.1.0"
+					}
+				}
+			}
+		},
+		"which": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"isexe": "^2.0.0"
+			}
+		},
+		"winston": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+			"integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"async": "~1.0.0",
+				"colors": "1.0.x",
+				"cycle": "1.0.x",
+				"eyes": "0.1.x",
+				"isstream": "0.1.x",
+				"stack-trace": "0.0.x"
+			},
+			"dependencies": {
+				"async": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+					"dev": true,
+					"optional": true
+				}
 			}
 		},
 		"wrappy": {
@@ -2258,13 +2704,11 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"ws": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-			"integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
+			"integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
 			"requires": {
-				"async-limiter": "~1.0.0",
-				"safe-buffer": "~5.1.0",
-				"ultron": "~1.1.0"
+				"async-limiter": "~1.0.0"
 			}
 		},
 		"xml2js": {
@@ -2284,6 +2728,16 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
 			"integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+		},
+		"yauzl": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"dev": true,
+			"optional": true,
+			"requires": {
+				"fd-slicer": "~1.0.1"
+			}
 		},
 		"z-schema": {
 			"version": "3.23.0",


### PR DESCRIPTION
Hesh was seeing a verification failure in a step with the name "canary" in it, but it had nothing to do with canary.  The package-lock.json for edge E2E tests was missing jshint, so I'm hoping that a package-lock.json update will fix this.  