### PR TITLE
(doc) Update developer setup to include windows-build-tools on windows.

### DIFF
--- a/doc/node-devbox-setup.md
+++ b/doc/node-devbox-setup.md
@@ -25,7 +25,15 @@ The SDK is entirely open-source (as you probably figured out already if you're r
 $ git clone https://github.com/azure/azure-iot-sdk-node
 ```
 
-The SDK ships in a few separate NPM packages that depend on each other. Once the repository has been cloned, some features span accross multiple packages so in order to build and test these features, we need to "link" those package together in a single environment. We use the awesome [lerna.js](https://lernajs.io) to do that, so you have to install this first.
+If you are going to be developing on Windows you will need to install some additional build tools.  In an administrator command prompt:
+
+```
+npm install -g windows-build-tools
+```
+
+This will probably take serveral minutes to run.
+
+The SDK ships in a few separate NPM packages that depend on each other. Once the repository has been cloned, some features span across multiple packages so in order to build and test these features, we need to "link" those package together in a single environment. We use the awesome [lerna.js](https://lernajs.io) to do that, so you have to install this first.  At a prompt with administrative privileges:
 
 ```
 npm install -g lerna


### PR DESCRIPTION
<!--
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->
The developer doc did not mention the necessity of installing the windows-build-tools package on a Windows system.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->

Add instructions to do so.
