### PR TITLE
fix: Remove sync calls in async setOptions.

### DIFF
--- a/device/core/devdoc/internal_client_requirements.md
+++ b/device/core/devdoc/internal_client_requirements.md
@@ -79,7 +79,7 @@ The `sendEventBatch` method sends a list of event messages to the IoT Hub as the
 
 **SRS_NODE_INTERNAL_CLIENT_16_044: [** The `done` callback shall be invoked with a standard javascript `Error` object and no result object if the client could not be configured as requested. **]**
 
-**SRS_NODE_INTERNAL_CLIENT_06_001: [** The `setOptions` method shall first test if the `ca` property is the name of an already existent file.  If so, it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string. **]**
+**SRS_NODE_INTERNAL_CLIENT_06_001: [** The `setOptions` method shall assume the `ca` property is the name of an already existent file and it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string. **]**
 
 #### complete(message, completeCallback)
 

--- a/device/core/src/internal_client.ts
+++ b/device/core/src/internal_client.ts
@@ -206,27 +206,24 @@ export abstract class InternalClient extends EventEmitter {
   setOptions(options: DeviceClientOptions, done?: (err?: Error, result?: results.TransportConfigured) => void): void {
     /*Codes_SRS_NODE_INTERNAL_CLIENT_16_042: [The `setOptions` method shall throw a `ReferenceError` if the options object is falsy.]*/
     if (!options) throw new ReferenceError('options cannot be falsy.');
-    let localOptions: DeviceClientOptions = {};
-    for (let k in options) {
-      localOptions[k] = options[k];
-    }
 
-    /*Codes_SRS_NODE_INTERNAL_CLIENT_06_001: [The `setOptions` method shall first test if the `ca` property is the name of an already existent file.  If so, it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string.] */
-    if (localOptions.ca) {
-      if (fs.existsSync(localOptions.ca)) {
-        localOptions.ca = fs.readFileSync(localOptions.ca, 'utf8');
-      }
+    /*Codes_SRS_NODE_INTERNAL_CLIENT_06_001: [The `setOptions` method shall assume the `ca` property is the name of an already existent file and it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string.] */
+    if (options.ca) {
+      fs.readFile(options.ca, 'utf8', (err, contents) => {
+        if (!err) {
+          let localOptions: DeviceClientOptions = {};
+          for (let k in options) {
+            localOptions[k] = options[k];
+          }
+          localOptions.ca = contents;
+          this._invokeSetOptions(localOptions, done);
+        } else {
+          this._invokeSetOptions(options, done);
+        }
+      });
+    } else {
+      this._invokeSetOptions(options, done);
     }
-
-    // Making this an operation that can be retried because we cannot assume the transport's behavior (whether it's going to disconnect/reconnect, etc).
-    const retryOp = new RetryOperation(this._retryPolicy, this._maxOperationTimeout);
-    retryOp.retry((opCallback) => {
-      this._transport.setOptions(localOptions, opCallback);
-    }, (err) => {
-      /*Codes_SRS_NODE_INTERNAL_CLIENT_16_043: [The `done` callback shall be invoked no parameters when it has successfully finished setting the client and/or transport options.]*/
-      /*Codes_SRS_NODE_INTERNAL_CLIENT_16_044: [The `done` callback shall be invoked with a standard javascript `Error` object and no result object if the client could not be configured as requested.]*/
-      safeCallback(done, err);
-    });
   }
 
   complete(message: Message, completeCallback: (err?: Error, result?: results.MessageCompleted) => void): void {
@@ -312,6 +309,19 @@ export abstract class InternalClient extends EventEmitter {
       }
     });
   }
+
+  private _invokeSetOptions(options: DeviceClientOptions, done?: (err?: Error, result?: results.TransportConfigured) => void): void {
+    // Making this an operation that can be retried because we cannot assume the transport's behavior (whether it's going to disconnect/reconnect, etc).
+    const retryOp = new RetryOperation(this._retryPolicy, this._maxOperationTimeout);
+    retryOp.retry((opCallback) => {
+      this._transport.setOptions(options, opCallback);
+    }, (err) => {
+      /*Codes_SRS_NODE_INTERNAL_CLIENT_16_043: [The `done` callback shall be invoked no parameters when it has successfully finished setting the client and/or transport options.]*/
+      /*Codes_SRS_NODE_INTERNAL_CLIENT_16_044: [The `done` callback shall be invoked with a standard javascript `Error` object and no result object if the client could not be configured as requested.]*/
+      safeCallback(done, err);
+    });
+  }
+
 
   private _validateDeviceMethodInputs(methodName: string, callback: (request: DeviceMethodRequest, response: DeviceMethodResponse) => void): void {
     // Codes_SRS_NODE_INTERNAL_CLIENT_13_020: [ onDeviceMethod shall throw a ReferenceError if methodName is falsy. ]

--- a/device/core/test/_internal_client_test.js
+++ b/device/core/test/_internal_client_test.js
@@ -172,31 +172,35 @@ var ModuleClient = require('../lib/module_client').ModuleClient;
         fs.unlinkSync('aziotfakepemfile');
       });
 
-      /*Tests_SRS_NODE_INTERNAL_CLIENT_06_001: [The `setOption` method shall first test if the `ca` property is the name of an already existent file.  If so, it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string.] */
+      /*Tests_SRS_NODE_INTERNAL_CLIENT_06_001: [The `setOptions` method shall assume the `ca` property is the name of an already existent file and it will attempt to read that file as a pem into a string value and pass the string to config object `ca` property.  Otherwise, it is assumed to be a pem string.] */
       it('sets CA cert with contents of file if provided', function (testCallback) {
         var fakeBaseClient = new FakeTransport();
-        fakeBaseClient.setOptions = sinon.stub();
+        fakeBaseClient.setOptions = sinon.stub().callsArg(1);
         var fakeMethodClient = {}
         fakeMethodClient.setOptions = sinon.stub();
         var client = new ClientCtor(fakeBaseClient);
         client._methodClient = fakeMethodClient;
-        client.setOptions({ ca: 'aziotfakepemfile' });
-        assert(fakeBaseClient.setOptions.called);
-        assert.strictEqual(fakeBaseClient.setOptions.firstCall.args[0].ca, 'ca cert');
-        testCallback();
+        client.setOptions({ ca: 'aziotfakepemfile' }, function(err) {
+          assert.isNotOk(err, 'the setOptions passed')
+          assert(fakeBaseClient.setOptions.called);
+          assert.strictEqual(fakeBaseClient.setOptions.firstCall.args[0].ca, 'ca cert');
+          testCallback();
+        });
       });
 
       it('sets CA cert with contents of provided string', function (testCallback) {
         var fakeBaseClient = new FakeTransport();
-        fakeBaseClient.setOptions = sinon.stub();
+        fakeBaseClient.setOptions = sinon.stub().callsArg(1);
         var fakeMethodClient = {}
         fakeMethodClient.setOptions = sinon.stub();
         var client = new ClientCtor(fakeBaseClient);
         client._methodClient = fakeMethodClient;
-        client.setOptions({ ca: 'ca cert' });
-        assert(fakeBaseClient.setOptions.called);
-        assert.strictEqual(fakeBaseClient.setOptions.firstCall.args[0].ca, 'ca cert');
-        testCallback();
+        client.setOptions({ ca: 'ca cert' }, function(err) {
+          assert.isNotOk(err, 'the setOptions passed')
+          assert(fakeBaseClient.setOptions.called);
+          assert.strictEqual(fakeBaseClient.setOptions.firstCall.args[0].ca, 'ca cert');
+          testCallback();
+        });
       });
     });
 


### PR DESCRIPTION
<!--
# Description of the problem
There was a call to a sync function in the async setOptions.
# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
Replace the call to the sync functions with a simple call the async readfile.  Note that the existence check was completely dropped on the recommendation of the  fs.stat documentation.