### PR TITLE
(fix) Pin @types/node to 8.9.4 to work around a breakage.

### DIFF
--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@types/async": "^2.0.42",
     "@types/lodash.merge": "^4.6.3",
-    "@types/node": "^8.0.28",
+    "@types/node": "8.9.4",
     "chai": "^4.1.2",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",

--- a/common/transport/mqtt/package.json
+++ b/common/transport/mqtt/package.json
@@ -13,7 +13,7 @@
     "mqtt": "^2.15.2"
   },
   "devDependencies": {
-    "@types/node": "^8.0.28",
+    "@types/node": "8.9.4",
     "chai": "^4.1.2",
     "es5-shim": "^4.5.9",
     "istanbul": "^0.4.5",

--- a/device/core/package.json
+++ b/device/core/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/debug": "0.0.30",
-    "@types/node": "^8.0.37",
+    "@types/node": "8.9.4",
     "@types/traverse": "^0.6.29",
     "chai": "^4.1.2",
     "es5-shim": "^4.5.9",

--- a/device/transport/amqp/package.json
+++ b/device/transport/amqp/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/debug": "0.0.30",
-    "@types/node": "^8.0.28",
+    "@types/node": "8.9.4",
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "nyc": "^12.0.2",

--- a/device/transport/http/package.json
+++ b/device/transport/http/package.json
@@ -14,13 +14,13 @@
     "node-crontab": "^0.0.8"
   },
   "devDependencies": {
-    "@types/node": "^8.0.45",
+    "@types/node": "8.9.4",
     "azure-iothub": "1.7.4",
     "chai": "^4.1.2",
-    "nyc": "^12.0.2",
-    "source-map-support": "^0.5.8",
     "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
     "sinon": "^4.0.2",
+    "source-map-support": "^0.5.8",
     "tslint": "^5.1.0",
     "typescript": "2.5.3"
   },

--- a/device/transport/mqtt/package.json
+++ b/device/transport/mqtt/package.json
@@ -16,13 +16,13 @@
   },
   "devDependencies": {
     "@types/mqtt": "0.0.34",
-    "@types/node": "^8.0.30",
+    "@types/node": "8.9.4",
     "chai": "^4.1.2",
     "es5-shim": "^4.5.9",
-    "nyc": "^12.0.2",
-    "source-map-support": "^0.5.8",
     "mocha": "^5.2.0",
+    "nyc": "^12.0.2",
     "sinon": "^4.0.2",
+    "source-map-support": "^0.5.8",
     "tslint": "^5.1.0",
     "typescript": "2.5.2"
   },

--- a/provisioning/transport/amqp/package.json
+++ b/provisioning/transport/amqp/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/bluebird": "ts2.2",
-    "@types/node": "^8.0.55",
+    "@types/node": "8.9.4",
     "chai": "^4.1.2",
     "istanbul": "^0.4.4",
     "mocha": "^5.2.0",


### PR DESCRIPTION
An incompatibility occurred in the most currently distributed node types module. 
We force those modules where this showed up version 8.9.4.
This gets them back on their feet.