### PR TITLE
Increase module method test delay

### DIFF
--- a/e2etests/test/device_method.js
+++ b/e2etests/test/device_method.js
@@ -136,7 +136,8 @@ var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
         var methodParams = {
           methodName: methodName,
           payload: testPayload,
-          timeoutInSeconds: 10
+          connectTimeoutInSeconds: 30,
+          responseTimeoutInSeconds: 45
         };
         debug('service sending method call:');
         debug(JSON.stringify(methodParams, null, 2));

--- a/e2etests/test/eventhub_receiver_helper.js
+++ b/e2etests/test/eventhub_receiver_helper.js
@@ -19,12 +19,14 @@ EventHubReceiverHelper.prototype.openClient = function(done) {
   var self = this;
   this.ehClient = eventHubClient.fromConnectionString(hubConnectionString);
   this.ehReceivers = [];
+  // account for potential delays and clock skews
+  var startTime = Date.now() - 5000;
 
   this.ehClient.open()
       .then(self.ehClient.getPartitionIds.bind(self.ehClient))
       .then(function (partitionIds) {
         return partitionIds.map(function (partitionId) {
-          return self.ehClient.createReceiver('$Default', partitionId,{ 'startAfterTime' : Date.now()}).then(function(receiver) {
+          return self.ehClient.createReceiver('$Default', partitionId,{ 'startAfterTime' : startTime }).then(function(receiver) {
             self.ehReceivers.push(receiver);
             receiver.on('errorReceived', function(err) {
               self.emit(err);

--- a/e2etests/test/module_messaging.js
+++ b/e2etests/test/module_messaging.js
@@ -16,7 +16,7 @@ var MqttWs = require('azure-iot-device-mqtt').MqttWs;
 var transportsToTest = [ Amqp, AmqpWs, Mqtt, MqttWs ];
 
 describe('module messaging', function() {
-  this.timeout(46000);
+  this.timeout(60000);
 
   transportsToTest.forEach(function(Transport) {
     describe('using ' + Transport.name, function() {

--- a/e2etests/test/module_methods.js
+++ b/e2etests/test/module_methods.js
@@ -48,7 +48,8 @@ describe('module methods', function() {
         var methodParams = {
           methodName: methodName,
           payload: requestPayload,
-          responseTimeoutInSeconds: 15
+          connectTimeoutInSeconds: 30,
+          responseTimeoutInSeconds: 45
         };
 
         debug('adding method handler for ' + methodName);

--- a/e2etests/test/module_twin.js
+++ b/e2etests/test/module_twin.js
@@ -14,7 +14,7 @@ var MqttWs = require('azure-iot-device-mqtt').MqttWs;
 var transportsToTest = [ Amqp, AmqpWs, Mqtt, MqttWs ];
 
 describe('module twin', function() {
-  this.timeout(46000);
+  this.timeout(60000);
 
   transportsToTest.forEach(function(Transport) {
     describe('using ' + Transport.name, function() {
@@ -69,7 +69,7 @@ describe('module twin', function() {
             debug('twin.update returned ' + (err ? err : 'success'));
             assert(!err);
           });
-        }, 3000);
+        }, 10000);
       });
 
       it('can send reported properties', function(done) {


### PR DESCRIPTION
Module methods tests are throwing not-found errors. increasing the delay to account for some service side delays.