### PR TITLE
Fix some language/naming issues reported by Policheck

### DIFF
--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -1,6 +1,6 @@
 # Client requirements (Device client)
 
-The `Client` class is the historical client object that is used by devices to connect to IoT Hub and Edge Hub. Modules use the `ModuleClient` class.
+The `Client` class is the historical client object that is used by devices to connect to Azure IoT Hub and Azure IoT Edge. Modules use the `ModuleClient` class.
 
 ## Overview
 

--- a/device/core/devdoc/module_client_requirements.md
+++ b/device/core/devdoc/module_client_requirements.md
@@ -1,6 +1,6 @@
 # ModuleClient requirements
 
-The `ModuleClient` class is used to connect modules to Azure IoT Hub and Azure Edge hub. Devices use the `Client` class.
+The `ModuleClient` class is used to connect modules to Azure IoT Hub and Azure IoT Edge. Devices use the `Client` class.
 
 ## Overview
 

--- a/device/core/devdoc/modules_events_and_messages_design.md
+++ b/device/core/devdoc/modules_events_and_messages_design.md
@@ -81,7 +81,7 @@ Additionally, some of the iothub-ness of the MQTT transport (such as username cr
 To support modules, we update the MqttBase TransportConfig to remove the coincidental overlap and make the conversion of hub configuration to mqtt configuration explicit.
 
 Specific justifications:
-1. The old notion of `host` is broken because it was used to create both the URI and the username.  For Edge, the GateWayHostName is used to construct the URI and the hostname in the connection string is used to build the username.  Building the URI and userId belong in upper layers, so I moved it there.
+1. The old notion of `host` is broken because it was used to create both the URI and the username.  For Azure IoT Edge, the GateWayHostName is used to construct the URI and the hostname in the connection string is used to build the username.  Building the URI and userId belong in upper layers, so I moved it there.
 2. The old notion of `deviceId` is broken.  It was previously used as the MQTT clientId.  For Modules, the clientId is "deviceId/moduleId", so I made the field name explicit.
 3. The optional `username` field was a hack for DPS, but MQTT base would still construct the userName based on IotHub rules.  Since userName is different for device/module connections, I just moved all this logic up to the device transport.
 4. The `uri` field needed to be created at an upper level because of #1.  This also allows a cleaner MqttWs implementation.

--- a/device/edge-sample/readme.md
+++ b/device/edge-sample/readme.md
@@ -1,4 +1,4 @@
-# Microsoft Azure IoT SDK for Node.js Edge module sample
+# Azure IoT Edge: node.js module sample
 
 This folder contains a set of Dockerfiles which can be used to crate an Azure IoT Edge module using node.js which can be deployed and run inside of an Azure IoT Edge environment
 

--- a/device/samples/edge_downstream_device.js
+++ b/device/samples/edge_downstream_device.js
@@ -13,7 +13,7 @@ var Message = require('azure-iot-device').Message;
 
 // 1) Obtain the connection string for your downstream device and to it
 //    append this string GatewayHostName=<edge device hostname>;
-// 2) The edge device hostname is the hostname set in the config.yaml of the Edge device
+// 2) The Azure IoT Edge device hostname is the hostname set in the config.yaml of the Azure IoT Edge device
 //    to which this sample will connect to.
 //
 // The resulting string should look like the following

--- a/e2etests/test/device_method.js
+++ b/e2etests/test/device_method.js
@@ -84,7 +84,7 @@ var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
       });
     });
 
-    // nuke the test device after every test
+    // delete the test device identity after every test
     afterEach(function (done) {
       if (!!deviceClient) {
         debug('disconnecting device client...');

--- a/readme-modules.md
+++ b/readme-modules.md
@@ -1,6 +1,6 @@
 # Microsoft Azure IoT SDK for Node.js modules-preview branch for Microsoft Edge modules.
 
-This branch of the Azure IoT SDK for Node.js contains code to use the Mqtt protocol to act as a Microsoft Azure Edge module and talk to a Microsoft Azure Edge hub instance.
+This branch of the Azure IoT SDK for Node.js contains code to use the Mqtt protocol to act as a Microsoft Azure IoT Edge module and talk to a Microsoft Azure IoT Edge hub instance.
 
 ## Important note
 This code is not currently published on NPM.  In order to use these modules, you need to use the versions in this branch.  Instructions for working with this code outside of the NPM repository can be found [here](./doc/node-devbox-setup.md)


### PR DESCRIPTION
Fix Edge naming as well as the use of the word "nuke"