### PR TITLE
Allow SharedAccessSignature in connection string

### DIFF
--- a/common/core/src/connection_string.ts
+++ b/common/core/src/connection_string.ts
@@ -48,6 +48,12 @@ export class ConnectionString {
   // tslint:disable-next-line:variable-name
   GatewayHostName?: string;
   /**
+   * A shared access signature which encapsulates "device connect" permissions on an IoT hub.
+   * @memberof {azure-iot-common.ConnectionString}
+   */
+  // tslint:disable-next-line:variable-name
+  SharedAccessSignature?: string;
+  /**
    * This property exists only if a device uses x509 certificates for authentication and if it exists, will be set to True.
    * @memberof {azure-iot-common.ConnectionString}
    */

--- a/device/core/devdoc/connection_string_requirement.md
+++ b/device/core/devdoc/connection_string_requirement.md
@@ -29,7 +29,13 @@ The `parse` static method returns a new instance of the `ConnectionString` objec
 
 **SRS_NODE_DEVICE_CONNSTR_05_002: [** It shall throw `ArgumentError` if any of `HostName` or `DeviceId` fields are not found in the source argument.**]**
 
-**SRS_NODE_DEVICE_CONNSTR_16_001: [** It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time or if none of them are present. **]**
+**SRS_NODE_DEVICE_CONNSTR_16_001: [** It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time. **]**
+
+**SRS_NODE_DEVICE_CONNSTR_16_006: [** It shall throw `ArgumentError` if `SharedAccessSignature` and `x509` are present at the same time. **]**
+
+**SRS_NODE_DEVICE_CONNSTR_16_007: [** It shall throw `ArgumentError` if `SharedAccessKey` and `SharedAccessSignature` are present at the same time. **]**
+
+**SRS_NODE_DEVICE_CONNSTR_16_008: [** It shall throw `ArgumentError` if none of `SharedAccessKey`, `SharedAccessSignature` and `x509` are present. **]**
 
 ### createWithSharedAccessKey(hostName, deviceId, sharedAccessKey) [static]
 

--- a/device/core/devdoc/device_client_requirements.md
+++ b/device/core/devdoc/device_client_requirements.md
@@ -27,6 +27,8 @@ class Client extends InternalClient {
 
 **SRS_NODE_DEVICE_CLIENT_16_093: [** The `fromConnectionString` method shall create a new `X509AuthorizationProvider` object with the connection string passed as argument if it contains an X509 parameter and pass this object to the transport constructor. **]**
 
+**SRS_NODE_DEVICE_CLIENT_16_094: [** The `fromConnectionString` method shall create a new `SharedAccessSignatureAuthenticationProvider` object with the connection string passed as argument if it contains a SharedAccessSignature parameter and pass this object to the transport constructor. **]**
+
 ### fromSharedAccessSignature
 
 **SRS_NODE_DEVICE_CLIENT_16_029: [** The `fromSharedAccessSignature` method shall throw a `ReferenceError` if the sharedAccessSignature argument is falsy. **]**

--- a/device/core/src/connection_string.ts
+++ b/device/core/src/connection_string.ts
@@ -17,9 +17,18 @@ export function parse(source: string): ConnectionString {
   /*Codes_SRS_NODE_DEVICE_CONNSTR_05_001: [The parse method shall return the result of calling azure-iot-common.ConnectionString.parse.]*/
   /*Codes_SRS_NODE_DEVICE_CONNSTR_05_002: [It shall throw ArgumentError if any of 'HostName' or 'DeviceId' fields are not found in the source argument.]*/
   const connectionString = ConnectionString.parse(source, ['HostName', 'DeviceId']);
-  /*Codes_SRS_NODE_DEVICE_CONNSTR_16_001: [It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time or if none of them are present.]*/
-  if ((connectionString.SharedAccessKey && connectionString.x509) || (!connectionString.SharedAccessKey && !connectionString.x509)) {
+  /*Codes_SRS_NODE_DEVICE_CONNSTR_16_001: [It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time.]*/
+  /*Codes_SRS_NODE_DEVICE_CONNSTR_16_006: [It shall throw `ArgumentError` if `SharedAccessKey` and `SharedAccessSignature` are present at the same time.]*/
+  /*Codes_SRS_NODE_DEVICE_CONNSTR_16_007: [It shall throw `ArgumentError` if `SharedAccessSignature` and `x509` are present at the same time.]*/
+  /*Codes_SRS_NODE_DEVICE_CONNSTR_16_008: [It shall throw `ArgumentError` if none of `SharedAccessKey`, `SharedAccessSignature` and `x509` are present.]*/
+  if (connectionString.SharedAccessKey && connectionString.x509) {
     throw new errors.ArgumentError('The connection string must contain either a SharedAccessKey or x509=true');
+  } else if (connectionString.SharedAccessKey && connectionString.SharedAccessSignature) {
+    throw new errors.ArgumentError('The connection string must contain either a SharedAccessKey or SharedAccessSignature');
+  } else if (connectionString.SharedAccessSignature && connectionString.x509) {
+    throw new errors.ArgumentError('The connection string must contain either a SharedAccessSignature or x509=true');
+  } else if ((!connectionString.SharedAccessKey && !connectionString.SharedAccessSignature && !connectionString.x509)) {
+    throw new errors.ArgumentError('The connection string must contain either a SharedAccessKey, SharedAccessSignature or x509=true');
   }
 
   return connectionString;

--- a/device/core/src/device_client.ts
+++ b/device/core/src/device_client.ts
@@ -197,6 +197,9 @@ export class Client extends InternalClient {
 
     if (cn.SharedAccessKey) {
       authenticationProvider = SharedAccessKeyAuthenticationProvider.fromConnectionString(connStr);
+    } else if (cn.SharedAccessSignature) {
+      /*Codes_SRS_NODE_DEVICE_CLIENT_16_094: [The `fromConnectionString` method shall create a new `SharedAccessSignatureAuthenticationProvider` object with the connection string passed as argument if it contains a SharedAccessSignature parameter and pass this object to the transport constructor.]*/
+      authenticationProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(cn.SharedAccessSignature);
     } else {
       /*Codes_SRS_NODE_DEVICE_CLIENT_16_093: [The `fromConnectionString` method shall create a new `X509AuthorizationProvider` object with the connection string passed as argument if it contains an X509 parameter and pass this object to the transport constructor.]*/
       authenticationProvider = new X509AuthenticationProvider({

--- a/device/core/test/_connection_string_test.js
+++ b/device/core/test/_connection_string_test.js
@@ -14,7 +14,9 @@ var incompleteConnectionStrings = {
 
 var invalidConnectionStrings = {
   BothSharedAccessKeyAndx509:'DeviceId=id;HostName=name;SharedAccessKey=key;x509=true',
-  NeitherSharedAccessKeyNorx509: 'DeviceId=id;HostName=name'
+  BothSharedAccessKeyAndSharedAccessSignature:'DeviceId=id;HostName=name;SharedAccessKey=key;SharedAccessSignature=key',
+  BothSharedAccessSignatureAndx509:'DeviceId=id;HostName=name;SharedAccessSignature=key;x509=true',
+  NeitherSharedAccessKeyNorSharedAccessSignatureNorx509: 'DeviceId=id;HostName=name'
 };
 
 describe('ConnectionString', function () {
@@ -35,8 +37,11 @@ describe('ConnectionString', function () {
       }, ArgumentError);
     });
 
-    /*Codes_SRS_NODE_DEVICE_CONNSTR_16_001: [It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time or if none of them are present.]*/
-    ['BothSharedAccessKeyAndx509', 'NeitherSharedAccessKeyNorx509'].forEach(function(key) {
+    /*Tests_SRS_NODE_DEVICE_CONNSTR_16_001: [It shall throw `ArgumentError` if `SharedAccessKey` and `x509` are present at the same time.]*/
+    /*Tests_SRS_NODE_DEVICE_CONNSTR_16_006: [It shall throw `ArgumentError` if `SharedAccessSignature` and `x509` are present at the same time.]*/
+    /*Tests_SRS_NODE_DEVICE_CONNSTR_16_007: [It shall throw `ArgumentError` if `SharedAccessKey` and `SharedAccessSignature` are present at the same time.]*/
+    /*Tests_SRS_NODE_DEVICE_CONNSTR_16_008: [It shall throw `ArgumentError` if none of `SharedAccessKey`, `SharedAccessSignature` and `x509` are present.]*/
+    ['BothSharedAccessKeyAndx509', 'BothSharedAccessKeyAndSharedAccessSignature', 'BothSharedAccessSignatureAndx509', 'NeitherSharedAccessKeyNorx509'].forEach(function(key) {
       it('throws if the connection string is invalid because ' + key, function() {
         assert.throws(function() {
           ConnectionString.parse(invalidConnectionStrings[key]);

--- a/device/core/test/_device_client_test.js
+++ b/device/core/test/_device_client_test.js
@@ -13,6 +13,7 @@ var Message = require('azure-iot-common').Message;
 var errors = require('azure-iot-common').errors;
 var results = require('azure-iot-common').results;
 var X509AuthenticationProvider = require('../lib/x509_authentication_provider').X509AuthenticationProvider;
+var SharedAccessSignatureAuthenticationProvider = require('../lib/sas_authentication_provider').SharedAccessSignatureAuthenticationProvider;
 var Client = require('../lib/device_client').Client;
 
 describe('Device Client', function () {
@@ -57,6 +58,15 @@ describe('Device Client', function () {
       var x509ConnectionString = 'HostName=host;DeviceId=id;x509=true';
       Client.fromConnectionString(x509ConnectionString, function (authProvider) {
         assert.instanceOf(authProvider, X509AuthenticationProvider);
+        testCallback();
+      });
+    });
+
+    /*Tests_SRS_NODE_DEVICE_CLIENT_16_094: [The `fromConnectionString` method shall create a new `SharedAccessSignatureAuthenticationProvider` object with the connection string passed as argument if it contains a SharedAccessSignature parameter and pass this object to the transport constructor.]*/
+    it('creates a SharedAccessSignatureAuthenticationProvider and passes it to the transport', function (testCallback) {
+      var SharedAccessSignatureConnectionString = 'HostName=host;DeviceId=id;SharedAccessSignature=' + sharedAccessSignature;
+      Client.fromConnectionString(SharedAccessSignatureConnectionString, function (authProvider) {
+        assert.instanceOf(authProvider, SharedAccessSignatureAuthenticationProvider);
         testCallback();
       });
     });


### PR DESCRIPTION
.NET and Java SDK allows to specify SharedAccessSignature in the device connection string, while the Node SDK has a different method to connect a device with a SAS token.

Description of the solution
Added parsing of SharedAccessSignature so that device Client.fromConnectionString handles connection string in the format HostName=<your_hub_name>.azure-devices.net;DeviceId=<your_device_id>;SharedAccessSignature=SharedAccessSignature sr=<your_hub_name>.azure-devices.net%2Fdevices%2F1&sig=pe9UaBjPDrBX7q8z5%2F1I1Ll8CGYyDhKljSCKVem9Qcc%3D&se=1508715695