### PR TITLE
(update) add the file_upload tests to the slow phase.

### DIFF
--- a/e2etests/package.json
+++ b/e2etests/package.json
@@ -59,7 +59,7 @@
     "flaky_tests": "npm-run-all -p -l  job_client method_disconnect d2c_disconnect twin_disconnect server_validation",
     "phase0_modules": "npm-run-all -p -l module_crud module_messaging module_twin module_methods configurations",
     "phase1_fast": "npm-run-all -p -l service registry device_acknowledge_tests upload_disconnect authentication",
-    "phase2_slow": "npm-run-all -p -l device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect",
+    "phase2_slow": "npm-run-all -p -l file_upload device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect",
     "alltest": "npm run  phase0_modules && npm run phase1_fast && npm run phase2_slow",
     "e2e": "npm -s run lint && npm -s run alltest",
     "test": "npm -s run lint && npm -s run alltest"


### PR DESCRIPTION
The file_upload tests really should be part of the normal e2e test run.