### PR TITLE
Fix(#459) azure-iothub.Client.invokeDeviceMethod TS signature

### DIFF
--- a/service/src/client.ts
+++ b/service/src/client.ts
@@ -249,8 +249,8 @@ export class Client extends EventEmitter {
    * @throws {ReferenceError}  If one of the required parameters is null, undefined or empty.
    * @throws {TypeError}       If one of the parameters is of the wrong type.
    */
-  invokeDeviceMethod(deviceId: string, methodParams: DeviceMethodParams, done?: IncomingMessageCallback<any>): void;
-  invokeDeviceMethod(deviceId: string, moduleId: string, methodParams: DeviceMethodParams, done?: IncomingMessageCallback<any>): void;
+  invokeDeviceMethod(deviceId: string, methodParams: DeviceMethodParams, done: IncomingMessageCallback<any>): void;
+  invokeDeviceMethod(deviceId: string, moduleId: string, methodParams: DeviceMethodParams, done: IncomingMessageCallback<any>): void;
   invokeDeviceMethod(deviceId: string, methodParams: DeviceMethodParams): Promise<ResultWithIncomingMessage<any>>;
   invokeDeviceMethod(deviceId: string, moduleId: string, methodParams: DeviceMethodParams): Promise<ResultWithIncomingMessage<any>>;
   invokeDeviceMethod(deviceId: string, moduleIdOrMethodParams: string | DeviceMethodParams, methodParamsOrDone?: DeviceMethodParams | IncomingMessageCallback<any>, done?: IncomingMessageCallback<any>): Promise<ResultWithIncomingMessage<any>> | void {


### PR DESCRIPTION
# Reference/Link to the issue solved with this PR (if any)
#459 

# Description of the problem
The Promise-based overload isn't detected because of the optional nature of the callback in the other signature. this leads to compile-time error for typescript users.

# Description of the solution
Make the callback mandatory in callback-based signatures