### PR TITLE
Stabilize method_disconnect end-to-end tests

### DIFF
--- a/e2etests/test/method_disconnect.js
+++ b/e2etests/test/method_disconnect.js
@@ -147,14 +147,14 @@ protocolAndTermination.forEach( function (testConfiguration) {
     var methodResult = 200;
 
     var setMethodHandler = function(methodName, testPayload) {
-      debug('---------- new method test ------------');
+      debug('Setting up new method handler for: ' + methodName);
       // setup device to handle the method call
       deviceClient.onDeviceMethod(methodName, function(request, response) {
         // validate request
         assert.isNotNull(request);
         assert.strictEqual(request.methodName, methodName);
         assert.deepEqual(request.payload, testPayload);
-        debug('device: received method request');
+        debug('device: received method request: ' + request.methodName);
         debug(JSON.stringify(request, null, 2));
         // validate response
         assert.isNotNull(response);
@@ -171,30 +171,27 @@ protocolAndTermination.forEach( function (testConfiguration) {
     };
 
     var sendMethodCall = function(serviceClient, methodName, testPayload, sendMethodCallback) {
-      setTimeout(function() {
-        // make the method call via the service
         var methodParams = {
           methodName: methodName,
           payload: testPayload,
           connectTimeoutInSeconds: 10,
           responseTimeoutInSeconds: 10
         };
-        debug('service sending method call:');
+        debug('service invoking method: ' + methodName + ' with payload:');
         debug(JSON.stringify(methodParams, null, 2));
         serviceClient.invokeDeviceMethod(
-                provisionedDevice.deviceId,
-                methodParams,
-                function(err, result) {
-                  if(!err) {
-                    debug('got method results');
-                    debug(JSON.stringify(result, null, 2));
-                    assert.strictEqual(result.status, methodResult);
-                    assert.deepEqual(result.payload, testPayload);
-                  }
-                  debug('---------- end method test ------------');
-                  sendMethodCallback(err);
-                });
-      }, 1000);
+          provisionedDevice.deviceId,
+          methodParams,
+          function(err, result) {
+            if(!err) {
+              debug('got method results');
+              debug(JSON.stringify(result, null, 2));
+              assert.strictEqual(result.status, methodResult);
+              assert.deepEqual(result.payload, testPayload);
+            }
+            debug('---------- end method test ------------');
+            sendMethodCallback(err);
+          });
     };
 
     doConnectTest(testConfiguration.testEnabled)('Service sends a method, iothub client receives it, and' + testConfiguration.closeReason + 'which is noted by the device', function (testCallback) {
@@ -211,20 +208,35 @@ protocolAndTermination.forEach( function (testConfiguration) {
       };
       deviceClient.on('disconnect', disconnectHandler);
       var firstPayload = { k1: uuid.v4() };
-      setMethodHandler(methodName1, firstPayload);
-      sendMethodCall(serviceClient, methodName1, firstPayload, function(err) {
-        if (!err) {
-          debug('got result from first method invocation.  Having the client send the kill');
-          firstMethodSent = true;
-          var terminateMessage = new Message('');
-          terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
-          terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
-          terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
-          deviceClient.sendEvent(terminateMessage, function (sendErr) {
-            debug('at the callback for the fault injection send, err is:' + sendErr);
-          });
-        } else {
+      deviceClient.open(function (err) {
+        if (err) {
+          debug('error connecting the device client: ' + err.toString());
           testCallback(err);
+        } else {
+          debug('setting up method handler for ' + methodName1);
+          setMethodHandler(methodName1, firstPayload);
+          debug('waiting 2 seconds before invoking ' + methodName1);
+          setTimeout(function () {
+            sendMethodCall(serviceClient, methodName1, firstPayload, function(err) {
+              if (!err) {
+                debug('got result from first method invocation.  Having the client inject the fault');
+                firstMethodSent = true;
+                var terminateMessage = new Message('');
+                terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
+                terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
+                terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
+                deviceClient.sendEvent(terminateMessage, function (sendErr) {
+                  debug('at the callback for the fault injection');
+                  if (sendErr) {
+                    debug('Fault injection error is: ' + sendErr.toString());
+                  }
+                });
+              } else {
+                debug('invocation of ' + methodName1 + ' failed with error: ' + err.toString());
+                testCallback(err);
+              }
+            });
+          }, 2000);
         }
       });
     });
@@ -234,6 +246,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
         testCallback(new Error('unexpected disconnect'));
       });
       var secondMethodSend = function() {
+        debug('invoking ' + methodName2);
         sendMethodCall(serviceClient, methodName2, payload2, function(err) {
           debug('got result from second method invocation.');
           testCallback(err);
@@ -241,21 +254,40 @@ protocolAndTermination.forEach( function (testConfiguration) {
       };
       var payload1 = { k1: uuid.v4() };
       var payload2 = { k1: uuid.v4() };
-      setMethodHandler(methodName1, payload1);
-      setMethodHandler(methodName2, payload2);
-      sendMethodCall(serviceClient, methodName1, payload1, function(err) {
-        if (!err) {
-          debug('got result from first method invocation.  Having the client send the kill');
-          var terminateMessage = new Message('');
-          terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
-          terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
-          terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
-          deviceClient.sendEvent(terminateMessage, function (sendErr) {
-            debug('at the callback for the fault injection send, err is:' + sendErr);
-            secondMethodTimeout = setTimeout(secondMethodSend.bind(this), (testConfiguration.delayInSeconds + 2)*1000);
-          });
-        } else {
+      debug('connecting device client');
+      deviceClient.open(function (err) {
+        if (err) {
+          debug('error when opening the device client: ' + err.toString());
           testCallback(err);
+        } else {
+          debug('setting method handlers');
+          setMethodHandler(methodName1, payload1);
+          setMethodHandler(methodName2, payload2);
+          debug('waiting 5 seconds for subscription before calling first method');
+          setTimeout(function () {
+            debug('calling method1');
+            sendMethodCall(serviceClient, methodName1, payload1, function(err) {
+              if (!err) {
+                debug('got result from first method invocation.  Having the client send the kill');
+                var terminateMessage = new Message('');
+                terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
+                terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
+                terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
+                deviceClient.sendEvent(terminateMessage, function (sendErr) {
+                  debug('at the callback for the fault injection send');
+                  if (sendErr) {
+                    debug('received an error while injecting the fault: ' + sendErr.toString());
+                  }
+                  var delayBeforeSecondMethod = (testConfiguration.delayInSeconds + 5) * 1000;
+                  debug('waiting ' + delayBeforeSecondMethod + ' milliseconds before invoking: ' + methodName2);
+                  secondMethodTimeout = setTimeout(secondMethodSend.bind(this), delayBeforeSecondMethod);
+                });
+              } else {
+                debug('failed to invoke: ' + methodName1 + ' with error: ' + err.toString());
+                testCallback(err);
+              }
+            });
+          }, 5000);
         }
       });
     });


### PR DESCRIPTION
- add logs
- add timeouts
- manually open device client

I've had pretty good success with this (passed 90 times in a row, with logging enabled and disabled)