### PR TITLE
Stabilize twin_disconnect tests

### DIFF
--- a/e2etests/package.json
+++ b/e2etests/package.json
@@ -57,10 +57,10 @@
     "module_messaging": "mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reports.json test/module_messaging.js",
     "module_twin": "mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reports.json test/module_twin.js",
     "module_methods": "mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reports.json test/module_methods.js",
-    "flaky_tests": "npm-run-all -p -l job_client twin_disconnect server_validation",
+    "flaky_tests": "npm-run-all -p -l job_client server_validation",
     "phase0_modules": "npm-run-all -p -l module_crud module_messaging module_twin module_methods configurations",
     "phase1_fast": "npm-run-all -p -l service registry device_acknowledge_tests upload_disconnect authentication",
-    "phase2_slow": "npm-run-all -p -l file_upload device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect method_disconnect d2c_disconnect",
+    "phase2_slow": "npm-run-all -p -l file_upload device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect method_disconnect d2c_disconnect twin_disconnect",
     "alltest": "npm run  phase0_modules && npm run phase1_fast && npm run phase2_slow",
     "e2e": "npm -s run lint && npm -s run alltest",
     "test": "npm -s run lint && npm -s run alltest"

--- a/e2etests/test/device_identity_helper.js
+++ b/e2etests/test/device_identity_helper.js
@@ -11,7 +11,6 @@ var uuid = require('uuid');
 
 var pem = require('pem');
 var Registry = require('azure-iothub').Registry;
-var chalk = require('chalk');
 
 var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
@@ -24,9 +23,10 @@ var host = ConnectionString.parse(hubConnectionString).HostName;
 function setupDevice(deviceDescription, provisionDescription, done) {
   registry.create(deviceDescription, function (err) {
     if (err) {
-      console.log(chalk.red('Device was NOT successfully created: ') + deviceDescription.deviceId);
+      debug('Failed to create device identity: ' + deviceDescription.deviceId + ' : ' + err.toString());
       done(err);
     } else {
+      debug('Device created: ' + deviceDescription.deviceId);
       done(null, provisionDescription);
     }
   });
@@ -161,41 +161,23 @@ function createSASDevice(deviceId, done) {
   );
 }
 
-function createDeviceSafe(deviceId, createDevice, callback) {
-  registry.get(deviceId, function(err) {
-    if (!err || err.constructor.name !== 'DeviceNotFoundError') {
-      var errMessageText = 'error creating e2e test device ' + deviceId + ' ' + (err ? err.constructor.name : 'device already exists');
-      console.log(chalk.red(errMessageText));
-    } else {
-      createDevice(deviceId, function(err, deviceInfo){
-        if (err) {
-          console.log(chalk.red('Could not create certificates or device: ' + err.message));
-          callback(err);
-        } else {
-          callback(null, deviceInfo);
-        }
-      });
-    }
-  });
-}
-
 function deleteDevice(deviceId, callback) {
   registry.delete(deviceId, callback);
 }
 
 module.exports = {
   createDeviceWithX509SelfSignedCert: function (callback) {
-    createDeviceSafe('0000e2etest-delete-me-node-x509-' + uuid.v4(), createCertDevice, callback);
+    createCertDevice('0000e2etest-delete-me-node-x509-' + uuid.v4(), callback);
   },
   createDeviceWithSymmetricKey: function (callback) {
-    createDeviceSafe('0000e2etest-delete-me-node-key-' + uuid.v4(), createKeyDevice, callback);
+    createKeyDevice('0000e2etest-delete-me-node-key-' + uuid.v4(), callback);
   },
   createDeviceWithSas: function (callback) {
-    createDeviceSafe('0000e2etest-delete-me-node-sas-' + uuid.v4(), createSASDevice, callback);
+    createSASDevice('0000e2etest-delete-me-node-sas-' + uuid.v4(), callback);
   },
   createDeviceWithX509CASignedCert: function (callback) {
     // max number of letters for this is
-    createDeviceSafe('00e2e-del-me-node-CACert-' + uuid.v4(), createCACertDevice, callback);
+    createCACertDevice('00e2e-del-me-node-CACert-' + uuid.v4(), callback);
   },
   deleteDevice: deleteDevice
 };

--- a/e2etests/test/device_identity_helper.js
+++ b/e2etests/test/device_identity_helper.js
@@ -8,6 +8,7 @@ var deviceSas = require('azure-iot-device').SharedAccessSignature;
 var anHourFromNow = require('azure-iot-common').anHourFromNow;
 
 var uuid = require('uuid');
+var debug = require('debug')('e2etests:DeviceIdentityHelper');
 
 var pem = require('pem');
 var Registry = require('azure-iothub').Registry;


### PR DESCRIPTION
- Add Rendezvous logic
- Use DeviceIdentityHelper instead of custom code
- Change test to use a test property instead of versions and reuse devices

Ran 90 times with no problem. Will be squashed before it's merged.