### PR TITLE
d2c_disconnect -> fast phase (avoid event hubs cg overload)

### DIFF
--- a/e2etests/package.json
+++ b/e2etests/package.json
@@ -59,8 +59,8 @@
     "module_methods": "mocha --reporter mocha-multi-reporters --reporter-options configFile=../mocha-reports.json test/module_methods.js",
     "flaky_tests": "npm-run-all -p -l job_client server_validation",
     "phase0_modules": "npm-run-all -p -l module_crud module_messaging module_twin module_methods configurations",
-    "phase1_fast": "npm-run-all -p -l service registry device_acknowledge_tests upload_disconnect authentication",
-    "phase2_slow": "npm-run-all -p -l file_upload device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect method_disconnect d2c_disconnect twin_disconnect",
+    "phase1_fast": "npm-run-all -p -l service registry device_acknowledge_tests upload_disconnect authentication d2c_disconnect",
+    "phase2_slow": "npm-run-all -p -l file_upload device_method twin_e2e_tests sas_token_tests device_service empty_messages c2d_disconnect method_disconnect twin_disconnect",
     "alltest": "npm run  phase0_modules && npm run phase1_fast && npm run phase2_slow",
     "e2e": "npm -s run lint && npm -s run alltest",
     "test": "npm -s run lint && npm -s run alltest"


### PR DESCRIPTION
too many test suites in the slow phase use the event hubs SDK leading to too many readers in the same consumer group. 
moving d2c_disconnect tests to the fast phase to revert this condition