### PR TITLE
pipeline build def for running e2e in the gate

### DIFF
--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -1,0 +1,20 @@
+variables:
+  Horton.FrameworkRoot: $(Agent.BuildDirectory)/e2e-fx
+  Horton.FrameworkRef: refs/tags/node-gate-2
+  Horton.Language: node
+  Horton.Repo: Azure/azure-iot-sdk-node
+  Horton.Commit: $(Build.SourceBranch)
+  Horton.ForcedImage: ''
+
+resources:
+  repositories:
+  - repository: e2e_fx
+    type: github
+    name: Azure/iot-sdks-e2e-fx
+    ref: refs/tags/node-gate-2
+    endpoint: 'e2e-fx-github-access'
+
+jobs:
+- template: vsts/templates/jobs-build-ci.yaml@e2e_fx
+
+  


### PR DESCRIPTION
This is all we need to run Horton e2e jobs in the gate.  There is an e2e-fx tag in this yaml file (unfortinately, twice) which defines what version of the Horton scripts to use.