### PR TITLE
Fix arg parsing in provisioning query sample

### DIFF
--- a/provisioning/service/samples/query.js
+++ b/provisioning/service/samples/query.js
@@ -6,8 +6,8 @@
 var provisioningServiceClient = require('azure-iot-provisioning-service').ProvisioningServiceClient;
 
 var argv = require('yargs')
-  .usage('Usage: $0 --connectionstring <DEVICE PROVISIONING CONNECTION STRING> ')
-  .option('connectionstring', {
+  .usage('Usage: $0 --connectionString <DEVICE PROVISIONING CONNECTION STRING> ')
+  .option('connectionString', {
     alias: 'c',
     describe: 'The connection string for the Device Provisioning instance',
     type: 'string',


### PR DESCRIPTION
# Description of the problem
yargs is case sensitive and our options were not declared properly

# Description of the solution
fixed the typos in the options declaration.