### PR TITLE
style(comment): add missing invokeDeviceMethod object key params

### DIFF
--- a/service/src/client.ts
+++ b/service/src/client.ts
@@ -239,10 +239,12 @@ export class Client extends EventEmitter {
    * @param {String}    deviceId            The identifier of an existing device identity.
    * @param {String}    moduleId            The identifier of an existing module identity (optional)
    * @param {Object}    params              An object describing the method and shall have the following properties:
-   *                                        - methodName          The name of the method that shall be invoked.
-   *                                        - payload             [optional] The payload to use for the method call.
-   *                                        - timeoutInSeconds    [optional] The number of seconds IoT Hub shall wait for the device
-   *                                                              to send a response before deeming the method execution a failure.
+   *                                        - methodName                  The name of the method that shall be invoked.
+   *                                        - payload                     [optional] The payload to use for the method call.
+   *                                        - responseTimeoutInSeconds    [optional] The number of seconds IoT Hub shall wait for the device
+   *                                                                      to send a response before deeming the method execution a failure.
+   *                                        - connectTimeoutInSeconds     [optional] The number of seconds IoT Hub shall wait for the service
+   *                                                                      to connect to the device before declaring the device is unreachable.
    * @param {Function}  [done]              The optional callback to call with the result of the method execution.
    * @returns {ResultWithIncomingMessage<any> | void} Promise if no callback function was passed, void otherwise.
    *


### PR DESCRIPTION
# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

The comments does not match the real interface properties.

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->

I added the `connectTimeoutInSeconds` property in the comment and renamed the `timeoutInSeconds` comment property to `responseTimeoutInSeconds`.