### PR TITLE
Fix for #560 - bug in Device.Client#close()

### DIFF
--- a/device/core/src/device_client.ts
+++ b/device/core/src/device_client.ts
@@ -104,7 +104,7 @@ export class Client extends InternalClient {
   close(closeCallback?: Callback<results.Disconnected>): Promise<results.Disconnected> | void {
     return callbackToPromise((_callback) => {
       this._transport.removeListener('disconnect', this._deviceDisconnectHandler);
-      super.close(closeCallback);
+      super.close(_callback);
     }, closeCallback);
   }
 


### PR DESCRIPTION
Call super.close() with proper callback to fix the behavior when Device.Client#close() is called with no callback (e.g when callers expects to get a Promise)

Carry over for #560