### PR TITLE
Update node-devbox-setup.md

### DIFF
--- a/doc/node-devbox-setup.md
+++ b/doc/node-devbox-setup.md
@@ -42,7 +42,7 @@ npm install -g lerna
 Once lerna is installed, you can set up your development environment by running the `bootstrap command` at the root of the repository: This will install all dependencies and link packages together.
 
 ```
-lerna bootstrap
+lerna bootstrap --hoist
 ```
 
 If you want to build/run the code, you'll need to compile the packages:


### PR DESCRIPTION
# Description of the problem
The current documentation uses the command: 
```
lerna bootstrap
```

# Description of the solution
This documentation will be updated to the correct command:
```
lerna boostrap --hoist
```

If hoist isn't used, the dependencies will be left in the individual directories (instead of the top level, saving large amounts of space).