### PR TITLE
fix(#569): support forceDetach while auto-attaching a link because of a send

### DIFF
--- a/common/transport/amqp/devdoc/sender_link_requirements.md
+++ b/common/transport/amqp/devdoc/sender_link_requirements.md
@@ -57,6 +57,8 @@ The `SenderLink` class implements a state machine that manages the underlying `r
 
 **SRS_NODE_AMQP_SENDER_LINK_16_011: [** If the state machine is not in the `attached` state, the `SenderLink` object shall attach the link first and then send the message. **]**
 
+**SRS_NODE_AMQP_SENDER_LINK_16_027: [** If the state machine is not in the attached state and the link is force-detached before successfully attaching , the send callback shall be called with the error passed to forceDetach **]**
+
 **SRS_NODE_AMQP_SENDER_LINK_16_012: [** If the message cannot be sent the `callback` shall be called with an `Error` object describing the AMQP error reported by the service. **]**
 
 **SRS_NODE_AMQP_SENDER_LINK_16_013: [** If the message is successfully sent, the `callback` shall be called with a first parameter (error) set to `null` and a second parameter of type `MessageEnqueued`. **]**

--- a/common/transport/amqp/package.json
+++ b/common/transport/amqp/package.json
@@ -36,7 +36,7 @@
     "alltest": "istanbul cover ../../../node_modules/mocha/bin/_mocha -- --reporter spec test/_*_test*.js",
     "ci": "npm -s run lint && npm -s run build && npm -s run alltest-min && npm -s run check-cover",
     "test": "npm -s run lint && npm -s run build && npm -s run alltest && npm -s run check-cover",
-    "check-cover": "istanbul check-coverage --statements 95 --branches 82 --functions 92 --lines 96"
+    "check-cover": "istanbul check-coverage --statements 96 --branches 83 --functions 92 --lines 96"
   },
   "engines": {
     "node": ">= 0.10"

--- a/common/transport/amqp/src/sender_link.ts
+++ b/common/transport/amqp/src/sender_link.ts
@@ -194,7 +194,16 @@ export class SenderLink extends EventEmitter implements AmqpLink {
               //
               // We are depending on the attach path to process the send queue when it is done attaching.
               //
-              this._fsm.handle('attach');
+              this._fsm.handle('attach', (err) => {
+                /*Codes_SRS_NODE_AMQP_SENDER_LINK_16_027: [If the state machine is not in the attached state and the link is force-detached before successfully attaching , the send callback shall be called with the error passed to forceDetach]*/
+                if (err) {
+                  debug('failed to auto-attach, likely because a forceDetach happened: ' + err.toString());
+                  // no need to handle transitions, failing to attach will automatically revert to detached and take care of unsent messages.
+                } else {
+                  debug('link was auto-attached.');
+                  // no need to handle transitions here either, a successful attach will already set us in the attached state and take care of unsent messages.
+                }
+              });
             }
           }
         },

--- a/common/transport/amqp/test/_sender_link_test.js
+++ b/common/transport/amqp/test/_sender_link_test.js
@@ -120,6 +120,26 @@ describe('SenderLink', function() {
       });
     });
 
+    // Bugfix for https://github.com/Azure/azure-iot-sdk-node/issues/569
+    /*Tests_SRS_NODE_AMQP_SENDER_LINK_16_027: [If the state machine is not in the attached state and the link is force-detached before successfully attaching , the send callback shall be called with the error passed to forceDetach]*/
+    it('does not throw if the link is forceDetached while auto-attaching and fails the send operation with the error provided by forceDetach', function (testCallback) {
+      var fakeError = new Error('fake');
+      var fakeRheaLink = new EventEmitter();
+      var fakeContext = {sender: fakeRheaLink};
+      fakeRheaLink.name = 'rheaSenderLink';
+      var fakeRheaSession = new EventEmitter();
+      fakeRheaSession.open_sender = sinon.stub().returns(fakeRheaLink);
+
+      var link = new SenderLink('link', {}, fakeRheaSession);
+      link.send(new AmqpMessage(''), function(err) {
+        assert(fakeRheaSession.open_sender.calledOnce);
+        assert.strictEqual(err, fakeError);
+        testCallback();
+      });
+
+      link.forceDetach(fakeError);
+    });
+
     /*Tests_SRS_NODE_AMQP_SENDER_LINK_16_010: [The `send` method shall use the link created by the underlying `rhea` to send the specified `message` to the IoT hub.]*/
     /*Tests_SRS_NODE_AMQP_SENDER_LINK_16_013: [If the message is successfully sent, the `callback` shall be called with a first parameter (error) set to `null` and a second parameter of type `MessageEnqueued`.]*/
     it('sends the message passed as argument and calls the callback if successful', function(testCallback) {


### PR DESCRIPTION
see #569 for the explanation of the problem

i believe the best approach to fix #569 is to add a callback, log the situation and do nothing given state transitions are already handled separately.

I'm mildly worried that if forceDetach gets called without an error though, the callback for the send operation might get called without an error as well, which would be misleading. Fixing this is unrelated to the bug though: for now the error parameter on forceDetach is optional. it should probably be mandatory.
