### PR TITLE
add debug logs and increase timeouts on fault injection tests

### DIFF
--- a/e2etests/test/c2d_disconnect.js
+++ b/e2etests/test/c2d_disconnect.js
@@ -19,7 +19,7 @@ var DeviceIdentityHelper = require('./device_identity_helper.js');
 
 var hubConnectionString = process.env.IOTHUB_CONNECTION_STRING;
 
-var numberOfC2DMessages = 5;
+var numberOfC2DMessages = 3;
 var sendMessageTimeout = null;
 
 var doConnectTest = function doConnectTest(doIt) {
@@ -260,16 +260,16 @@ protocolAndTermination.forEach( function (testConfiguration) {
       var sendMessage = function (messageId) {
         serviceClient.send(provisionedDevice.deviceId, originalMessages[messageId].message, function (sendErr) {
           if (sendErr) {
-            debug('failed to send message with id: ' + messageId + ': ' + sendErr.toString());
+            debug('service client: failed to send message with id: ' + messageId + ': ' + sendErr.toString());
             testCallback(sendErr);
           } else {
-            debug('message sent: ' + messageId);
+            debug('service client: message sent: ' + messageId);
             originalMessages[messageId].sent = true;
             if (allDone()) {
-              debug('all messages have been sent and received!');
+              debug('service client: all messages have been sent and received!');
               testCallback();
             } else {
-              debug('still not done!');
+              debug('service client: still not done!');
             }
           }
         });
@@ -302,7 +302,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
             //
             // It doesn't matter whether this was a message we want, complete it so that the message queue stays clean.
             //
-            debug('c2d message received with id: ' + receivedMessage.messageId);
+            debug('device client: c2d message received with id: ' + receivedMessage.messageId);
             deviceClient.complete(receivedMessage, function (err, result) {
               if (err) {
                 debug('error while settling (accept) the message: ' + err.toString());
@@ -321,34 +321,34 @@ protocolAndTermination.forEach( function (testConfiguration) {
                     terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
                     terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
                     terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
-                    debug('Injecting fault: ' + testConfiguration.operationType);
+                    debug('device client: Injecting fault: ' + testConfiguration.operationType);
                     faultInjected = true;
                     deviceClient.sendEvent(terminateMessage, function (sendErr) {
-                      debug('at the callback for the fault injection send, err is:' + sendErr);
+                      debug('device client: at the callback for the fault injection send, err is:' + sendErr);
                     });
                   }
 
                   if (allDone()) {
-                    debug('all messages have been received. test successful');
+                    debug('device client: all messages have been received. test successful');
                     testCallback();
                   } else {
-                    debug('scheduling next message in 3 seconds');
-                    sendMessageTimeout = setTimeout(sendNextMessage, 3000);
+                    debug('device client: scheduling next message in 6 seconds');
+                    sendMessageTimeout = setTimeout(sendNextMessage, 6000);
                   }
                 } else {
-                  debug('received an unanticipated message, id: ' + receivedMessage.messageId + ' data: ' + receivedMessage.data.toString());
+                  debug('device client: received an unanticipated message, id: ' + receivedMessage.messageId + ' data: ' + receivedMessage.data.toString());
                 }
               }
             });
           });
-          debug('connecting service client...');
+          debug('service client: connecting...');
           serviceClient.open(function (serviceErr) {
             if (serviceErr) {
-              debug('Failed to connect servic client:' + serviceErr.toString());
+              debug('service client: Failed to connect:' + serviceErr.toString());
               testCallback(serviceErr);
             } else {
-              debug('service client connected');
-              debug('sending first message');
+              debug('service client: connected');
+              debug('service client: sending first message');
               sendNextMessage();
             }
           });

--- a/e2etests/test/d2c_disconnect.js
+++ b/e2etests/test/d2c_disconnect.js
@@ -23,7 +23,7 @@ var doConnectTest = function doConnectTest(doIt) {
   return doIt ? it : it.skip;
 };
 
-var numberOfD2CMessages = 5;
+var numberOfD2CMessages = 3;
 var sendMessageTimeout = null;
 
 var protocolAndTermination = [
@@ -331,7 +331,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
             if (allMessagesReceived()) {
               rdv.imDone('ehClient');
             } else {
-              sendMessageTimeout = setTimeout(sendNextMessage, 3000);
+              sendMessageTimeout = setTimeout(sendNextMessage, 6000);
             }
           } else {
             debug('eventhubs client: eventData doesn\'t match: ' + eventData.body.toString());

--- a/e2etests/test/d2c_disconnect.js
+++ b/e2etests/test/d2c_disconnect.js
@@ -146,38 +146,39 @@ protocolAndTermination.forEach( function (testConfiguration) {
       originalMessage.messageId = uuidData;
 
       var disconnectHandler = function () {
-        debug('Device client disconnected');
+        debug('device client: disconnected');
         deviceClient.removeListener('disconnect', disconnectHandler);
         if (messageReceived) {
           rdv.imDone('deviceClient');
         } else {
-          testCallback(new Error('device client disconnected but the original message was not received.'));
+          testCallback(new Error('device client: disconnected but the original message was not received.'));
         }
       };
       var onEventHubError = function(err) {
-        debug('Event Hubs client error: ' + err.toString());
+        debug('eventhubs client: error: ' + err.toString());
         testCallback(err);
       };
       var onEventHubMessage = function (eventData) {
         if (eventData.annotations['iothub-connection-device-id'] === provisionedDevice.deviceId) {
-          debug('received a message from the test device');
+          debug('eventhubs client: received a message from the test device: ' + provisionedDevice.deviceId);
           var received_message_uuid = eventData.properties && eventData.properties.message_id && uuidBuffer.toString(eventData.properties.message_id);
           if (received_message_uuid && received_message_uuid === originalMessage.messageId) {
             rdv.imDone('ehClient');
-            debug('received the sent message - send the fault packet');
+            debug('eventhubs client: received the sent message');
+            debug('device client: send the fault packet');
             messageReceived = true;
             var terminateMessage = new Message('');
             terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
             terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
             terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
             deviceClient.sendEvent(terminateMessage, function (sendErr) {
-              debug('at the callback for the fault injection send, err is:' + sendErr);
+              debug('device client: at the callback for the fault injection send, err is:' + sendErr);
             });
           } else {
-            debug('eventData doesn\'t match: ' + originalMessage.messageId);
+            debug('eventhubs client: eventData doesn\'t match: ' + originalMessage.messageId);
           }
         } else {
-          debug('Incoming device id is: ' + eventData.annotations['iothub-connection-device-id']);
+          debug('eventhubs client: ignoring message from: ' + eventData.annotations['iothub-connection-device-id']);
         }
       };
 
@@ -188,29 +189,36 @@ protocolAndTermination.forEach( function (testConfiguration) {
         deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
         deviceClient.setRetryPolicy(new NoRetry());
       }).then(function () {
+        debug('eventhubs client: connected. getting partition ids');
         return ehClient.getPartitionIds();
       }).then(function (partitionIds) {
+        debug('eventhubs client: got partition ids. setting up receivers');
         partitionIds.forEach(function (partitionId) {
           ehClient.receive(partitionId, onEventHubMessage, onEventHubError, { eventPosition: EventPosition.fromEnqueuedTime(testStart) });
         });
+        debug('eventhubs client: receivers started: waiting 3 seconds before starting device client');
         return new Promise(function (resolve) {
           setTimeout(function () {
             resolve();
           }, 3000);
         });
       }).then(function () {
+        debug('device client: connecting...');
         deviceClient.open(function (openErr) {
           if (openErr) {
+            debug('device client: error connecting: ' + openErr.toString());
             testCallback(openErr);
           } else {
             rdv.imIn('deviceClient');
+            debug('device client: connected');
             deviceClient.on('disconnect', disconnectHandler);
+            debug('device client: sending: ' + originalMessage.messageId);
             deviceClient.sendEvent(originalMessage, function (sendErr) {
               if (sendErr) {
-                debug('error sending the initial message: ' + sendErr.toString());
+                debug('device client: error sending the initial message: ' + sendErr.toString());
                 testCallback(sendErr);
               } else {
-                debug('initial message sent');
+                debug('device client: initial message sent');
               }
             });
           }
@@ -259,18 +267,19 @@ protocolAndTermination.forEach( function (testConfiguration) {
       };
 
       var sendMessage = function (messageId) {
+        debug('device client: sending ' + messageId);
         deviceClient.sendEvent(originalMessages[messageId].message, function (sendErr) {
           if (sendErr) {
-            debug('failed to send message with id: ' + messageId + ': ' + sendErr.toString());
+            debug('device client: failed to send message with id: ' + messageId + ': ' + sendErr.toString());
             testCallback(sendErr);
           } else {
-            debug('message sent: ' + messageId);
+            debug('device client: message sent: ' + messageId);
             originalMessages[messageId].sent = true;
             if (allMessagesSent()) {
-              debug('all messages have been sent!');
+              debug('device client: all messages have been sent!');
               rdv.imDone('deviceClient');
             } else {
-              debug('device client still has messages to send!');
+              debug('device client: still has messages to send!');
             }
           }
         });
@@ -281,39 +290,40 @@ protocolAndTermination.forEach( function (testConfiguration) {
           if (originalMessages[messageId].sent) {
             continue;
           } else {
-            debug('Sending message with id: ' + messageId);
+            debug('device client: found an unsent message: ' + messageId);
             return sendMessage(messageId);
           }
         }
-        debug('all messages have been sent.');
+        debug('device client: all messages seem to have been sent');
       };
 
       var startAfterTime = Date.now() - 5000;
       debug('starting to listen to messages received since: ' + new Date(startAfterTime).toISOString());
 
       var onEventHubError = function(err) {
-        debug('EventHubClient error: ' + err.toString());
+        debug('eventhubs client: error: ' + err.toString());
         testCallback(err);
       };
 
       var onEventHubMessage = function (eventData) {
         if (eventData.annotations['iothub-connection-device-id'] === provisionedDevice.deviceId) {
-          debug('did get a message for this device.');
+          debug('eventhubs client: received a message from the test device: ' + provisionedDevice.deviceId);
           var receivedMessageId = eventData.body.toString();
           if (originalMessages[receivedMessageId]) {
-            debug('It was one of the messages we sent: ' + receivedMessageId);
+            debug('eventhubs client: It was one of the messages we sent: ' + receivedMessageId);
             originalMessages[receivedMessageId].received = true;
             if (!faultInjected) {
-              debug('Fault has not been injected yet. Failing now...');
+              debug('eventhubs client: Fault has not been injected yet.');
+              debug('device client: injecting fault now...');
               var terminateMessage = new Message('');
               terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
               terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
               terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
               faultInjected = true;
               deviceClient.sendEvent(terminateMessage, function (sendErr) {
-                debug('fault injection message sent');
+                debug('device client: fault injection message sent');
                 if (sendErr) {
-                  debug('error at fault injection:' + sendErr);
+                  debug('device client: error at fault injection:' + sendErr);
                 }
               });
             }
@@ -324,10 +334,10 @@ protocolAndTermination.forEach( function (testConfiguration) {
               sendMessageTimeout = setTimeout(sendNextMessage, 3000);
             }
           } else {
-            debug('eventData message id doesn\'t match any stored message id');
+            debug('eventhubs client: eventData doesn\'t match: ' + eventData.body.toString());
           }
         } else {
-          debug('Incoming device id is: ' + eventData.annotations['iothub-connection-device-id']);
+          debug('eventhubs client: ignoring message from: ' + eventData.annotations['iothub-connection-device-id']);
         }
       };
 
@@ -337,25 +347,29 @@ protocolAndTermination.forEach( function (testConfiguration) {
         rdv.imIn('ehClient');
         deviceClient = createDeviceClient(testConfiguration.transport, provisionedDevice);
       }).then(function () {
+        debug('eventhubs client: connected. getting partition ids');
         return ehClient.getPartitionIds();
       }).then(function (partitionIds) {
+        debug('eventhubs client: got partition ids. setting up receivers');
         partitionIds.forEach(function (partitionId) {
           ehClient.receive(partitionId, onEventHubMessage, onEventHubError, { eventPosition: EventPosition.fromEnqueuedTime(startAfterTime) });
         });
+        debug('eventhubs client: receivers started: waiting 3 seconds before starting device client');
         return new Promise(function (resolve) {
           setTimeout(function () {
             resolve();
           }, 3000);
         });
       }).then(function () {
+        debug('device client: connecting...');
         deviceClient.open(function (openErr) {
           if (openErr) {
-            debug('error connecting the device client');
+            debug('device client: error: ' + openErr.toString());
             testCallback(openErr);
           } else {
             rdv.imIn('deviceClient');
             deviceClient.on('disconnect', function () {
-              debug('Device client disconnect event should not fire during this test');
+              debug('device client: disconnect event fired. that\'s a test failure.');
               testCallback(new Error('unexpected disconnect'));
             });
             sendNextMessage();
@@ -363,7 +377,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
         });
       })
       .catch(function (err) {
-        debug('caught event hub error: ' + err.toString());
+        debug('eventhubs client: error: ' + err.toString());
         testCallback(err);
       });
     });

--- a/e2etests/test/twin_disconnect.js
+++ b/e2etests/test/twin_disconnect.js
@@ -304,7 +304,7 @@ protocolAndTermination.forEach( function (testConfiguration) {
               debug('device client: fault injection succeeded for device: ' + deviceDescription.deviceId);
             }
           });
-          twinUpdateAfterFaultInjectionTimeout = setTimeout(setTwinPropsAfterFaultInjection, (testConfiguration.delayInSeconds + 5) * 1000);
+          twinUpdateAfterFaultInjectionTimeout = setTimeout(setTwinPropsAfterFaultInjection, (testConfiguration.delayInSeconds + 10) * 1000);
         } else if (deviceTwin.properties.desired.testProp === afterFaultInjectionTestPropertyValue) {
           debug('device client: received notification for desired property after fault injection.');
           rdv.imDone(deviceClientIdentifier);

--- a/e2etests/test/twin_disconnect.js
+++ b/e2etests/test/twin_disconnect.js
@@ -212,45 +212,45 @@ protocolAndTermination.forEach( function (testConfiguration) {
 
       debug('attaching disconnect event handler');
       deviceClient.on('disconnect', function () {
-        debug('We did get a disconnect event');
+        debug('device client: disconnect event');
         if (deviceTwin.properties.desired.testProp === faultInjectionTestPropertyValue) {
           rdv.imDone(deviceClientIdentifier);
         } else {
-          testCallback(new Error('unexpected disconnect for device: ' + deviceDescription.deviceId));
+          testCallback(new Error('device client: unexpected disconnect for device: ' + deviceDescription.deviceId));
         }
       });
-      debug('attaching desired properties change handler');
-      debug('will trigger fault injection when test property value is: ' + faultInjectionTestPropertyValue);
+      debug('device client: attaching desired properties change handler');
+      debug('device client: will trigger fault injection when test property value is: ' + faultInjectionTestPropertyValue);
       deviceTwin.on('properties.desired', function() {
         if (deviceTwin.properties.desired.testProp === faultInjectionTestPropertyValue) {
           var terminateMessage = new Message(' ');
           terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
           terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
           terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
-          debug('sending fault injection message');
+          debug('device client: sending fault injection message');
           deviceClient.sendEvent(terminateMessage, function (sendErr) {
             if (sendErr) {
-              debug('fault injection error: ' + sendErr.toString());
+              debug('device client: fault injection error: ' + sendErr.toString());
             } else {
-              debug('fault injection successful');
+              debug('device client: fault injection successful');
             }
           });
         } else {
-          debug('received notification for desired property change. testProperty: ' + deviceTwin.properties.desired.testProp);
+          debug('device client: received notification for desired property change. testProperty: ' + deviceTwin.properties.desired.testProp);
         }
       });
 
       // giving a few seconds for the twin subscription to happen before we send the update.
-      debug('waiting 3 seconds before triggering a twin update from the service API');
+      debug('service client: waiting 3 seconds before triggering a twin update from the service API');
       faultInjectionTimeout = setTimeout(function () {
-        debug('Updating twin properties');
+        debug('service client: Updating twin properties');
         serviceTwin.update( { properties : { desired : { testProp: faultInjectionTestPropertyValue } } }, function(err) {
           if (err) {
-            debug('Twin update failed for device: ' + deviceDescription.deviceId + '. Error updating twin for fault injection: ' + err.toString());
+            debug('service client: Twin update failed for device: ' + deviceDescription.deviceId + '. Error updating twin for fault injection: ' + err.toString());
             err.message += '; test device: ' + deviceDescription.deviceId;
             testCallback(err);
           } else {
-            debug('twin properties updated to trigger fault injection with value: ' + faultInjectionTestPropertyValue);
+            debug('service client: twin properties updated to trigger fault injection with value: ' + faultInjectionTestPropertyValue);
             rdv.imDone(serviceTwinUpdateIdentifier);
           }
         });
@@ -276,52 +276,54 @@ protocolAndTermination.forEach( function (testConfiguration) {
       });
 
       var setTwinPropsAfterFaultInjection = function() {
+        debug('service client: updating twin after fault injection');
         serviceTwin.update( { properties : { desired : { testProp: afterFaultInjectionTestPropertyValue } } }, function(err) {
           if (err) {
+            debug('service client: error updating property after fault injection: ' + err.toString());
             err.message += '; test device: ' + deviceDescription.deviceId;
             testCallback(err);
           } else {
-            debug('sent new property update after fault injection');
+            debug('service client: sent new property update after fault injection');
             rdv.imDone(serviceTwinUpdateIdentifier);
           }
         });
       };
 
-      debug('attaching desired properties update handler');
+      debug('device client: attaching desired properties update handler');
       deviceTwin.on('properties.desired', function() {
         if (deviceTwin.properties.desired.testProp === faultInjectionTestPropertyValue) {
           var terminateMessage = new Message(' ');
           terminateMessage.properties.add('AzIoTHub_FaultOperationType', testConfiguration.operationType);
           terminateMessage.properties.add('AzIoTHub_FaultOperationCloseReason', testConfiguration.closeReason);
           terminateMessage.properties.add('AzIoTHub_FaultOperationDelayInSecs', testConfiguration.delayInSeconds);
-          debug('sending fault injection message');
+          debug('device client: sending fault injection message');
           deviceClient.sendEvent(terminateMessage, function (sendErr) {
             if (sendErr) {
-              debug('error at fault injection for device: ' + deviceDescription.deviceId + ' : ' + sendErr.toString());
+              debug('device client: error at fault injection for device: ' + deviceDescription.deviceId + ' : ' + sendErr.toString());
             } else {
-              debug('fault injection succeeded for device: ' + deviceDescription.deviceId);
+              debug('device client: fault injection succeeded for device: ' + deviceDescription.deviceId);
             }
           });
           twinUpdateAfterFaultInjectionTimeout = setTimeout(setTwinPropsAfterFaultInjection, (testConfiguration.delayInSeconds + 5) * 1000);
         } else if (deviceTwin.properties.desired.testProp === afterFaultInjectionTestPropertyValue) {
-          debug('received notification for desired property after fault injection.');
+          debug('device client: received notification for desired property after fault injection.');
           rdv.imDone(deviceClientIdentifier);
         } else {
-          debug('ignoring test property value: ' + deviceTwin.properties.desired.testProp);
+          debug('device client: ignoring test property value: ' + deviceTwin.properties.desired.testProp);
         }
       });
 
       // giving a few seconds for the twin subscription to happen before we send the update.
-      debug('waiting 3 seconds before twin update that will trigger the fault injection.');
+      debug('service client: waiting 3 seconds before twin update that will trigger the fault injection.');
       faultInjectionTimeout = setTimeout(function () {
-        debug('updating twin property for fault injection');
+        debug('service client: updating twin property for fault injection');
         serviceTwin.update( { properties : { desired : { testProp: faultInjectionTestPropertyValue } } }, function(err) {
           if (err) {
-            debug('failed to update twin for fault injection for device: ' + deviceDescription.deviceId + ' : ' + err.toString());
+            debug('service client: failed to update twin for fault injection for device: ' + deviceDescription.deviceId + ' : ' + err.toString());
             err.message += '; deviceId: ' + deviceDescription.deviceId;
             testCallback(err);
           } else {
-            debug('successfully sent twin update that will trigger fault injection');
+            debug('service client: successfully sent twin update that will trigger fault injection');
           }
         });
       }, 3000);


### PR DESCRIPTION
Seeing some failures due to race conditions in a limited series of fault injection tests. adding logging for easier debugging and increasing timeouts.
i'm also reducing the number of messages to send from 5 to 3 to limit the increase in test execution time.