### PR TITLE
HTTPS agent support added to AMQP over WebSocket transport

### DIFF
--- a/device/core/src/interfaces.ts
+++ b/device/core/src/interfaces.ts
@@ -16,6 +16,10 @@ import { Agent } from 'https';
  * @see {DeviceClientOptions}
  */
 export interface AmqpTransportOptions {
+  /**
+   * Optional [Agent]{@link https://nodejs.org/api/https.html#https_class_https_agent} object to use with AMQP-WS connections
+   */
+  webSocketAgent?: Agent;
 }
 
 /**
@@ -124,7 +128,7 @@ export interface DeviceClientOptions extends X509 {
   http?: HttpTransportOptions;
 
   /**
-   * Optional object with options specific to the Mqtt transport
+   * Optional object with options specific to the Amqp transport
    */
   amqp?: AmqpTransportOptions;
 }

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -82,6 +82,8 @@ The `connect` method establishes a connection with the Azure IoT Hub instance.
 
 **SRS_NODE_DEVICE_AMQP_13_002: [** The `connect` method shall set the CA cert on the options object when calling the underlying connection object's connect method if it was supplied. **]**
 
+**SRS_NODE_DEVICE_AMQP_99_084: [** The `connect` method shall set the HTTPS agent on the options object when calling the underlying connection object's connect method if it was supplied. **]** 
+
 ### disconnect(done)
 The `disconnect` method terminates the connection with the Azure IoT Hub instance.
 

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -285,10 +285,16 @@ export class Amqp extends EventEmitter implements DeviceTransport {
                     sslOptions: credentials.x509,
                     userAgentString: userAgentString
                   };
-                  /*Codes_SRS_NODE_DEVICE_AMQP_13_002: [ The connect method shall set the CA cert on the options object when calling the underlying connection object's connect method if it was supplied. ]*/
-                  if (this._options && this._options.ca) {
+                  if (this._options) {
                     config.sslOptions = config.sslOptions || {};
-                    config.sslOptions.ca = this._options.ca;
+                    /*Codes_SRS_NODE_DEVICE_AMQP_13_002: [ The connect method shall set the CA cert on the options object when calling the underlying connection object's connect method if it was supplied. ]*/
+                    if (this._options.ca) {
+                      config.sslOptions.ca = this._options.ca;
+                    }
+                    /*Codes_SRS_NODE_DEVICE_AMQP_99_084: [ The connect method shall set the HTTPS agent on the options object when calling the underlying connection object's connect method if it was supplied. ]*/
+                    if (this._options.amqp && this._options.amqp.webSocketAgent) {
+                      config.sslOptions.agent = this._options.amqp.webSocketAgent;
+                    }
                   }
                   this._amqp.connect(config, (err, connectResult) => {
                     if (err) {

--- a/device/transport/amqp/test/_amqp_test.js
+++ b/device/transport/amqp/test/_amqp_test.js
@@ -400,6 +400,17 @@ describe('Amqp', function () {
         });
       });
 
+      /*Tests_SRS_NODE_DEVICE_AMQP_99_084: [ The connect method shall set the HTTPS agent on the options object when calling the underlying connection object's connect method if it was supplied. ]*/
+      it('sets HTTPS agent if provided', function (testCallback) {
+        transport.setOptions({ amqp: { webSocketAgent: 'https agent' } });
+        transport.connect(function (err) {
+          assert.isNotOk(err);
+          assert(fakeBaseClient.connect.called);
+          assert.strictEqual(fakeBaseClient.connect.firstCall.args[0].sslOptions.agent, 'https agent');
+          testCallback();
+        });
+      });
+
       it('sets gateway host name if provided', function (testCallback) {
         fakeTokenAuthenticationProvider.getDeviceCredentials = sinon.stub().callsArgWith(0, null, configWithGatewayHostName);
         transport.connect(function (err) {


### PR DESCRIPTION
carry over from #579 
rebased and squashed.