### PR TITLE
fix(azure-iot-common-amqp): remove console log from test file

### DIFF
--- a/common/transport/amqp/test/_amqp_common_errors_test.js
+++ b/common/transport/amqp/test/_amqp_common_errors_test.js
@@ -101,7 +101,6 @@ describe('translateError', function() {
       var specific_message = 'specific error message';
       let testErr = { error: { message: { message: specific_message }}};    
       var err = translateError(message, testErr.error);
-      console.log(err.message);
       assert.equal(err.message, message + '. ' + specific_message);
     });
   });


### PR DESCRIPTION
There was a console log left in a test file. It should be removed to clean up the unit test logs.