### PR TITLE
HTTPS agent support added to AMQP provisioning transport

### DIFF
--- a/provisioning/device/src/interfaces.ts
+++ b/provisioning/device/src/interfaces.ts
@@ -5,6 +5,7 @@
 
 import { X509, Callback, SharedAccessSignature } from 'azure-iot-common';
 import { X509Registration } from './x509_registration';
+import { Agent } from 'https';
 
 /**
  * Configuration options for provisioning transports.  Passed into the transport's setTransportOptions function.
@@ -19,6 +20,11 @@ export interface ProvisioningTransportOptions {
    * default timeout to use when communicating with the service
    */
   timeoutInterval?: number;
+
+  /**
+   * Optional agent to use when communicating with the service
+   */
+  webSocketAgent?: Agent;
 }
 
 /**

--- a/provisioning/transport/amqp/devdoc/amqp_requirements.md
+++ b/provisioning/transport/amqp/devdoc/amqp_requirements.md
@@ -34,6 +34,8 @@ and shall set the password to the passed in sas token.
 
 **SRS_NODE_PROVISIONING_AMQP_16_002: [** The `registrationRequest` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method. **]**
 
+**SRS_NODE_PROVISIONING_AMQP_99_026: [** The `registrationRequest` method shall connect the AMQP client with the SSL agent given in the `auth` parameter of the previously called `setAuthentication` method. **]**
+
 **SRS_NODE_PROVISIONING_AMQP_16_003: [** The `registrationRequest` method shall attach a sender link on the `<idScope>/registrations/<registrationId>` endpoint with the following properties:
 ```
 com.microsoft:api-version: <API_VERSION>

--- a/provisioning/transport/amqp/devdoc/amqp_requirements.md
+++ b/provisioning/transport/amqp/devdoc/amqp_requirements.md
@@ -34,7 +34,7 @@ and shall set the password to the passed in sas token.
 
 **SRS_NODE_PROVISIONING_AMQP_16_002: [** The `registrationRequest` method shall connect the AMQP client with the certificate and key given in the `auth` parameter of the previously called `setAuthentication` method. **]**
 
-**SRS_NODE_PROVISIONING_AMQP_99_026: [** The `registrationRequest` method shall connect the AMQP client with the SSL agent given in the `auth` parameter of the previously called `setAuthentication` method. **]**
+**SRS_NODE_PROVISIONING_AMQP_99_001: [** The `registrationRequest` method shall connect the AMQP client with the SSL agent given in the `auth` parameter of the previously called `setAuthentication` method. **]**
 
 **SRS_NODE_PROVISIONING_AMQP_16_003: [** The `registrationRequest` method shall attach a sender link on the `<idScope>/registrations/<registrationId>` endpoint with the following properties:
 ```

--- a/provisioning/transport/amqp/src/amqp.ts
+++ b/provisioning/transport/amqp/src/amqp.ts
@@ -144,7 +144,7 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
               sslOptions: this._x509Auth,
               userAgentString: ProvisioningDeviceConstants.userAgent
             };
-            /*Codes_SRS_NODE_PROVISIONING_AMQP_99_026: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
+            /*Codes_SRS_NODE_PROVISIONING_AMQP_99_001: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
             config.sslOptions = config.sslOptions || {};
             config.sslOptions.agent = this._config.webSocketAgent;
             if (this._sas) {

--- a/provisioning/transport/amqp/src/amqp.ts
+++ b/provisioning/transport/amqp/src/amqp.ts
@@ -144,6 +144,9 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
               sslOptions: this._x509Auth,
               userAgentString: ProvisioningDeviceConstants.userAgent
             };
+            /*Codes_SRS_NODE_PROVISIONING_AMQP_99_026: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
+            config.sslOptions = config.sslOptions || {};
+            config.sslOptions.agent = this._config.webSocketAgent;
             if (this._sas) {
               /*Codes_SRS_NODE_PROVISIONING_AMQP_06_002: [** The `registrationRequest` method shall connect the amqp client, if utilizing the passed in sas from setSharedAccessSignature, shall in the connect options set the username to:
                 ```
@@ -480,7 +483,8 @@ export class Amqp extends EventEmitter implements X509ProvisioningTransport, Tpm
    */
   setTransportOptions(options: ProvisioningTransportOptions): void {
     [
-      'pollingInterval'
+      'pollingInterval',
+      'webSocketAgent'
     ].forEach((optionName) => {
       if (options.hasOwnProperty(optionName)) {
         this._config[optionName] = options[optionName];

--- a/provisioning/transport/amqp/test/_amqp_test.js
+++ b/provisioning/transport/amqp/test/_amqp_test.js
@@ -171,6 +171,17 @@ describe('Amqp', function () {
         });
       });
 
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_99_026: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
+      it('connects the AMQ connection on using the agent set in transport options', function (testCallback) {
+        var expectedAgent = '__FAKE_AGENT__';
+        amqp.setTransportOptions({webSocketAgent: expectedAgent});
+        amqp.registrationRequest({ registrationId: 'fakeRegistrationId' }, function () {
+          var actualAgent = fakeAmqpBase.connect.getCall(0).args[0].sslOptions.agent;
+          assert.equal(actualAgent, expectedAgent);
+          testCallback();
+        });
+      });
+
       /*Tests_SRS_NODE_PROVISIONING_AMQP_16_008: [The `registrationRequest` method shall call its callback with an error if the transport fails to connect.]*/
       it ('calls its callback with an error if it fails to connect', function (testCallback) {
         fakeAmqpBase.connect = sinon.stub().callsArgWith(1, fakeError);

--- a/provisioning/transport/amqp/test/_amqp_test.js
+++ b/provisioning/transport/amqp/test/_amqp_test.js
@@ -171,7 +171,7 @@ describe('Amqp', function () {
         });
       });
 
-      /*Tests_SRS_NODE_PROVISIONING_AMQP_99_026: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
+      /*Tests_SRS_NODE_PROVISIONING_AMQP_99_001: [The `registrationRequest` method shall connect the AMQP client with the agent given in the `webSocketAgent` parameter of the previously called `setTransportOptions` method.]*/
       it('connects the AMQ connection on using the agent set in transport options', function (testCallback) {
         var expectedAgent = '__FAKE_AGENT__';
         amqp.setTransportOptions({webSocketAgent: expectedAgent});


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Description of the problem
Currently, it is not possible to provision a device behind a corporate HTTPS proxy using AMQP transport due to missing HTTPS agent support.
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
HTTPS agent support added to AMQP provisioning transport so that a device can be provisioned behind a corporate HTTPS proxy:

```javascript
const HttpsProxyAgent = require('https-proxy-agent');
const AmqpWs = require('azure-iot-provisioning-device-amqp').AmqpWs;

const proxy = 'http://localhost:8866';
const agent = new HttpsProxyAgent(proxy);
const transport = new AmqpWs();

transport.setTransportOptions({
    webSocketAgent: agent
});
```

<!-- How you solved the issue and the other things you considered and maybe rejected -->
