### PR TITLE
[digitaltwin] moving sdkInfo to client instance

### DIFF
--- a/digitaltwins/device/src/digital_twin_client.ts
+++ b/digitaltwins/device/src/digital_twin_client.ts
@@ -132,13 +132,12 @@ interface InterfaceInstanceInformation {
 // tslint:disable-next-line:no-var-requires
 const packageJson = require('../package.json');
 
-/**
- * @private
- * An instantiation of the SDK information interface.
- */
-const sdkInformation = new SdkInformation('urn_azureiot_Client_SDKInformation', 'urn:azureiot:Client:SDKInformation:1');
-
 export class DigitalTwinClient {
+  //
+  // An instantiation of the SDK information interface.
+  //
+  private readonly _sdkInformation: SdkInformation  = new SdkInformation('urn_azureiot_Client_SDKInformation', 'urn:azureiot:Client:SDKInformation:1');
+
   //
   // Dictionary of each interfaceInstance and the associated interface.
   //
@@ -164,7 +163,7 @@ export class DigitalTwinClient {
     this._capabilityModel = capabilityModel;
     this._client = client;
     this._twin = {} as Twin;
-    this.addInterfaceInstance(sdkInformation);
+    this.addInterfaceInstance(this._sdkInformation);
   }
 
   /**
@@ -636,15 +635,15 @@ export class DigitalTwinClient {
             // Intentionally letting a failure of SDK information report
             // be ignored.
             //
-            sdkInformation.language.report('Node.js', (err?: Error) => {
+            this._sdkInformation.language.report('Node.js', (err?: Error) => {
               if (err) {
                 debug('Error updating the SDK language: ' + err.toString());
               }
-              sdkInformation.version.report(packageJson.name + '/' + packageJson.version, (err?: Error) => {
+              this._sdkInformation.version.report(packageJson.name + '/' + packageJson.version, (err?: Error) => {
                 if (err) {
                   debug('Error updating the SDK version: ' + err.toString());
                 }
-                sdkInformation.vendor.report('Microsoft Corporation', (err?: Error) => {
+                this._sdkInformation.vendor.report('Microsoft Corporation', (err?: Error) => {
                   if (err) {
                     debug('Error updating the SDK vendor: ' + err.toString());
                   }


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [x] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [x] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR
https://github.com/Azure/azure-iot-sdk-node/issues/615

# Description of the problem
`sdkInformation` was declared at module level but registered at the constructor, leading to a race condition whenever more than one client object was created.

# Description of the solution
Moved `sdkInformation` to a client instance field.
