### PR TITLE
[fix](azure-iot-device-mqtt): remove double nesting on sendEvent TransportObj

### DIFF
--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -118,6 +118,10 @@ The `sendEvent` method sends an event to an IoT hub on behalf of the device indi
 
 **SRS_NODE_DEVICE_MQTT_16_027: [** The `sendEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to publish the message. **]**
 
+**SRS_NODE_DEVICE_MQTT_41_004 [** The `sendEvent` method shall call its callback with a `MessageEnqueued` **]**
+**SRS_NODE_DEVICE_MQTT_41_005 [** The `sendOutputEvent` method shall call its callback with a `MessageEnqueued` **]**
+
+
 ### sendEventBatch(messages, done)
 **SRS_NODE_DEVICE_MQTT_16_056: [** The `sendEventBatch` method shall throw a `NotImplementedError` **]**
 

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -271,6 +271,8 @@ export class Mqtt extends EventEmitter implements DeviceTransport {
                 /*Codes_SRS_NODE_DEVICE_MQTT_18_050: [The `sendOutputEvent` method shall call its callback with an `Error` that has been translated using the `translateError` method if the `MqttBase` object fails to publish the message. ]*/
                 sendEventCallback(translateError(err));
               } else {
+                /*Codes_SRS_NODE_DEVICE_MQTT_41_004 [ The `sendEvent` method shall call its callback with a `MessageEnqueued` ]*/
+                /*Codes_SRS_NODE_DEVICE_MQTT_41_005 [ The `sendOutputEvent` method shall call its callback with a `MessageEnqueued` ]*/
                 sendEventCallback(null, new results.MessageEnqueued(result));
               }
             });
@@ -395,7 +397,7 @@ export class Mqtt extends EventEmitter implements DeviceTransport {
         done(err);
       } else {
         debug('PUBACK: ' + JSON.stringify(puback));
-        done(null, new results.MessageEnqueued(puback));
+        done(null, puback);
       }
     });
   }
@@ -646,7 +648,7 @@ export class Mqtt extends EventEmitter implements DeviceTransport {
         done(err);
       } else {
         debug('PUBACK: ' + JSON.stringify(puback));
-        done(null, new results.MessageEnqueued(puback));
+        done(null, puback);
       }
     });
   }

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -295,6 +295,29 @@ describe('Mqtt', function () {
         fakemqtt.emit('connect', { connack: true });
       });
 
+      /*Tests_SRS_NODE_DEVICE_MQTT_41_004 [ The `sendEvent` method shall call its callback with a `MessageEnqueued` ]*/
+      /*Tests_SRS_NODE_DEVICE_MQTT_41_005 [ The `sendOutputEvent` method shall call its callback with a `MessageEnqueued` ]*/
+      it('calls the callback with the correctly structured response parameter', function (done) {
+        // There was a bug in the mqtt SendEvent code whereby the `response` would contain a doubly nested object.
+        // This was caused by creating a new MessagedEnqueued object, and then passing that in as a parameter
+        // to a callback that would use it as a parameter for creating a MessageEnqueued object, leading to a 
+        // odd double nesting. This does not seek to test the MessageEnqueued object itself, since that should
+        // be tested in the results unit testing, just to verify that the response is generated properly without
+        // double nesting.
+        fakeMqttBase.publish.callsArgWith(3, null, 'fakeResultObject');
+        var transport = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);
+        transport.connect(function () {
+          testConfig.sendFunc(transport, new Message('message'), function(err, resp) {
+            assert.equal(resp.constructor.name, 'MessageEnqueued');
+            assert(resp.hasOwnProperty('transportObj'));
+            assert.equal(resp.transportObj,'fakeResultObject');
+            done();
+          });
+        });
+        fakemqtt.emit('connect', { connack: true });
+
+      });
+
       [
         /*Tests_SRS_NODE_COMMON_MQTT_BASE_16_011: [The `sendEvent` method shall serialize the `messageId` property of the message as a key-value pair on the topic with the key `$.mid`.]*/
         /*Tests_SRS_NODE_DEVICE_MQTT_18_040: [ The `sendOutputEvent` method shall serialize the `messageId` property of the message as a key-value pair on the topic with the key `$.mid`. ]*/


### PR DESCRIPTION
This is in reference to #626 

The wrapping of the response was 1) redundant and 2) out of line with how other MQTT calls are made. 

With this change an MQTT PUB and ACK look like this:
```
  azure-iot-mqtt-base:MqttBase CONNACK: {"cmd":"connack","retain":false,"qos":0,"dup":false,"length":2,"topic":null,"payload":null,"sessionPresent":false,"returnCode":0} +1ms
...
  azure-iot-device-mqtt:Mqtt PUBACK: {"cmd":"publish","topic":"devices/beta/messages/events/IMPACT_EMERGENCY=false","payload":"{\"size\":26.15078342292594,\"timeTillImpact\":22.72007917052823}","qos":1,"retain":false,"messageId":10181,"dup":false} +2s
```

Before (without this change):
```
  azure-iot-mqtt-base:MqttBase CONNACK: {"cmd":"connack","retain":false,"qos":0,"dup":false,"length":2,"topic":null,"payload":null,"sessionPresent":false,"returnCode":0} +1ms
...
  azure-iot-device-mqtt:Mqtt PUBACK: {"transportObj":{"cmd":"publish","topic":"devices/beta/messages/events/IMPACT_EMERGENCY=false","payload":"{\"size\":49.08919394567126,\"timeTillImpact\":57.049220217156815}","qos":1,"retain":false,"messageId":48866,"dup":false}} +6s
```

This resolves the unnecessary double nesting that occurred on message responses, which was a bug. 