### PR TITLE
fix(device provisioning): device enrollment has more optional properties

### DIFF
--- a/provisioning/service/src/interfaces.ts
+++ b/provisioning/service/src/interfaces.ts
@@ -78,17 +78,17 @@ export interface X509Attestation {
   /**
    * x509 certificate object which provides all information for a leaf certificate.
    */
-  clientCertificates: X509Certificates;
+  clientCertificates?: X509Certificates;
   /**
    * x509 certificate object which provides all information needed for a certificate
    * suitable for signing other certificates.
    */
-  signingCertificates: X509Certificates;
+  signingCertificates?: X509Certificates;
   /**
    * Primary and secondary CA reference.  These will be names rather than
    * actual certificates.
    */
-  caReferences: X509CAReferences;
+  caReferences?: X509CAReferences;
 }
 
 /**
@@ -149,7 +149,7 @@ export interface X509CertificateWithInfo {
    * This property is populated by the service from the information
    * provided by the certificate property of this object.
    */
-  info: X509CertificateInfo;
+  info?: X509CertificateInfo;
 }
 
 /**
@@ -166,7 +166,7 @@ export interface X509Certificates {
    * and authentication for an enrollment in the case that the primary is
    * revoked.
    */
-  secondary: X509CertificateWithInfo;
+  secondary?: X509CertificateWithInfo;
 }
 
 export interface X509CAReferences {
@@ -446,16 +446,16 @@ export interface EnrollmentGroup {
    * The IoT Hub that will be the destination of the provisioning for devices
    * associated with this object.
    */
-  iotHubHostName: string;
+  iotHubHostName?: string;
   /**
    * The initial twin document that will be created for devices upon their provisioning.
    */
-  initialTwin: InitialTwin;
+  initialTwin?: InitialTwin;
   /**
    * An opaque value suitable to uniquely identify a particular generation
    * of this object for use during a CRUD operation.
    */
-  etag: string;
+  etag?: string;
   /**
    * Indicates whether this object can be used as the basis for a device
    * provisioning.
@@ -464,12 +464,12 @@ export interface EnrollmentGroup {
   /**
    * The date and time that this object was created.
    */
-  createdDateTimeUtc: string;
+  createdDateTimeUtc?: string;
   /**
    * The date and time that this object was last updated.  This
    * could include an update or an actual registration.
    */
-  lastUpdatedDateTimeUtc: string;
+  lastUpdatedDateTimeUtc?: string;
 
   /**
    * The behavior when a device is re-provisioned to an IoT hub.
@@ -488,7 +488,7 @@ export interface EnrollmentGroup {
   /**
    * The list of names of IoT hubs the device(s) in this resource can be allocated to. It must be a subset of tenant level list of IoT hubs.
    */
-  iotHubs: string[];
+  iotHubs?: string[];
 
   /**
    * Custom allocation definition.


### PR DESCRIPTION
* fix(device provisioning): X509Attestation and children have optional properties

Not all parameters are required to create an enrollment group.

Actually this is a sufficient request:

```json
{
  enrollmentGroupId: 'first',
  attestation: {
    type: 'x509',
    x509: {
      signingCertificates: {
        primary: {
          certificate: fs.readFileSync(process.argv[3], 'utf-8').toString()
        }
      }
    }
  },
  provisioningStatus: 'disabled'
}
```

[Source](https://docs.microsoft.com/en-us/azure/iot-dps/quick-enroll-device-x509-node#create-the-enrollment-group-sample)

* fix(device provisioning): mark optional properties on EnrollmentGroup

<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected -->
