### PR TITLE
fix(azure-iot-device): security provider should deal with module SAS

### DIFF
--- a/device/core/src/sas_authentication_provider.ts
+++ b/device/core/src/sas_authentication_provider.ts
@@ -79,9 +79,12 @@ export class SharedAccessSignatureAuthenticationProvider extends EventEmitter im
     const sas: SharedAccessSignature = SharedAccessSignature.parse(sharedAccessSignature);
     const decodedUri = decodeURIComponent(sas.sr);
     const uriSegments = decodedUri.split('/');
+    const uriDeviceId = (uriSegments.length >= 3 && uriSegments[1] === 'devices') ? (uriSegments[2]) : null;
+    const uriModuleId = (uriSegments.length >= 5 && uriSegments[3] === 'modules') ? (uriSegments[4]) : null;
     const credentials: TransportConfig = {
       host: uriSegments[0],
-      deviceId: uriSegments[uriSegments.length - 1],
+      deviceId: uriDeviceId,
+      moduleId: uriModuleId,
       sharedAccessSignature: sharedAccessSignature
     };
 

--- a/device/core/test/_sas_authentication_provider_test.js
+++ b/device/core/test/_sas_authentication_provider_test.js
@@ -114,6 +114,15 @@ describe('SharedAccessSignatureAuthenticationProvider', function () {
         testCallback();
       });
     });
+
+    it('create a correct config when the sr contains a module', function (testCallback) {
+      var sharedAccessSignature = '"SharedAccessSignature sr=hubName.azure-devices.net/devices/deviceId/modules/module42&sig=s1gn4tur3&se=1454204843"';
+      var sasAuthProvider = SharedAccessSignatureAuthenticationProvider.fromSharedAccessSignature(sharedAccessSignature);
+      sasAuthProvider.getDeviceCredentials(function (err, creds) {
+        assert.strictEqual(creds.moduleId, 'module42')
+        testCallback();
+      });
+    });
   });
 
   describe('#stop', function () {


### PR DESCRIPTION
The SAS security provider should propagate through the moduleId if the SAS has one.

#657
