### PR TITLE
feat(multiple): add an option to set token renewal values for shared …

### DIFF
--- a/common/core/src/authentication_provider.ts
+++ b/common/core/src/authentication_provider.ts
@@ -26,4 +26,5 @@ export interface AuthenticationProvider {
   type: AuthenticationType;
   getDeviceCredentials(callback: Callback<TransportConfig>): void;
   getDeviceCredentials(): Promise<TransportConfig>;
-}
+  setTokenRenewalValues?(tokenValidTimeInSeconds: number, tokenRenewalMarginInSeconds: number): void;
+  }

--- a/device/core/devdoc/sak_authentication_provider_requirements.md
+++ b/device/core/devdoc/sak_authentication_provider_requirements.md
@@ -26,7 +26,7 @@ sakAuthProvider.on('newTokenAvailable', function (credentials) {
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_001: [** The `constructor` shall create the initial token value using the `credentials` parameter. **]**
 
-**SRS_NODE_SAK_AUTH_PROVIDER_16_011: [** The `constructor` shall throw an `ArgumentError` if the `tokenRenewalMarginInSeconds` is less than or equal `tokenValidTimeInSeconds`. **]**
+**SRS_NODE_SAK_AUTH_PROVIDER_16_011: [** The `constructor` shall throw an `ArgumentError` if the `tokenValidTimeInSeconds` is less than or equal `tokenRenewalMarginInSeconds`. **]**
 
 ## getDeviceCredentials(callback: (err: Error, credentials: TransportConfig) => void): void
 
@@ -51,6 +51,18 @@ sakAuthProvider.on('newTokenAvailable', function (credentials) {
 **SRS_NODE_SAK_AUTH_PROVIDER_16_012: [** The `stop` method shall clear the token renewal timer if it is running. **]**
 
 **SRS_NODE_SAK_AUTH_PROVIDER_16_013: [** The `stop` method shall simply return if the token renewal timer is not running. **]**
+
+## setTokenRenewalValues(tokenValidTimeInSeconds: number, tokenRenewalMarginInSeconds: number): void
+
+The `setTokenRenewalValues` method shall set the renewal values for token generation.  If the authentication provider has begun the periodic generation of tokens, this will cause a new token generation at the next tick.
+
+**SRS_NODE_SAK_AUTH_PROVIDER_06_001: [** The `setTokenRenewalValues` shall throw an `ArgumentError` if the `tokenRenewalMarginInSeconds` is less than or equal `tokenValidTimeInSeconds`. **]**
+
+**SRS_NODE_SAK_AUTH_PROVIDER_06_002: [** If there is no timer running when `setTokenRenewalValues` is invoked, there will NOT be a timer running when it returns.
+ **]**
+
+**SRS_NODE_SAK_AUTH_PROVIDER_06_003: [** If there is a timer running when `setTokenRenewalValues` is invoked it will cause a token renewal to happen almost immediately and cause the subsequent renewals to happen with as specified with the new values.
+ **]**
 
 # Generated Security Token
 

--- a/device/core/src/interfaces.ts
+++ b/device/core/src/interfaces.ts
@@ -124,6 +124,12 @@ export interface DeviceClientOptions extends X509 {
   productInfo?: string;
 
   /**
+   * Optional object with token renewal values.  Only use with authentication
+   * that uses pre shared keys.
+   */
+  tokenRenewal?: TokenRenewalValues;
+
+  /**
    * Optional object with options specific to the MQTT transport
    */
    mqtt?: MqttTransportOptions;
@@ -149,6 +155,16 @@ export interface BlobUploadCommonResponseStub {
     bodyAsText?: string;
   };
 }
+
+/**
+ * Structure used to pass down token renewal values for authentication that
+ * utilizes pre-shared keys.
+ */
+export interface TokenRenewalValues {
+  tokenValidTimeInSeconds: number;
+  tokenRenewalMarginInSeconds: number;
+}
+
 
 /**
  * Structure to mimic the RestError class from @azure/core-http

--- a/device/core/test/_device_client_test.js
+++ b/device/core/test/_device_client_test.js
@@ -91,7 +91,7 @@ describe('Device Client', function () {
   describe('#uploadToBlob', function() {
     /*Tests_SRS_NODE_DEVICE_CLIENT_16_037: [The `uploadToBlob` method shall throw a `ReferenceError` if `blobName` is falsy.]*/
     [undefined, null, ''].forEach(function (blobName) {
-      it('throws a ReferenceError if \'blobName\' is ' + blobName + '\'', function() {
+      it('throws a ReferenceError if \'blobName\' is \'' + blobName + '\'', function() {
         var client = new Client(new EventEmitter(), null, {});
         assert.throws(function() {
           client.uploadToBlob(blobName, new stream.Readable(), 42, function() {});
@@ -101,7 +101,7 @@ describe('Device Client', function () {
 
     /*Tests_SRS_NODE_DEVICE_CLIENT_16_038: [The `uploadToBlob` method shall throw a `ReferenceError` if `stream` is falsy.]*/
     [undefined, null, ''].forEach(function (stream) {
-      it('throws a ReferenceError if \'stream\' is ' + stream + '\'', function() {
+      it('throws a ReferenceError if \'stream\' is \'' + stream + '\'', function() {
         var client = new Client(new EventEmitter(), null, {});
         assert.throws(function() {
           client.uploadToBlob('blobName', stream, 42, function() {});
@@ -111,7 +111,7 @@ describe('Device Client', function () {
 
     /*Tests_SRS_NODE_DEVICE_CLIENT_16_039: [The `uploadToBlob` method shall throw a `ReferenceError` if `streamLength` is falsy.]*/
     [undefined, null, '', 0].forEach(function (streamLength) {
-      it('throws a ReferenceError if \'streamLength\' is ' + streamLength + '\'', function() {
+      it('throws a ReferenceError if \'streamLength\' is \'' + streamLength + '\'', function() {
         var client = new Client(new EventEmitter(), null, {});
         assert.throws(function() {
           client.uploadToBlob('blobName', new stream.Readable(), streamLength, function() {});
@@ -150,7 +150,7 @@ describe('Device Client', function () {
   describe('#getBlobSharedAccessSignature', function() {
     /*Tests_SRS_NODE_DEVICE_CLIENT_41_001: [The `getBlobSharedAccessSignature` method shall throw a `ReferenceError` if `blobName` is falsy.]*/
     [undefined, null, ''].forEach(function (blobName) {
-      it('throws a ReferenceError if \'blobName\' is ' + blobName + '\'', function() {
+      it('throws a ReferenceError if \'blobName\' is \'' + blobName + '\'', function() {
         var client = new Client(new EventEmitter(), null, {}, {});
         assert.throws(function() {
           client.getBlobSharedAccessSignature(blobName, function() {});
@@ -177,7 +177,7 @@ describe('Device Client', function () {
     it('calls the done callback with the upload parameters if the method call succeeded', function (done) {
       let fakeUploadParams = {
         fake: 'string'
-      };  
+      };
       class FakeFileUploadApi {
         constructor() {
           this.getBlobSharedAccessSignature = function (blobName, callback) {
@@ -198,7 +198,7 @@ describe('Device Client', function () {
   describe('#notifyBlobUploadStatus', function() {
     /*Tests_SRS_NODE_DEVICE_CLIENT_41_005: [The `notifyBlobUploadStatus` method shall throw a `ReferenceError` if `isSuccess` is falsy.]*/
     [undefined, null, ''].forEach(function (isSuccess) {
-    it('throws a ReferenceError if \'isSuccess\' is ' + isSuccess + '\'', function(done) {
+    it('throws a ReferenceError if \'isSuccess\' is \'' + isSuccess + '\'', function(done) {
       let statusCode = 1;
       let statusDescription = 'NaN';
       let correlationId = 'fakeCorrelationId';
@@ -215,7 +215,7 @@ describe('Device Client', function () {
 
     /*Tests_SRS_NODE_DEVICE_CLIENT_41_006: [The `notifyBlobUploadStatus` method shall throw a `ReferenceError` if `statusCode` is falsy but not the number 0.]*/
     [undefined, null, ''].forEach(function (statusCode) {
-    it('throws a ReferenceError if \'statusCode\' is ' + statusCode + '\'', function(done) {
+    it('throws a ReferenceError if \'statusCode\' is \'' + statusCode + '\'', function(done) {
       let isSuccess = 0;
       let statusDescription = 'NaN';
       let correlationId = 'fakeCorrelationId';
@@ -238,7 +238,7 @@ describe('Device Client', function () {
 
     /*Tests_SRS_NODE_DEVICE_CLIENT_41_007: [The `notifyBlobUploadStatus` method shall throw a `ReferenceError` if `statusDescription` is falsy but not an empty string.]*/
     [undefined, null, ''].forEach(function (statusDescription) {
-    it('throws a ReferenceError if \'statusDescription\' is ' + statusDescription + '\'', function(done) {
+    it('throws a ReferenceError if \'statusDescription\' is \'' + statusDescription + '\'', function(done) {
       let isSuccess = 0;
       let statusDescription = 'NaN';
       let correlationId = 'fakeCorrelationId';
@@ -255,7 +255,7 @@ describe('Device Client', function () {
 
     /*Tests_SRS_NODE_DEVICE_CLIENT_41_016: [The `notifyBlobUploadStatus` method shall throw a `ReferenceError` if `correlationId` is falsy.]*/
     [undefined, null, ''].forEach(function (correlationId) {
-      it('throws a ReferenceError if \'isSuccess\' is ' + correlationId + '\'', function(done) {
+      it('throws a ReferenceError if \'isSuccess\' is \'' + correlationId + '\'', function(done) {
         let isSuccess = 0;
         let statusCode = 1;
         let statusDescription = 'NaN';
@@ -282,7 +282,7 @@ describe('Device Client', function () {
         };
       };
       let client = new Client(new EventEmitter(), null, null, new FakeFileUploadApi());
-      client.notifyBlobUploadStatus(correlationId, isSuccess, statusCode, statusDescription, function(err) { 
+      client.notifyBlobUploadStatus(correlationId, isSuccess, statusCode, statusDescription, function(err) {
       assert.instanceOf(err, Error);
         done();
       });

--- a/device/transport/amqp/devdoc/device_amqp_requirements.md
+++ b/device/transport/amqp/devdoc/device_amqp_requirements.md
@@ -82,7 +82,7 @@ The `connect` method establishes a connection with the Azure IoT Hub instance.
 
 **SRS_NODE_DEVICE_AMQP_13_002: [** The `connect` method shall set the CA cert on the options object when calling the underlying connection object's connect method if it was supplied. **]**
 
-**SRS_NODE_DEVICE_AMQP_99_084: [** The `connect` method shall set the HTTPS agent on the options object when calling the underlying connection object's connect method if it was supplied. **]** 
+**SRS_NODE_DEVICE_AMQP_99_084: [** The `connect` method shall set the HTTPS agent on the options object when calling the underlying connection object's connect method if it was supplied. **]**
 
 **SRS_NODE_DEVICE_AMQP_41_001: [** The AMQP transport should use the productInfo string in the `options` object if present **]**
 
@@ -153,9 +153,16 @@ This method is deprecated. The `AmqpReceiver` object and pattern is going away a
 
 **SRS_NODE_DEVICE_AMQP_06_004: [** The AMQP transport should use the x509 settings passed in the `options` object to connect to the service if present.**]**
 
-**SRS_NODE_DEVICE_AMQP_16_053: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called while using token-based authentication. **]**
+**SRS_NODE_DEVICE_AMQP_16_053: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called with a cert option while using token-based authentication. **]**
 
+**SRS_NODE_DEVICE_AMQP_06_012: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication. **]**
+
+**SRS_NODE_DEVICE_AMQP_06_013: [** The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option.
+ **]**
+ 
 **SRS_NODE_DEVICE_AMQP_13_001: [** The `setOptions` method shall save the options passed in. **]**
+
+
 
 ### abandon(message, done)
 

--- a/device/transport/amqp/src/amqp.ts
+++ b/device/transport/amqp/src/amqp.ts
@@ -690,8 +690,20 @@ export class Amqp extends EventEmitter implements DeviceTransport {
       if (this._authenticationProvider.type === AuthenticationType.X509) {
         (this._authenticationProvider as X509AuthenticationProvider).setX509Options(options);
       } else {
-        /*Codes_SRS_NODE_DEVICE_AMQP_16_053: [The `setOptions` method shall throw an `InvalidOperationError` if the method is called while using token-based authentication.]*/
+        /*Codes_SRS_NODE_DEVICE_AMQP_16_053: [The `setOptions` method shall throw an `InvalidOperationError` if the method is called with a cert option while using token-based authentication.]*/
         throw new errors.InvalidOperationError('cannot set X509 options when using token-based authentication');
+      }
+    }
+
+    /* Codes_SRS_NODE_DEVICE_AMQP_06_012: [The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication.] */
+    if (options.tokenRenewal) {
+      if (this._authenticationProvider.type === AuthenticationType.X509) {
+        throw new errors.InvalidOperationError('cannot set token renewal options when using X509 authentication');
+      } else if (!this._authenticationProvider.setTokenRenewalValues) {
+        throw new errors.InvalidOperationError('can only set token renewal options when using pre-shared key authentication');
+      } else {
+        /* Codes_SRS_NODE_DEVICE_AMQP_06_013: [The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option.] */
+        this._authenticationProvider.setTokenRenewalValues(options.tokenRenewal.tokenValidTimeInSeconds, options.tokenRenewal.tokenRenewalMarginInSeconds);
       }
     }
 

--- a/device/transport/http/devdoc/http_requirements.md
+++ b/device/transport/http/devdoc/http_requirements.md
@@ -170,6 +170,10 @@ Host: <config.host>
 
 **SRS_NODE_DEVICE_HTTP_41_003: [** `productInfo` must be set before `http._ensureAgentString` is invoked for the first time **]**
 
+**SRS_NODE_DEVICE_HTTP_06_001: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication. **]**
+
+**SRS_NODE_DEVICE_HTTP_06_002: [** The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option. **]**
+
 ### abandon(message, done)
 
 **SRS_NODE_DEVICE_HTTP_RECEIVER_16_009: [**`abandon` shall construct an HTTP request using information supplied by the caller, as follows:

--- a/device/transport/http/src/http.ts
+++ b/device/transport/http/src/http.ts
@@ -342,6 +342,18 @@ export class Http extends EventEmitter implements DeviceTransport {
       }
     }
 
+    /* Codes_SRS_NODE_DEVICE_HTTP_06_001: [The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication.] */
+    if (options.tokenRenewal) {
+      if (this._authenticationProvider.type === AuthenticationType.X509) {
+        throw new errors.InvalidOperationError('cannot set token renewal options when using X509 authentication');
+      } else if (!this._authenticationProvider.setTokenRenewalValues) {
+        throw new errors.InvalidOperationError('can only set token renewal options when using pre-shared key authentication');
+      } else {
+        /* Codes_SRS_NODE_DEVICE_HTTP_06_002: [The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option.] */
+        this._authenticationProvider.setTokenRenewalValues(options.tokenRenewal.tokenValidTimeInSeconds, options.tokenRenewal.tokenRenewalMarginInSeconds);
+      }
+    }
+
     /*Codes_SRS_NODE_DEVICE_HTTP_16_010: [`setOptions` should not throw if `done` has not been specified.]*/
     /*Codes_SRS_NODE_DEVICE_HTTP_16_005: [If `done` has been specified the `setOptions` method shall call the `done` callback with no arguments when successful.]*/
     /*Codes_SRS_NODE_DEVICE_HTTP_16_009: [If `done` has been specified the `setOptions` method shall call the `done` callback with a standard javascript `Error` object when unsuccessful.]*/

--- a/device/transport/mqtt/devdoc/mqtt_requirements.md
+++ b/device/transport/mqtt/devdoc/mqtt_requirements.md
@@ -215,6 +215,11 @@ The `reject` method is there for compatibility purposes with other transports bu
 
 **_SRS_NODE_DEVICE_MQTT_41_003: [** `productInfo` must be set before `mqtt._ensureAgentString` is invoked for the first time **]**
 
+**SRS_NODE_DEVICE_MQTT_06_001: [** The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication.
+ **]**
+
+**SRS_NODE_DEVICE_MQTT_06_002: [** The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option.
+ **]**
 
 ### onDeviceMethod(methodName, methodCallback)
 

--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -499,6 +499,18 @@ export class Mqtt extends EventEmitter implements DeviceTransport {
       }
     }
 
+    /* Codes_SRS_NODE_DEVICE_MQTT_06_001: [The `setOptions` method shall throw an `InvalidOperationError` if the method is called with token renewal options while using using cert or non renewal authentication.] */
+    if (options.tokenRenewal) {
+      if (this._authenticationProvider.type === AuthenticationType.X509) {
+        throw new errors.InvalidOperationError('cannot set token renewal options when using X509 authentication');
+      } else if (!this._authenticationProvider.setTokenRenewalValues) {
+        throw new errors.InvalidOperationError('can only set token renewal options when using pre-shared key authentication');
+      } else {
+        /* Codes_SRS_NODE_DEVICE_MQTT_06_002: [The authentication providers `setTokenRenewalValues` method shall be invoked with the values provided in the tokenRenewal option.] */
+        this._authenticationProvider.setTokenRenewalValues(options.tokenRenewal.tokenValidTimeInSeconds, options.tokenRenewal.tokenRenewalMarginInSeconds);
+      }
+    }
+
     this._mqtt.setOptions(options);
 
     if (!options.cert) {


### PR DESCRIPTION
…access key authentication

Added the option at the device client level.  Adjusted the transports to validate the options.
Adjusted the SAK authentication provider to have a new method to set the renewal values.  If the
authentication provider is NOT already "running" then just set the values.  Otherwise set the values
and cause a new token event available to be emitted.
