### PR TITLE
chore(multiple): replace fake keys in tests with generated uuids

### DIFF
--- a/device/core/package.json
+++ b/device/core/package.json
@@ -27,6 +27,7 @@
     "sinon": "^7.4.1",
     "source-map-support": "^0.5.16",
     "ts-node": "^8.6.2",
+    "uuid": "^3.3.2",
     "tslint": "^5.18.0",
     "typescript": "2.9.2"
   },

--- a/device/core/test/_internal_client_test.js
+++ b/device/core/test/_internal_client_test.js
@@ -5,6 +5,7 @@
 
 var assert = require('chai').assert;
 var sinon = require('sinon');
+var uuid = require('uuid');
 var fs = require('fs');
 var EventEmitter = require('events').EventEmitter;
 var SimulatedHttp = require('./http_simulated.js');
@@ -218,7 +219,7 @@ var ModuleClient = require('../lib/module_client').ModuleClient;
           } else {
             done();
           }
-        }); 
+        });
       });
     });
 
@@ -672,7 +673,7 @@ describe('Over simulated HTTPS', function () {
         deviceId: deviceId,
         authentication: {
           symmetricKey: {
-            primaryKey: 'key=='
+            primaryKey: uuid.v4()
           }
         }
       });

--- a/service/samples/package.json
+++ b/service/samples/package.json
@@ -10,6 +10,6 @@
   },
   "dependencies": {
     "azure-iothub": "1.12.0",
-    "azure-storage": "^2.8.1"
+    "azure-storage": "^2.10.2"
   }
 }

--- a/service/test/_registry_test.js
+++ b/service/test/_registry_test.js
@@ -5,6 +5,7 @@
 
 var assert = require('chai').assert;
 var sinon = require('sinon');
+var uuid = require('uuid');
 var endpoint = require('azure-iot-common').endpoint;
 var errors = require('azure-iot-common').errors;
 var Registry = require('../lib/registry.js').Registry;
@@ -1028,16 +1029,17 @@ describe('Registry', function () {
       /* Tests_SRS_NODE_IOTHUB_REGISTRY_06_031: [A device information with an authentication object that doesn't contain the x509Thumbprint property will be normalized with a `type` property with value "sas".] */
       /* Tests_SRS_NODE_IOTHUB_REGISTRY_06_030: [A device information with an authentication object that contains the x509Thumbprint property with at least one of `primaryThumbprint` or `secondaryThumbprint` sub-properties will be normalized with a `type` property with value "selfSigned".] */
       it('constructs a valid HTTP request', function(testCallback) {
+        var fakeKey = uuid.v4();
         var addedDevices = [
           { deviceId: 'devicezero'},
           { deviceId: 'deviceone', authentication: { x509Thumbprint: { primaryThumbprint: 'abc' }}},
-          { deviceId: 'devicetwo', authentication: { symmetricKey: { primaryKey: 'abc' }}},
+          { deviceId: 'devicetwo', authentication: { symmetricKey: { primaryKey: fakeKey }}},
           { deviceId: 'devicethree', authentication: { type: 'certificateAuthority' }},
         ];
         var sentBody = [
           { id: 'devicezero', importMode:'create', authentication: { type: 'sas', symmetricKey: { primaryKey: '', secondaryKey: '' }}},
           { id: 'deviceone', importMode:'create', authentication: { type: 'selfSigned', x509Thumbprint: { primaryThumbprint: 'abc' }}},
-          { id: 'devicetwo', importMode:'create', authentication: { type: 'sas', symmetricKey: { primaryKey: 'abc' }}},
+          { id: 'devicetwo', importMode:'create', authentication: { type: 'sas', symmetricKey: { primaryKey: fakeKey }}},
           { id: 'devicethree', importMode:'create', authentication: { type: 'certificateAuthority' }},
         ];
         var fakeHttpHelper = {

--- a/vsts/node-nightly-df.yaml
+++ b/vsts/node-nightly-df.yaml
@@ -61,7 +61,7 @@ phases:
   displayName: Windows Build - Node 8
   condition: succeededOrFailed()
   queue:
-    name: Hosted
+    name: Hosted VS2017
   steps:
   - task: NodeTool@0
     displayName: 'Use Node 8.10.x'


### PR DESCRIPTION
sdl detected embedded keys in code.  That was indeed true but they were only fake keys for fake
devices.  Regardless, replaced them with generated uuids.

