### PR TITLE
fix(azure-iot-device): lint error on simple sample

### DIFF
--- a/device/samples/package.json
+++ b/device/samples/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "npmlockrefresh": "npm i --package-lock-only",
-    "lint": "jshint --show-non-errors ."
+    "lint": "jshint --show-non-errors .",
+    "ci": "npm run lint"
   }
 }

--- a/device/samples/simple_sample_device.js
+++ b/device/samples/simple_sample_device.js
@@ -49,7 +49,7 @@ function generateMessage () {
 }
 
 function errorCallback (err) {
-  (err) => console.error(err.message);
+  console.error(err.message);
 }
 
 function connectCallback () {
@@ -61,7 +61,7 @@ function connectCallback () {
     client.sendEvent(message, printResultFor('send'));
   }, 2000);
 
-};
+}
 
 // fromConnectionString must specify a transport constructor, coming from any transport package.
 let client = Client.fromConnectionString(deviceConnectionString, Protocol);


### PR DESCRIPTION
this is a patch to the PR #819 that added the connect events. There were linting errors in the sample that went uncaught. Those are now patched. 

Additionally this adds the ci script to device/samples, to run the linter on check-in, thus preventing this issue in the future.