### PR TITLE
fix(azure-iothub): schedule deviceMethod and updateTwin need to speci…

### DIFF
--- a/service/src/job_client.ts
+++ b/service/src/job_client.ts
@@ -16,6 +16,8 @@ import { TripleValueCallback, tripleValueCallbackToPromise } from 'azure-iot-com
 // tslint:disable-next-line:no-var-requires
 const packageJson = require('../package.json');
 
+const defaultMaxExecutionTimeInSeconds = 3600;
+
 export type JobType = 'scheduleUpdateTwin' | 'scheduleDeviceMethod';
 export type JobStatus = 'queued' | 'scheduled' | 'running' | 'cancelled' | 'finished';
 
@@ -183,8 +185,8 @@ export class JobClient {
           throw new TypeError('The callback must be the last parameter');
         } else {
           _callback = jobStartTime;
-          jobStartTime = null;
-          maxExecutionTimeInSeconds = null;
+          jobStartTime = new Date();
+          maxExecutionTimeInSeconds = defaultMaxExecutionTimeInSeconds;
         }
         /*Codes_SRS_NODE_JOB_CLIENT_16_019: [If `maxExecutionTimeInSeconds` is a function, `maxExecutionTimeInSeconds` shall be considered the callback and a `TypeError` shall be thrown if `_callback` is not `undefined`.]*/
       } else if (typeof maxExecutionTimeInSeconds === 'function') {
@@ -192,7 +194,7 @@ export class JobClient {
           throw new TypeError('The callback must be the last parameter');
         } else {
           _callback = maxExecutionTimeInSeconds;
-          maxExecutionTimeInSeconds = null;
+          maxExecutionTimeInSeconds = defaultMaxExecutionTimeInSeconds;
         }
       }
 
@@ -286,8 +288,8 @@ export class JobClient {
           throw new TypeError('The callback must be the last parameter');
         } else {
           _callback = jobStartTime;
-          jobStartTime = null;
-          maxExecutionTimeInSeconds = null;
+          jobStartTime = new Date();
+          maxExecutionTimeInSeconds = defaultMaxExecutionTimeInSeconds;
         }
         /*Codes_SRS_NODE_JOB_CLIENT_16_025: [If `maxExecutionTimeInSeconds` is a function, `maxExecutionTimeInSeconds` shall be considered the callback and a `TypeError` shall be thrown if `_callback` is not `undefined`.]*/
       } else if (typeof maxExecutionTimeInSeconds === 'function') {
@@ -295,7 +297,7 @@ export class JobClient {
           throw new TypeError('The callback must be the last parameter');
         } else {
           _callback = maxExecutionTimeInSeconds;
-          maxExecutionTimeInSeconds = null;
+          maxExecutionTimeInSeconds = defaultMaxExecutionTimeInSeconds;
         }
       }
 

--- a/service/test/_job_client_test.js
+++ b/service/test/_job_client_test.js
@@ -11,6 +11,8 @@ var JobClient = require('../dist/job_client.js').JobClient;
 var DeviceMethod = require('../dist/device_method.js').DeviceMethod;
 var Query = require('../dist/query.js').Query;
 
+const defaultMaxExecutionTimeInSeconds = 3600;
+
 describe('JobClient', function() {
   function testFalsyArg (fn, badArgName, badArgValue, args) {
     it('throws a ReferenceError when ' + badArgName + ' is \'' + badArgValue + '\'', function() {
@@ -360,6 +362,43 @@ describe('JobClient', function() {
       assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, fakeMaxExecutionTime);
     });
 
+    it('sends default start time and execution time if parameters not specified', function() {
+      this.clock = sinon.useFakeTimers();
+      var fakeTimeNowString = (new Date()).toISOString();
+      var fakeJobId = 'id';
+      var fakeQuery = 'SELECT * FROM devices';
+      var fakeMethodParams = {
+        methodName: 'name',
+        payload: { foo: 'bar' },
+        responseTimeoutInSeconds: 15
+      };
+
+      var fakeRestApiClient = { executeApiCall: sinon.stub() };
+
+      var client = new JobClient(fakeRestApiClient);
+      client.scheduleDeviceMethod(fakeJobId, fakeQuery, fakeMethodParams, function() {});
+      this.clock.restore();
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].startTime, fakeTimeNowString);
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, defaultMaxExecutionTimeInSeconds);
+    });
+
+    it('sends default max execution time if parameter not specified', function() {
+      var fakeJobId = 'id';
+      var fakeQuery = 'SELECT * FROM devices';
+      var fakeMethodParams = {
+        methodName: 'name',
+        payload: { foo: 'bar' },
+        responseTimeoutInSeconds: 15
+      };
+
+      var fakeStartTime = new Date(Date.now() + 3600);
+      var fakeRestApiClient = { executeApiCall: sinon.stub() };
+
+      var client = new JobClient(fakeRestApiClient);
+      client.scheduleDeviceMethod(fakeJobId, fakeQuery, fakeMethodParams, fakeStartTime, function() {});
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, defaultMaxExecutionTimeInSeconds);
+    });
+
     /*Tests_SRS_NODE_JOB_CLIENT_16_018: [If `jobStartTime` is a function, `jobStartTime` shall be considered the callback and a `TypeError` shall be thrown if `maxExecutionTimeInSeconds` and/or `done` are not `undefined`.]*/
     testCallback('scheduleDeviceMethod', ['jobId', 'query', {methodName: 'name'}]);
     /*Tests_SRS_NODE_JOB_CLIENT_16_019: [If `maxExecutionTimeInSeconds` is a function, `maxExecutionTimeInSeconds` shall be considered the callback and a `TypeError` shall be thrown if `done` is not `undefined`.]*/
@@ -446,6 +485,43 @@ describe('JobClient', function() {
       assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].queryCondition, fakeQuery);
       assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].startTime, new Date(fakeStartTime).toISOString());
       assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, fakeMaxExecutionTime);
+    });
+
+    it('sends default start time and execution time if parameters not specified', function() {
+      this.clock = sinon.useFakeTimers();
+      var fakeTimeNowString = (new Date()).toISOString();
+      var fakeJobId = 'id';
+      var fakeQuery = 'SELECT * FROM devices';
+      var fakePatch = {
+        tags: {
+          key: 'value'
+        }
+      };
+
+      var fakeRestApiClient = { executeApiCall: sinon.stub() };
+
+      var client = new JobClient(fakeRestApiClient);
+      client.scheduleTwinUpdate(fakeJobId, fakeQuery, fakePatch, function() {});
+      this.clock.restore();
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].startTime, fakeTimeNowString);
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, defaultMaxExecutionTimeInSeconds);
+    });
+
+    it('sends default max execution time if parameter not specified', function() {
+      var fakeJobId = 'id';
+      var fakeQuery = 'SELECT * FROM devices';
+      var fakePatch = {
+        tags: {
+          key: 'value'
+        }
+      };
+
+      var fakeStartTime = new Date(Date.now() + 3600);
+      var fakeRestApiClient = { executeApiCall: sinon.stub() };
+
+      var client = new JobClient(fakeRestApiClient);
+      client.scheduleTwinUpdate(fakeJobId, fakeQuery, fakePatch, fakeStartTime, function() {});
+      assert.strictEqual(fakeRestApiClient.executeApiCall.args[0][3].maxExecutionTimeInSeconds, defaultMaxExecutionTimeInSeconds);
     });
 
     /*Tests_SRS_NODE_JOB_CLIENT_16_024: [If `jobStartTime` is a function, `jobStartTime` shall be considered the callback and a `TypeError` shall be thrown if `maxExecutionTimeInSeconds` and/or `done` are not `undefined`.]*/


### PR DESCRIPTION
…fy defaults when arguments not supplied

Both methods were sending null for the values if the arguments to the methods were not supplied.
The service requires actual values.  Supplied Date.now and 3600 as defaults.

fix #847

