### PR TITLE
chore(azure-iot-device): proxy support sample

### DIFF
--- a/device/samples/device_through_proxy.js
+++ b/device/samples/device_through_proxy.js
@@ -1,0 +1,104 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+'use strict';
+
+// !IMPORTANT! This sample only pertains to HTTPS Proxy, via the HTTP Transport, MQTTWS Transport, and AMQPWS Transport.
+
+//
+
+
+// Uncomment one of these transports and then change it in fromConnectionString to test other transports
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
+const Client = require('azure-iot-device').Client;
+const Message = require('azure-iot-device').Message;
+
+// Using HTTPS Proxy Agent
+const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
+
+// String containing Hostname, Device Id & Device Key in the following formats:
+//  "HostName=<iothub_host_name>;DeviceId=<device_id>;SharedAccessKey=<device_key>"
+const deviceConnectionString = process.env.DEVICE_CONNECTION_STRING;
+let sendInterval;
+
+function disconnectHandler () {
+  clearInterval(sendInterval);
+  client.removeAllListeners();
+  client.open().catch((err) => {
+    console.error(err.message);
+  });
+}
+
+// The AMQP and HTTP transports have the notion of completing, rejecting or abandoning the message.
+// For example, this is only functional in AMQP and HTTP:
+// client.complete(msg, printResultFor('completed'));
+// If using MQTT calls to complete, reject, or abandon are no-ops.
+// When completing a message, the service that sent the C2D message is notified that the message has been processed.
+// When rejecting a message, the service that sent the C2D message is notified that the message won't be processed by the device. the method to use is client.reject(msg, callback).
+// When abandoning the message, IoT Hub will immediately try to resend it. The method to use is client.abandon(msg, callback).
+// MQTT is simpler: it accepts the message by default, and doesn't support rejecting or abandoning a message.
+function messageHandler (msg) {
+  console.log('Id: ' + msg.messageId + ' Body: ' + msg.data);
+  client.complete(msg, printResultFor('completed'));
+}
+
+function generateMessage () {
+  const windSpeed = 10 + (Math.random() * 4); // range: [10, 14]
+  const temperature = 20 + (Math.random() * 10); // range: [20, 30]
+  const humidity = 60 + (Math.random() * 20); // range: [60, 80]
+  const data = JSON.stringify({ deviceId: 'myFirstDevice', windSpeed: windSpeed, temperature: temperature, humidity: humidity });
+  const message = new Message(data);
+  message.properties.add('temperatureAlert', (temperature > 28) ? 'true' : 'false');
+  return message;
+}
+
+function errorCallback (err) {
+  console.error(err.message);
+}
+
+function connectCallback () {
+  console.log('Client connected');
+  // Create a message and send it to the IoT Hub every two seconds
+  sendInterval = setInterval(() => {
+    const message = generateMessage();
+    console.log('Sending message: ' + message.getData());
+    client.sendEvent(message, printResultFor('send'));
+  }, 2000);
+
+}
+
+// Create Proxy Agent
+// TODO: You need to change this to match the endpoint of your proxy server.
+const proxy = "http://localhost:8888/";
+let options = url.parse(proxy);
+var agent = new HttpsProxyAgent(options);
+
+// fromConnectionString must specify a transport constructor, coming from any transport package.
+let client = Client.fromConnectionString(deviceConnectionString, Protocol);
+// MQTTWS (MQTT over Websocket)
+client.setOptions({mqtt: {webSocketAgent: agent}})
+// AMQPWS (AMQP over Websocket)
+// client.setOptions({amqp: {agent: agent}})
+// HTTP
+// client.setOptions({http: {webSocketAgent: agent}})
+client.on('connect', connectCallback);
+client.on('error', errorCallback);
+client.on('disconnect', disconnectHandler);
+client.on('message', messageHandler);
+
+client.open()
+.catch(err => {
+  console.error('Could not connect: ' + err.message);
+});
+
+// Helper function to print results in the console
+function printResultFor(op) {
+  return function printResult(err, res) {
+    if (err) console.log(op + ' error: ' + err.toString());
+    if (res) console.log(op + ' status: ' + res.constructor.name);
+  };
+}

--- a/device/samples/device_through_proxy.js
+++ b/device/samples/device_through_proxy.js
@@ -5,9 +5,6 @@
 
 // !IMPORTANT! This sample only pertains to HTTPS Proxy, via the HTTP Transport, MQTTWS Transport, and AMQPWS Transport.
 
-//
-
-
 // Uncomment one of these transports and then change it in fromConnectionString to test other transports
 // const Protocol = require('azure-iot-device-amqp').AmqpWs;
 // const Protocol = require('azure-iot-device-http').Http;
@@ -80,11 +77,11 @@ var agent = new HttpsProxyAgent(options);
 // fromConnectionString must specify a transport constructor, coming from any transport package.
 let client = Client.fromConnectionString(deviceConnectionString, Protocol);
 // MQTTWS (MQTT over Websocket)
-client.setOptions({mqtt: {webSocketAgent: agent}})
+client.setOptions({mqtt: {webSocketAgent: agent}});
 // AMQPWS (AMQP over Websocket)
-// client.setOptions({amqp: {agent: agent}})
+// client.setOptions({amqp: {agent: agent}});
 // HTTP
-// client.setOptions({http: {webSocketAgent: agent}})
+// client.setOptions({http: {webSocketAgent: agent}});
 client.on('connect', connectCallback);
 client.on('error', errorCallback);
 client.on('disconnect', disconnectHandler);

--- a/device/samples/package.json
+++ b/device/samples/package.json
@@ -11,6 +11,7 @@
     "azure-iot-device-http": "1.13.0",
     "azure-iot-device-mqtt": "1.15.0",
     "es5-shim": "^4.5.12",
+    "https-proxy-agent": "^5.0.0",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/doc/device_client.md
+++ b/doc/device_client.md
@@ -1,0 +1,32 @@
+# Azure IoT Device Client Library
+
+The Azure IoT Device Client Library provides an efficient and well tested API for connecting and using devices with the Azure IoT Hub.
+
+## client.setOptions(options, [callback])
+
+Used directly after creating the Device Client to set options on the client. These should not be dynamically altered during runtime of the device client.
+
+### Available Options
+
+- `ca`: Public certificate in PEM form for certificate authority being used by the Hub service.  This is the CA that the hub is using to secure TLS connections and the client validates the connection using this public cert in order to validate the identity of the hub.  If you are connecting to an Azure IoT Hub inside of an Azure data center, you do not need to set this.  If you are connecting to some other hub (e.g. an Edge Hub), then you may need to set this to the server cert that the hub uses for TLS.
+- `keepalive`: Keepalive interval in numeric format (seconds). This controls the keepalive ping for MQTT specifically. If you are using AMQP or HTTP, this will do nothing.
+- `productInfo`: Custom user defined information to be appended to existing User Agent information. The User Agent Identification information is used predominantly by Microsoft internally for identifying metadata related to Device Client usage for Azure IoT.
+- `modelId`: !!Digital Twin Use Only!! String used in MQTT username setting the Digital Twin modelId.
+- `tokenRenewal`: Optional object with token renewal values.  Only use with authentication that uses pre shared keys.
+- `mqtt`: Options specific to the MQTT transport
+    - `webSocketAgent`: [Agent]{@link https://nodejs.org/api/https.html#https_class_https_agent} object to use with MQTT-WS connections. Can be used for tunneling proxies.
+- `http`: Options specific to the HTTP transport
+    - `agent`: [Agent]{@link https://nodejs.org/api/https.html#https_class_https_agent} object to use with HTTP connections. Can be used for tunneling proxies.
+    - `receivePolicy`: Configuration parameters to use for receive polling.
+        - `interval`: Interval **in seconds** at which the Azure IoT hub is going to be polled.
+        - `at`: Use this option to configure the receiver to receive only once at a specific time.
+        - `cron`: Use a cron-formatted string.
+        - `manualPolling`: Does not poll and instead rely on the user calling the `receive` method.
+        - `drain`: Boolean indicating whether only one message should be received all messages should be drained.
+- `amqp`: Options specific to the AMQP transport
+    - `webSocketAgent`: [Agent]{@link https://nodejs.org/api/https.html#https_class_https_agent} object to use with AMQP-WS connections. Can be used for tunneling proxies.
+- `cert`: X509 Certificate.
+- `key`: Key associated with the X509 certificate.
+- `passphrase`: Passphrase used to decode the key associated with the X509 certificate.
+- `clientCertEngine`: Name of an OpenSSL engine which can provide the client certificate.
+

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,8 @@
 
 The Azure IoT Node.js SDK enables developers to create IoT solutions written in Node.js for the Azure IoT platform. It is composed of the following client libraries:
 
-* **Device Client Library**: to connect devices and IoT Edge modules to Azure IoT Hub. [API Reference][node-api-device-reference]
-  * **Note:** IoT Edge for Node.js is scoped to Linux containers & devices only. [Learn more](https://techcommunity.microsoft.com/t5/internet-of-things/linux-modules-with-azure-iot-edge-on-windows-10-iot-enterprise/ba-p/1407066) about using Linux containers for IoT edge on Windows devices. 
+* **Device Client Library**: to connect devices and IoT Edge modules to Azure IoT Hub. [API Reference][node-api-device-reference] | [README](./doc/device_client.md)
+  * **Note:** IoT Edge for Node.js is scoped to Linux containers & devices only. [Learn more](https://techcommunity.microsoft.com/t5/internet-of-things/linux-modules-with-azure-iot-edge-on-windows-10-iot-enterprise/ba-p/1407066) about using Linux containers for IoT edge on Windows devices.
 * **Service Client Library**: enables developing back-end applications making use of Azure IoT Hub. [API Reference][node-api-service-reference]
 * **Provisioning Device Client Library**: to connect devices to the Azure IoT Provisioning Service. [API Reference][node-api-prov-device-reference]
 * **Provisioning Service Client Library**: enables developing back-end applications making use of the Azure IoT Provisioning Service. [API Reference][node-api-prov-service-reference]
@@ -37,7 +37,7 @@ The Azure IoT Node.js SDK enables developers to create IoT solutions written in 
 
 # npm Package List
 
-**Azure IoT Hub Device Client Libraries**
+**Azure IoT Hub [Device Client Libraries](./doc/device_client.md)**
 
 | Name            | npm package                                                                                                |
 |-----------------|------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
This PR is in conjunction with https://github.com/Azure/azure-iot-sdk-node/pull/865, where this PR is solely for the new Proxy Example Code. This provides clarity on how to use our device client with a proxy server over HTTP, MQTTWS, and AMQPWS.