### PR TITLE
fix(azure-iot-mqtt-base): avoid calling mqtt.js functions on undefined mqttClient

### DIFF
--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -462,12 +462,17 @@ export class MqttBase extends EventEmitter {
   }
 
   private _disconnectClient(forceDisconnect: boolean, callback: () => void): void {
-    debug('removing all listeners');
-    this._mqttClient.removeAllListeners();
-    debug('adding null error listener');
-    this._mqttClient.on('error', this._nullErrorCallback);
-    /* Codes_SRS_NODE_COMMON_MQTT_BASE_16_001: [The disconnect method shall call the done callback when the connection to the server has been closed.] */
-    this._mqttClient.end(forceDisconnect, callback);
+    if (this._mqttClient) {
+      debug('removing all listeners');
+      this._mqttClient.removeAllListeners();
+      debug('adding null error listener');
+      this._mqttClient.on('error', this._nullErrorCallback);
+      /* Codes_SRS_NODE_COMMON_MQTT_BASE_16_001: [The disconnect method shall call the done callback when the connection to the server has been closed.] */
+      this._mqttClient.end(forceDisconnect, callback);
+    } else {
+      debug('mqttClient is undefined');
+      process.nextTick(callback);
+    }
   }
 
   private _errorCallback(err: Error): void {

--- a/common/transport/mqtt/test/_mqtt_base_test.js
+++ b/common/transport/mqtt/test/_mqtt_base_test.js
@@ -272,6 +272,18 @@ describe('MqttBase', function () {
       });
       fakeMqtt.emit('connect');
     });
+
+    it('does not fail if _mqttClient is undefined', function (testCallback) {
+      var fakeMqtt = new FakeMqtt();
+      var mqttBase = new MqttBase(fakeMqtt);
+      mqttBase.connect(fakeConfig, function () {
+        mqttBase._mqttClient = undefined;
+        mqttBase.disconnect(function () {
+          testCallback();
+        });
+      });
+      fakeMqtt.emit('connect');
+    });
   });
 
   describe('#publish', function () {


### PR DESCRIPTION
fix #931

If `MqttBase` is in the `connecting` state and a state transition to `disconnecting` is initiated before `_mqttClient` is assigned a value, `removeAllListeners()` gets called on `undefined`, which causes a `TypeError` to be thrown. This PR fixes that problem.