### PR TITLE
feat(azure-iot-common): log when a NoRetry policy is used

### DIFF
--- a/common/core/src/retry_policy.ts
+++ b/common/core/src/retry_policy.ts
@@ -3,6 +3,9 @@
 
 'use strict';
 
+import * as dbg from 'debug';
+const debug = dbg('azure-iot-common:RetryPolicy');
+
 import { ErrorFilter, DefaultErrorFilter } from './retry_error_filter';
 
 /**
@@ -156,6 +159,10 @@ export class ExponentialBackOffWithJitter implements RetryPolicy {
  * @implements {RetryPolicy}
  */
 export class NoRetry implements RetryPolicy {
+  constructor() {
+    debug('An instance of NoRetry policy has been created. The client using this policy will not perform any retries on disconnection.');
+  }
+  
   /**
    * This will always return -1 as no retry is desired.
    *


### PR DESCRIPTION
This is an ask from CSS to quickly identify when a customer is using a `NoRetry` policy. 

.NET PR on the same issue: https://github.com/Azure/azure-iot-sdk-csharp/pull/1763