### PR TITLE
feat(azure-iot-common): log when a NoRetry policy is used

### DIFF
--- a/common/core/src/retry_operation.ts
+++ b/common/core/src/retry_operation.ts
@@ -24,6 +24,9 @@ export class RetryOperation {
    * @param {number} maxTimeout  The maximum timeout for this operation, after which no retry will be attempted.
    */
   constructor (policy: RetryPolicy, maxTimeout: number) {
+    if (policy && policy.constructor && policy.constructor.name === 'NoRetry') {
+      debug('A RetryOperation is being used with a NoRetry policy. The operation will not be retried on failure.');
+    }
     this._policy = policy;
     this._maxTimeout = maxTimeout;
   }

--- a/common/core/test/_retry_operation_test.js
+++ b/common/core/test/_retry_operation_test.js
@@ -8,6 +8,7 @@ var sinon = require('sinon');
 
 var errors = require('../dist/errors.js');
 var RetryOperation = require('../dist/retry_operation.js').RetryOperation;
+var NoRetry = require('../dist/retry_policy.js').NoRetry;
 
 describe('RetryOperation', function () {
   describe('retry', function () {
@@ -86,6 +87,19 @@ describe('RetryOperation', function () {
       }, function (finalErr, finalResult) {
         assert.isNotOk(finalErr);
         assert.strictEqual(finalResult, testResult);
+        testCallback();
+      });
+    });
+
+    it('does not retry if NoRetry policy is used', function (testCallback) {
+      var testError = new Error('fake timeout that shall not be retried');
+      var actualOperation = sinon.stub().callsArgWith(0, testError);
+
+      var testOperation = new RetryOperation(new NoRetry(), 1);
+      testOperation.retry(function (callback) {
+        actualOperation(callback);
+      }, function (finalErr) {
+        assert.strictEqual(actualOperation.callCount, 1);
         testCallback();
       });
     });


### PR DESCRIPTION
This is an ask from CSS to quickly identify when a customer is using a `NoRetry` policy. 

.NET PR on the same issue: https://github.com/Azure/azure-iot-sdk-csharp/pull/1763