### PR TITLE
[DON'T REVIEW] fix: 🐛 Support US Government cloud for AAD authentication

### DIFF
--- a/common/core/common.d.ts
+++ b/common/core/common.d.ts
@@ -26,3 +26,4 @@ export interface Receiver extends EventEmitter {
 }
 
 export { TransportConfig, X509 } from './dist/authorization';
+export { IoTHubTokenScopes } from './dist/token_scopes';

--- a/common/core/common.js
+++ b/common/core/common.js
@@ -37,5 +37,6 @@ module.exports = {
   NoErrorCallback: require('./dist/promise_utils').NoErrorCallback,
   DoubleValueCallback: require('./dist/promise_utils').DoubleValueCallback,
   TripleValueCallback: require('./dist/promise_utils').TripleValueCallback,
-  HttpResponseCallback: require('./dist/promise_utils').HttpResponseCallback
+  HttpResponseCallback: require('./dist/promise_utils').HttpResponseCallback,
+  IoTHubTokenScopes: require('./dist/token_scopes').IoTHubTokenScopes
 };

--- a/common/core/src/token_scopes.ts
+++ b/common/core/src/token_scopes.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+export enum IoTHubTokenScopes {
+    /**
+     * Token scope used for any cloud other than Azure US Government cloud. Used by default.
+     */
+    IOT_HUB_PUBLIC_SCOPE = 'https://iothubs.azure.net/.default',
+
+    /**
+     * Token scope for Azure US Government cloud.
+     */
+    IOT_HUB_US_GOVERNMENT_SCOPE = 'https://iothubs.azure.us/.default'
+}

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -111,14 +111,11 @@ export class RestApiClient {
     - User-Agent: <version string>]*/
     let httpHeaders: any = headers || {};
     if (this._config.tokenCredential) {
-      let accessToken = this.getToken();
-      Promise.resolve(accessToken).then((value) => {
-        if (value) {
-          httpHeaders.Authorization = value;
-          this.executeBody(requestBody, httpHeaders, headers, method, path, timeout, requestOptions, done);
-        } else {
-            throw new Error('AccessToken creation failed');
-        }
+      this.getToken().then((accessToken) => {
+        httpHeaders.Authorization = accessToken;
+        this.executeBody(requestBody, httpHeaders, headers, method, path, timeout, requestOptions, done);
+      }).catch((err) => {
+        done(err);
       });
     } else {
       if (this._config.sharedAccessSignature) {
@@ -130,7 +127,7 @@ export class RestApiClient {
 
   /**
    * @method             module:azure-iothub.RestApiClient.updateSharedAccessSignature
-   * @description        Updates the shared access signature used to authentify API calls.
+   * @description        Updates the shared access signature used to authenticate API calls.
    *
    * @param  {string}          sharedAccessSignature  The new shared access signature that should be used.
    *
@@ -175,11 +172,7 @@ export class RestApiClient {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
       this._accessToken = await this._config.tokenCredential.getToken(this._config.tokenScope || IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE) as any;
     }
-    if (this._accessToken) {
-      return this._BearerTokenPrefix + this._accessToken.token;
-    } else {
-      return null;
-    }
+    return this._BearerTokenPrefix + this._accessToken.token;
   }
 
   private executeBody(
@@ -297,7 +290,7 @@ export class RestApiClient {
   static translateError(body: any, response: any): HttpTransportError {
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_012: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 3 properties:
     - `response` shall contain the `IncomingMessage` object returned by the HTTP layer.
-    - `reponseBody` shall contain the content of the HTTP response.
+    - `responseBody` shall contain the content of the HTTP response.
     - `message` shall contain a human-readable error message.]*/
     let error: HttpTransportError;
     const errorContent = HttpBase.parseErrorBody(body);

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -3,7 +3,7 @@
 
 'use strict';
 
-import { anHourFromNow, errors, SharedAccessSignature, X509 } from 'azure-iot-common';
+import { anHourFromNow, errors, SharedAccessSignature, X509, IoTHubTokenScopes } from 'azure-iot-common';
 import { Http as HttpBase, HttpRequestOptions } from './http';
 import { AccessToken, TokenCredential } from '@azure/core-http';
 import  * as uuid from 'uuid';
@@ -36,7 +36,6 @@ export interface HttpTransportError extends Error {
  * @throws {ArgumentError}   If the config argument is missing a host or sharedAccessSignature error
  */
 export class RestApiClient {
-  private _iotHubPublicScope: string[] = ['https://iothubs.azure.net/.default'];
   private _BearerTokenPrefix: string = 'Bearer ';
   private _MinutesBeforeProactiveRenewal: number = 9;
   private _MillisecsBeforeProactiveRenewal: number = this._MinutesBeforeProactiveRenewal * 60000;
@@ -174,7 +173,7 @@ export class RestApiClient {
    */
    async getToken(): Promise<string> {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
-      this._accessToken = await this._config.tokenCredential.getToken(this._iotHubPublicScope) as any;
+      this._accessToken = await this._config.tokenCredential.getToken(this._config.tokenScope || IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE) as any;
     }
     if (this._accessToken) {
       return this._BearerTokenPrefix + this._accessToken.token;
@@ -377,6 +376,7 @@ export namespace RestApiClient {
         sharedAccessSignature?: string | SharedAccessSignature;
         x509?: X509;
         tokenCredential?: TokenCredential;
+        tokenScope?: string;
     }
 
     export type ResponseCallback = (err: Error, responseBody?: any, response?: any) => void;

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -227,7 +227,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
                         /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_06_004: [** If `putToken` is not successful then the client will remain disconnected and the callback, if provided, will be invoked with an error object.]*/
                         this._fsm.transition('disconnecting', err, callback);
                       } else {
-                        this._fsm.transition('authenticated', accessToken, callback)
+                        this._fsm.transition('authenticated', accessToken, callback);
                       }
                     });
                   }).catch((err) => {

--- a/service/src/job_client.ts
+++ b/service/src/job_client.ts
@@ -438,19 +438,28 @@ export class JobClient {
    * @static
    *
    * @param {String}    hostName                  Host name of the Azure service.
-   * @param {String}    tokenCredential           An Azure TokenCredential used to authenticate
+   * @param {Object}    tokenCredential           An Azure TokenCredential used to authenticate
    *                                              with the Azure  service
+   * @param {String}    tokenScope                The scope for the token used to authenticate
+   *                                              with the Azure service.
+   *                                              For any public cloud and private cloud other
+   *                                              than Azure US Government cloud, this can be
+   *                                              omitted. IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE
+   *                                              would be used internally in this case.
+   *                                              For Azure US Government cloud, this should be
+   *                                              IoTHubTokenScopes.IOT_HUB_US_GOVERNMENT_SCOPE.
    *
    * @throws  {ReferenceError}  If the tokenCredential argument is falsy.
    *
    * @returns {module:azure-iothub.JobClient}
    */
-   static fromTokenCredential(hostName: string, tokenCredential: TokenCredential): JobClient {
+   static fromTokenCredential(hostName: string, tokenCredential: TokenCredential, tokenScope?: string): JobClient {
     const config = {
       host: hostName,
       keyName: '',
       sharedAccessSignature: undefined,
-      tokenCredential: tokenCredential
+      tokenCredential: tokenCredential,
+      ...(tokenScope && { tokenScope: tokenScope })
     };
     return new JobClient(new RestApiClient(config, packageJson.name + '/' + packageJson.version));
   }

--- a/service/src/registry.ts
+++ b/service/src/registry.ts
@@ -1653,19 +1653,28 @@ export class Registry {
    * @static
    *
    * @param {String}    hostName                  Host name of the Azure service.
-   * @param {String}    tokenCredential           An Azure TokenCredential used to authenticate
+   * @param {Object}    tokenCredential           An Azure TokenCredential used to authenticate
    *                                              with the Azure  service
+   * @param {String}    tokenScope                The scope for the token used to authenticate
+   *                                              with the Azure service.
+   *                                              For any public cloud and private cloud other
+   *                                              than Azure US Government cloud, this can be
+   *                                              omitted. IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE
+   *                                              would be used internally in this case.
+   *                                              For Azure US Government cloud, this should be
+   *                                              IoTHubTokenScopes.IOT_HUB_US_GOVERNMENT_SCOPE.
    *
    * @throws  {ReferenceError}  If the tokenCredential argument is falsy.
    *
    * @returns {module:azure-iothub.Registry}
    */
-   static fromTokenCredential(hostName: string, tokenCredential: TokenCredential): Registry {
+   static fromTokenCredential(hostName: string, tokenCredential: TokenCredential, tokenScope?: string): Registry {
 
     const config: Registry.TransportConfig = {
       host: hostName,
       sharedAccessSignature: undefined,
-      tokenCredential: tokenCredential
+      tokenCredential: tokenCredential,
+      ...(tokenScope && { tokenScope: tokenScope })
     };
     return new Registry(config);
   }

--- a/service/test/_amqp_test.js
+++ b/service/test/_amqp_test.js
@@ -203,7 +203,7 @@ describe('Amqp', function() {
       })
     });
 
-    it('gets the token from the TokenCredential object using the IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE scope and passes it to putToken if tokenCredential is in the config but no tokenScope is specified', function (/* */) {
+    it('gets the token from the TokenCredential object using the IoTHubTokenScopes.IOT_HUB_PUBLIC_SCOPE scope and passes it to putToken if tokenCredential is in the config but no tokenScope is specified', function (testCallback) {
       var fakeToken = 'fake_token';
       var tokenCredentialConfig = {
         host: 'hub.host.name',

--- a/service/test/_client_test.js
+++ b/service/test/_client_test.js
@@ -99,6 +99,45 @@ describe('Client', function () {
     });
   });
 
+  describe('#fromTokenCredential', function () {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+    
+    it('creates an instance of the default transport', function() {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(client._transport, Amqp);
+    });
+
+    it('uses the transport given as argument', function () {
+      var FakeTransport = function (config) {
+        assert.isOk(config);
+      };
+
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential, FakeTransport);
+      assert.instanceOf(client._transport, FakeTransport);
+    });
+
+    it('returns an instance of Client', function () {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(client, Client);
+      assert.isOk(client._restApiClient);
+    });
+
+    it('correctly populates the config structure', function() {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential, "https://fake.scope.zw/.default");
+      assert.equal(client._transport._config.host, 'hub.host.tv');
+      assert.equal(client._transport._config.tokenCredential, fakeTokenCredential);
+      assert.equal(client._transport._config.tokenScope, "https://fake.scope.zw/.default");
+      assert.equal(client._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(client._restApiClient._config.tokenCredential, fakeTokenCredential);
+      assert.equal(client._restApiClient._config.tokenScope, "https://fake.scope.zw/.default");
+    });
+  });
+
   var goodSendParameters = [
     { obj: Buffer.from('foo'), name: 'Buffer' },
     { obj: 'foo', name: 'string' },

--- a/service/test/_job_client_test.js
+++ b/service/test/_job_client_test.js
@@ -180,6 +180,26 @@ describe('JobClient', function() {
     });
   });
 
+  describe('#fromTokenCredential', function() {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+
+    it('returns a JobClient instance', function() {
+      assert.instanceOf(JobClient.fromTokenCredential("hub.host.tv", fakeTokenCredential), JobClient);
+    });
+
+    it('correctly populates the config structure', function() {
+      var client = JobClient.fromTokenCredential("hub.host.tv", fakeTokenCredential, "https://fake.scope.zw/.default");
+      assert.equal(client._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(client._restApiClient._config.tokenCredential, fakeTokenCredential);
+      assert.equal(client._restApiClient._config.tokenScope, "https://fake.scope.zw/.default");
+    });
+  });
+
   describe('#getJob', function() {
     /*Tests_SRS_NODE_JOB_CLIENT_16_006: [The `getJob` method shall throw a `ReferenceError` if `jobId` is `null`, `undefined` or an empty string.]*/
     [undefined, null, ''].forEach(function(badValue) {

--- a/service/test/_registry_test.js
+++ b/service/test/_registry_test.js
@@ -249,6 +249,27 @@ describe('Registry', function () {
     });
   });
 
+  describe('#fromTokenCredential', function() {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+
+    it('returns a new instance of the Registry object', function() {
+      var registry = Registry.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(registry, Registry);
+    });
+
+    it('correctly populates the config structure', function() {
+      var registry = Registry.fromTokenCredential("hub.host.tv", fakeTokenCredential, "https://fake.scope.zw/.default");
+      assert.equal(registry._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(registry._restApiClient._config.tokenCredential, fakeTokenCredential);
+      assert.equal(registry._restApiClient._config.tokenScope, "https://fake.scope.zw/.default");
+    });
+  });
+
   describe('#create', function () {
     /*Tests_SRS_NODE_IOTHUB_REGISTRY_07_001: [The `create` method shall throw `ReferenceError` if the `deviceInfo` argument is falsy.]*/
     [undefined, null].forEach(function (badDeviceInfo) {


### PR DESCRIPTION
- Allow users to specify the token scope for AAD authentication
- Add constant values for the token scopes for public clouds and US Government clouds
- Fix error handling issues with `getToken()` in `RestApiClient` and `Amqp`
- Add missing unit tests for AAD authentication 