### PR TITLE
Fix getToken() error handling and add missing tests for AAD authentication

### DIFF
--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -173,6 +173,9 @@ export class RestApiClient {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
       this._accessToken = await this._config.tokenCredential.getToken(this._iotHubPublicScope) as any;
     }
+    if (!this._accessToken) {
+      throw new Error('AccessToken creation failed');
+    }
     return this._BearerTokenPrefix + this._accessToken.token;
   }
 

--- a/common/transport/http/src/rest_api_client.ts
+++ b/common/transport/http/src/rest_api_client.ts
@@ -36,7 +36,7 @@ export interface HttpTransportError extends Error {
  * @throws {ArgumentError}   If the config argument is missing a host or sharedAccessSignature error
  */
 export class RestApiClient {
-  private _iotHubPublicScope: string[] = ['https://iothubs.azure.net/.default'];
+  private _iotHubPublicScope: string = 'https://iothubs.azure.net/.default';
   private _BearerTokenPrefix: string = 'Bearer ';
   private _MinutesBeforeProactiveRenewal: number = 9;
   private _MillisecsBeforeProactiveRenewal: number = this._MinutesBeforeProactiveRenewal * 60000;
@@ -112,14 +112,11 @@ export class RestApiClient {
     - User-Agent: <version string>]*/
     let httpHeaders: any = headers || {};
     if (this._config.tokenCredential) {
-      let accessToken = this.getToken();
-      Promise.resolve(accessToken).then((value) => {
-        if (value) {
-          httpHeaders.Authorization = value;
-          this.executeBody(requestBody, httpHeaders, headers, method, path, timeout, requestOptions, done);
-        } else {
-            throw new Error('AccessToken creation failed');
-        }
+      this.getToken().then((accessToken) => {
+        httpHeaders.Authorization = accessToken;
+        this.executeBody(requestBody, httpHeaders, headers, method, path, timeout, requestOptions, done);
+      }).catch((err) => {
+        done(err);
       });
     } else {
       if (this._config.sharedAccessSignature) {
@@ -131,7 +128,7 @@ export class RestApiClient {
 
   /**
    * @method             module:azure-iothub.RestApiClient.updateSharedAccessSignature
-   * @description        Updates the shared access signature used to authentify API calls.
+   * @description        Updates the shared access signature used to authenticate API calls.
    *
    * @param  {string}          sharedAccessSignature  The new shared access signature that should be used.
    *
@@ -176,11 +173,7 @@ export class RestApiClient {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
       this._accessToken = await this._config.tokenCredential.getToken(this._iotHubPublicScope) as any;
     }
-    if (this._accessToken) {
-      return this._BearerTokenPrefix + this._accessToken.token;
-    } else {
-      return null;
-    }
+    return this._BearerTokenPrefix + this._accessToken.token;
   }
 
   private executeBody(
@@ -298,7 +291,7 @@ export class RestApiClient {
   static translateError(body: any, response: any): HttpTransportError {
     /*Codes_SRS_NODE_IOTHUB_REST_API_CLIENT_16_012: [Any error object returned by `translateError` shall inherit from the generic `Error` Javascript object and have 3 properties:
     - `response` shall contain the `IncomingMessage` object returned by the HTTP layer.
-    - `reponseBody` shall contain the content of the HTTP response.
+    - `responseBody` shall contain the content of the HTTP response.
     - `message` shall contain a human-readable error message.]*/
     let error: HttpTransportError;
     const errorContent = HttpBase.parseErrorBody(body);

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -589,6 +589,9 @@ export class Amqp extends EventEmitter implements Client.Transport {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
       this._accessToken = await this._config.tokenCredential.getToken(this._iotHubPublicScope) as any;
     }
+    if (!this._accessToken) {
+      throw new Error('AccessToken creation failed');
+    }
     return this._bearerTokenPrefix + this._accessToken.token;
   }
 

--- a/service/src/amqp.ts
+++ b/service/src/amqp.ts
@@ -222,20 +222,17 @@ export class Amqp extends EventEmitter implements Client.Transport {
                   });
                 } else if (this._config.tokenCredential) {
                   const audience = this._iotHubPublicScope;
-                  const accessToken = this.getToken();
-                  Promise.resolve(accessToken).then((value) => {
-                    if (value) {
-                      this._amqp.putToken(audience, value, (err) => {
-                        if (err) {
-                          /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_06_004: [** If `putToken` is not successful then the client will remain disconnected and the callback, if provided, will be invoked with an error object.]*/
-                          this._fsm.transition('disconnecting', err, callback);
-                        } else {
-                          this._fsm.transition('authenticated', value, callback);
-                        }
-                      });
-                    } else {
-                      this._fsm.transition('disconnecting', 'AccessToken creation failed', callback);
-                    }
+                  this.getToken().then((accessToken) => {
+                    this._amqp.putToken(audience, accessToken, (err) => {
+                      if (err) {
+                        /*Codes_SRS_NODE_IOTHUB_SERVICE_AMQP_06_004: [** If `putToken` is not successful then the client will remain disconnected and the callback, if provided, will be invoked with an error object.]*/
+                        this._fsm.transition('disconnecting', err, callback);
+                      } else {
+                        this._fsm.transition('authenticated', accessToken, callback);
+                      }
+                    });
+                  }).catch((err) => {
+                    this._fsm.transition('disconnecting', err, callback);
                   });
                 }
               }
@@ -592,11 +589,7 @@ export class Amqp extends EventEmitter implements Client.Transport {
     if ((!this._accessToken) || this.isAccessTokenCloseToExpiry(this._accessToken)) {
       this._accessToken = await this._config.tokenCredential.getToken(this._iotHubPublicScope) as any;
     }
-    if (this._accessToken) {
-      return this._bearerTokenPrefix + this._accessToken.token;
-    } else {
-      return null;
-    }
+    return this._bearerTokenPrefix + this._accessToken.token;
   }
 
   protected _getConnectionUri(): string {

--- a/service/test/_amqp_test.js
+++ b/service/test/_amqp_test.js
@@ -181,6 +181,25 @@ describe('Amqp', function() {
         });
       });
     });
+
+    it('gets the token from the TokenCredential object using the correct token scope and passes it to putToken if a TokenCredential is in the config', function (testCallback) {
+      var fakeToken = 'fake_token';
+      var tokenCredentialConfig = {
+        host: 'hub.host.name',
+        tokenCredential: {
+          getToken: sinon.stub().resolves({
+            token: fakeToken,
+            expiresOnTimeStamp: Date.now() + 3600000
+          })
+        }
+      }
+      var transport = new Amqp(tokenCredentialConfig, fakeAmqpBase);
+      transport.connect(function () {
+        assert(tokenCredentialConfig.tokenCredential.getToken.calledOnceWithExactly('https://iothubs.azure.net/.default'));
+        assert(fakeAmqpBase.putToken.calledOnceWith('https://iothubs.azure.net/.default', "Bearer " + fakeToken));
+        testCallback();
+      })
+    });
   });
 
   describe('#disconnect', function() {

--- a/service/test/_client_test.js
+++ b/service/test/_client_test.js
@@ -99,6 +99,43 @@ describe('Client', function () {
     });
   });
 
+  describe('#fromTokenCredential', function () {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+
+    it('creates an instance of the default transport', function() {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(client._transport, Amqp);
+    });
+
+    it('uses the transport given as argument', function () {
+      var FakeTransport = function (config) {
+        assert.isOk(config);
+      };
+
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential, FakeTransport);
+      assert.instanceOf(client._transport, FakeTransport);
+    });
+
+    it('returns an instance of Client', function () {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(client, Client);
+      assert.isOk(client._restApiClient);
+    });
+
+    it('correctly populates the config structure', function() {
+      var client = Client.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.equal(client._transport._config.host, 'hub.host.tv');
+      assert.equal(client._transport._config.tokenCredential, fakeTokenCredential);
+      assert.equal(client._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(client._restApiClient._config.tokenCredential, fakeTokenCredential);
+    });
+  });
+
   var goodSendParameters = [
     { obj: Buffer.from('foo'), name: 'Buffer' },
     { obj: 'foo', name: 'string' },

--- a/service/test/_job_client_test.js
+++ b/service/test/_job_client_test.js
@@ -180,6 +180,25 @@ describe('JobClient', function() {
     });
   });
 
+  describe('#fromTokenCredential', function() {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+
+    it('returns a JobClient instance', function() {
+      assert.instanceOf(JobClient.fromTokenCredential("hub.host.tv", fakeTokenCredential), JobClient);
+    });
+
+    it('correctly populates the config structure', function() {
+      var client = JobClient.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.equal(client._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(client._restApiClient._config.tokenCredential, fakeTokenCredential);
+    });
+  });
+
   describe('#getJob', function() {
     /*Tests_SRS_NODE_JOB_CLIENT_16_006: [The `getJob` method shall throw a `ReferenceError` if `jobId` is `null`, `undefined` or an empty string.]*/
     [undefined, null, ''].forEach(function(badValue) {

--- a/service/test/_registry_test.js
+++ b/service/test/_registry_test.js
@@ -249,6 +249,26 @@ describe('Registry', function () {
     });
   });
 
+  describe('#fromTokenCredential', function() {
+    var fakeTokenCredential = {
+      getToken: sinon.stub().resolves({
+        token: "fake_token",
+        expiresOnTimeStamp: Date.now() + 3600000
+      })
+    };
+
+    it('returns a new instance of the Registry object', function() {
+      var registry = Registry.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.instanceOf(registry, Registry);
+    });
+
+    it('correctly populates the config structure', function() {
+      var registry = Registry.fromTokenCredential("hub.host.tv", fakeTokenCredential);
+      assert.equal(registry._restApiClient._config.host, 'hub.host.tv');
+      assert.equal(registry._restApiClient._config.tokenCredential, fakeTokenCredential);
+    });
+  });
+
   describe('#create', function () {
     /*Tests_SRS_NODE_IOTHUB_REGISTRY_07_001: [The `create` method shall throw `ReferenceError` if the `deviceInfo` argument is falsy.]*/
     [undefined, null].forEach(function (badDeviceInfo) {


### PR DESCRIPTION
- Fix error handling issues with `getToken()` in `RestApiClient` and `Amqp`
- Add missing unit tests for AAD authentication