### PR TITLE
Adding commented protocols to appropriate samples

### DIFF
--- a/device/samples/javascript/device_methods.js
+++ b/device/samples/javascript/device_methods.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 require('es5-shim');
 var Client = require('azure-iot-device').Client;

--- a/device/samples/javascript/device_methods.js
+++ b/device/samples/javascript/device_methods.js
@@ -3,10 +3,15 @@
 
 'use strict';
 
-require('es5-shim');
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-var Client = require('azure-iot-device').Client;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
 
+require('es5-shim');
+var Client = require('azure-iot-device').Client;
 var client = null;
 
 function main() {

--- a/device/samples/javascript/device_through_proxy.js
+++ b/device/samples/javascript/device_through_proxy.js
@@ -6,9 +6,9 @@
 // !IMPORTANT! This sample only pertains to HTTPS Proxy, via the HTTP Transport, MQTTWS Transport, and AMQPWS Transport.
 
 // Choose a protocol by uncommenting one of these transports.
+const Protocol = require('azure-iot-device-mqtt').MqttWs;
 // const Protocol = require('azure-iot-device-amqp').AmqpWs;
 // const Protocol = require('azure-iot-device-http').Http;
-const Protocol = require('azure-iot-device-mqtt').MqttWs;
 
 const Client = require('azure-iot-device').Client;
 const Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/dmpatterns_fwupdate_device.js
+++ b/device/samples/javascript/dmpatterns_fwupdate_device.js
@@ -2,8 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 'use strict';
 
-var Client = require('azure-iot-device').Client;
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
+var Client = require('azure-iot-device').Client;
 var url = require('url');
 var async = require('async');
 

--- a/device/samples/javascript/dmpatterns_fwupdate_device.js
+++ b/device/samples/javascript/dmpatterns_fwupdate_device.js
@@ -4,10 +4,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var url = require('url');

--- a/device/samples/javascript/dmpatterns_reboot_device.js
+++ b/device/samples/javascript/dmpatterns_reboot_device.js
@@ -4,10 +4,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 

--- a/device/samples/javascript/dmpatterns_reboot_device.js
+++ b/device/samples/javascript/dmpatterns_reboot_device.js
@@ -2,9 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 'use strict';
 
-var Client = require('azure-iot-device').Client;
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
 
+var Client = require('azure-iot-device').Client;
 
 var deviceConnectionString = process.env.IOTHUB_DEVICE_CONNECTION_STRING;
 var client = Client.fromConnectionString(deviceConnectionString, Protocol);

--- a/device/samples/javascript/edge_downstream_device.js
+++ b/device/samples/javascript/edge_downstream_device.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/edge_downstream_device.js
+++ b/device/samples/javascript/edge_downstream_device.js
@@ -3,13 +3,16 @@
 
 'use strict';
 
-var fs = require('fs');
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
 // Choose a protocol by uncommenting one of these transports.
-// var Protocol = require('azure-iot-device-http').Http;
-// var Protocol = require('azure-iot-device-amqp').Amqp;
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;
+var fs = require('fs');
 
 // 1) Obtain the connection string for your downstream device and to it
 //    append this string GatewayHostName=<edge device hostname>;

--- a/device/samples/javascript/module_invoke_method.js
+++ b/device/samples/javascript/module_invoke_method.js
@@ -2,10 +2,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var ModuleClient = require('azure-iot-device').ModuleClient;
 

--- a/device/samples/javascript/module_invoke_method.js
+++ b/device/samples/javascript/module_invoke_method.js
@@ -1,10 +1,15 @@
 'use strict';
 
+// Choose a protocol by uncommenting one of these transports.
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
 
 var ModuleClient = require('azure-iot-device').ModuleClient;
-var Mqtt = require('azure-iot-device-mqtt').Mqtt;
 
-ModuleClient.fromEnvironment(Mqtt, (err, client) => {
+ModuleClient.fromEnvironment(Protocol, (err, client) => {
     if (err) {
         console.error(err.toString());
         process.exit(-1);

--- a/device/samples/javascript/remote_monitoring.js
+++ b/device/samples/javascript/remote_monitoring.js
@@ -3,7 +3,13 @@
 
 'use strict';
 
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var Client = require('azure-iot-device').Client;
 var ConnectionString = require('azure-iot-device').ConnectionString;
 var Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/remote_monitoring.js
+++ b/device/samples/javascript/remote_monitoring.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var ConnectionString = require('azure-iot-device').ConnectionString;

--- a/device/samples/javascript/simple_sample_device.js
+++ b/device/samples/javascript/simple_sample_device.js
@@ -3,12 +3,13 @@
 
 'use strict';
 
-const Protocol = require('azure-iot-device-mqtt').Mqtt;
 // Choose a protocol by uncommenting one of these transports.
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
 // const Protocol = require('azure-iot-device-amqp').AmqpWs;
 // const Protocol = require('azure-iot-device-http').Http;
 // const Protocol = require('azure-iot-device-amqp').Amqp;
 // const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 const Client = require('azure-iot-device').Client;
 const Message = require('azure-iot-device').Message;
 

--- a/device/samples/javascript/simple_sample_device.js
+++ b/device/samples/javascript/simple_sample_device.js
@@ -4,11 +4,11 @@
 'use strict';
 
 // Choose a protocol by uncommenting one of these transports.
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
+const Protocol = require('azure-iot-device-mqtt').Mqtt;
 // const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-http').Http;
 // const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 const Client = require('azure-iot-device').Client;
 const Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/simple_sample_device_twin.js
+++ b/device/samples/javascript/simple_sample_device_twin.js
@@ -3,10 +3,14 @@
 
 'use strict';
 
-var Client = require('azure-iot-device').Client;
-//var Protocol = require('azure-iot-device-amqp').Amqp;
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
 
+var Client = require('azure-iot-device').Client;
 var deviceConnectionString = process.env.IOTHUB_DEVICE_CONNECTION_STRING;
 
 // create the IoTHub client

--- a/device/samples/javascript/simple_sample_device_twin.js
+++ b/device/samples/javascript/simple_sample_device_twin.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var deviceConnectionString = process.env.IOTHUB_DEVICE_CONNECTION_STRING;

--- a/device/samples/javascript/simple_sample_device_with_sas.js
+++ b/device/samples/javascript/simple_sample_device_with_sas.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/simple_sample_device_with_sas.js
+++ b/device/samples/javascript/simple_sample_device_with_sas.js
@@ -3,11 +3,13 @@
 
 'use strict';
 
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
 // Choose a protocol by uncommenting one of these transports.
-// var Protocol = require('azure-iot-device-amqp').AmqpWs;
-// var Protocol = require('azure-iot-device-http').Http;
-// var Protocol = require('azure-iot-device-amqp').Amqp;
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;
 

--- a/device/samples/javascript/simple_sample_device_x509.js
+++ b/device/samples/javascript/simple_sample_device_x509.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/simple_sample_device_x509.js
+++ b/device/samples/javascript/simple_sample_device_x509.js
@@ -3,14 +3,16 @@
 
 'use strict';
 
-var fs = require('fs');
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
 // Choose a protocol by uncommenting one of these transports.
-// var Protocol = require('azure-iot-device-amqp').AmqpWs;
-// var Protocol = require('azure-iot-device-http').Http;
-// var Protocol = require('azure-iot-device-amqp').Amqp;
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var Client = require('azure-iot-device').Client;
 var Message = require('azure-iot-device').Message;
+var fs = require('fs');
 
 // String containing Hostname and Device Id in the following format:
 //  "HostName=<iothub_host_name>;DeviceId=<device_id>;x509=true"

--- a/device/samples/javascript/simple_sample_module.js
+++ b/device/samples/javascript/simple_sample_module.js
@@ -3,7 +3,13 @@
 
 'use strict';
 
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var ModuleClient = require('azure-iot-device').ModuleClient;
 var Message = require('azure-iot-device').Message;
 

--- a/device/samples/javascript/simple_sample_module.js
+++ b/device/samples/javascript/simple_sample_module.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var ModuleClient = require('azure-iot-device').ModuleClient;
 var Message = require('azure-iot-device').Message;

--- a/device/samples/javascript/simple_sample_module_method.js
+++ b/device/samples/javascript/simple_sample_module_method.js
@@ -3,7 +3,13 @@
 
 'use strict';
 
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 var ModuleClient = require('azure-iot-device').ModuleClient;
 
 ModuleClient.fromEnvironment(Protocol, function (err, client) {

--- a/device/samples/javascript/simple_sample_module_method.js
+++ b/device/samples/javascript/simple_sample_module_method.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var ModuleClient = require('azure-iot-device').ModuleClient;
 

--- a/device/samples/javascript/simple_sample_module_twin.js
+++ b/device/samples/javascript/simple_sample_module_twin.js
@@ -5,10 +5,10 @@
 
 // Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
-// const Protocol = require('azure-iot-device-amqp').Amqp;
-// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').Amqp;
+// var Protocol = require('azure-iot-device-http').Http;
+// var Protocol = require('azure-iot-device-mqtt').MqttWs;
+// var Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 var ModuleClient = require('azure-iot-device').ModuleClient;
 

--- a/device/samples/javascript/simple_sample_module_twin.js
+++ b/device/samples/javascript/simple_sample_module_twin.js
@@ -3,8 +3,14 @@
 
 'use strict';
 
-var ModuleClient = require('azure-iot-device').ModuleClient;
+// Choose a protocol by uncommenting one of these transports.
 var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
+var ModuleClient = require('azure-iot-device').ModuleClient;
 
 ModuleClient.fromEnvironment(Protocol, function (err, client) {
   if (err) {

--- a/device/samples/javascript/upload_to_blob.js
+++ b/device/samples/javascript/upload_to_blob.js
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// This example is deprecated. We recommend you follow the 'upload_to_blob_advanced.js' sample.
+// ⚠️THIS EXAMPLE IS DEPRECATED⚠️
+// We recommend you follow the 'upload_to_blob_advanced.js' sample.
 
 'use strict';
 

--- a/device/samples/javascript/upload_to_blob.js
+++ b/device/samples/javascript/upload_to_blob.js
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// ⚠️THIS EXAMPLE IS DEPRECATED⚠️
+// THIS EXAMPLE IS DEPRECATED
 // We recommend you follow the 'upload_to_blob_advanced.js' sample.
 
 'use strict';

--- a/device/samples/javascript/upload_to_blob_advanced.js
+++ b/device/samples/javascript/upload_to_blob_advanced.js
@@ -19,20 +19,16 @@
 'use strict';
 
 // Choose a protocol by uncommenting one of these transports.
-var Protocol = require('azure-iot-device-mqtt').Mqtt;
-// const Protocol = require('azure-iot-device-amqp').AmqpWs;
-// const Protocol = require('azure-iot-device-http').Http;
+const Protocol = require('azure-iot-device-mqtt').Mqtt;
 // const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-http').Http;
 // const Protocol = require('azure-iot-device-mqtt').MqttWs;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
 
 const Client = require('azure-iot-device').Client;
 const errors = require('azure-iot-common').errors;
 
-const {
-  AnonymousCredential,
-  BlockBlobClient,
-  newPipeline
-} = require('@azure/storage-blob');
+const {AnonymousCredential, BlockBlobClient, newPipeline } = require('@azure/storage-blob');
 
 // make sure you set these environment variables prior to running the sample.
 const deviceConnectionString = process.env.IOTHUB_DEVICE_CONNECTION_STRING;

--- a/device/samples/javascript/upload_to_blob_advanced.js
+++ b/device/samples/javascript/upload_to_blob_advanced.js
@@ -18,8 +18,14 @@
 
 'use strict';
 
+// Choose a protocol by uncommenting one of these transports.
+var Protocol = require('azure-iot-device-mqtt').Mqtt;
+// const Protocol = require('azure-iot-device-amqp').AmqpWs;
+// const Protocol = require('azure-iot-device-http').Http;
+// const Protocol = require('azure-iot-device-amqp').Amqp;
+// const Protocol = require('azure-iot-device-mqtt').MqttWs;
+
 const Client = require('azure-iot-device').Client;
-const Protocol = require('azure-iot-device-mqtt').Mqtt;
 const errors = require('azure-iot-common').errors;
 
 const {

--- a/device/samples/typescript/device_methods.ts
+++ b/device/samples/typescript/device_methods.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Client } from 'azure-iot-device';
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client } from 'azure-iot-device';
 
 let client: Client = null;
 

--- a/device/samples/typescript/dmpatterns_fwupdate_device.ts
+++ b/device/samples/typescript/dmpatterns_fwupdate_device.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
-import {
-  Client,
-  DeviceMethodRequest,
-  DeviceMethodResponse,
-  Twin,
-} from 'azure-iot-device';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import {Client, DeviceMethodRequest, DeviceMethodResponse, Twin,} from 'azure-iot-device';
 import * as url from 'url';
 import * as async from 'async';
 

--- a/device/samples/typescript/dmpatterns_reboot_device.ts
+++ b/device/samples/typescript/dmpatterns_reboot_device.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
 import { Client, DeviceMethodRequest, DeviceMethodResponse, Twin } from 'azure-iot-device';
 
 const deviceConnectionString: string = process.env.IOTHUB_DEVICE_CONNECTION_STRING || '';

--- a/device/samples/typescript/edge_downstream_device.ts
+++ b/device/samples/typescript/edge_downstream_device.ts
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import * as fs from 'fs';
-import { Client, Message } from 'azure-iot-device';
-
 // Choose a protocol by uncommenting one of these transports.
-// import { Http as Protocol } from 'azure-iot-device-http';
-// import { Amqp as Protocol } from 'azure-iot-device-amqp';
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client, Message } from 'azure-iot-device';
+import * as fs from 'fs'
 
 // 1) Obtain the connection string for your downstream device and to it
 //    append this string GatewayHostName=<edge device hostname>;

--- a/device/samples/typescript/remote_monitoring.ts
+++ b/device/samples/typescript/remote_monitoring.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
 import { Client, ConnectionString, Message } from 'azure-iot-device';
 
 // String containing Hostname, Device Id & Device Key in the following formats:

--- a/device/samples/typescript/simple_sample_device.ts
+++ b/device/samples/typescript/simple_sample_device.ts
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Client, Message } from 'azure-iot-device';
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
 // import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client, Message } from 'azure-iot-device';
 
 const deviceConnectionString: string = process.env.IOTHUB_DEVICE_CONNECTION_STRING || '';
 let sendInterval: NodeJS.Timeout;
@@ -13,10 +18,7 @@ if (deviceConnectionString === '') {
   process.exit(-1);
 }
 
-const client: Client = Client.fromConnectionString(
-  deviceConnectionString,
-  Protocol
-);
+const client: Client = Client.fromConnectionString(deviceConnectionString, Protocol);
 
 async function asyncMain(): Promise<void> {
   client.on('connect', connectHandler);

--- a/device/samples/typescript/simple_sample_device_twin.ts
+++ b/device/samples/typescript/simple_sample_device_twin.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Client, Twin } from 'azure-iot-device';
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
-// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
-// import { Http as Protocol } from 'azure-iot-device-Http';
 // import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
 // import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client, Twin } from 'azure-iot-device';
 
 const deviceConnectionString: string = process.env.IOTHUB_DEVICE_CONNECTION_STRING || '';
 

--- a/device/samples/typescript/simple_sample_device_with_sas.ts
+++ b/device/samples/typescript/simple_sample_device_with_sas.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { Client, Message } from 'azure-iot-device';
-import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
-
 // Choose a protocol by uncommenting one of these transports.
+import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
 // import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
-// import { Amqp as Protocol } from 'azure-iot-device-amqp'
-// import { Http as Protocol } from 'azure-iot-device-http';
+
+import { Client, Message } from 'azure-iot-device';
 
 // String SharedAccessSignature in the following formats:
 // "SharedAccessSignature sr=<iothub_host_name>/devices/<device_id>&sig=<signature>&se=<expiry>"

--- a/device/samples/typescript/simple_sample_device_x509.ts
+++ b/device/samples/typescript/simple_sample_device_x509.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import * as fs from 'fs';
-import { Client, Message } from 'azure-iot-device';
-
 // Choose a protocol by uncommenting one of these transports.
-// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
-// import { Amqp as Protocol } from 'azure-iot-device-amqp'
-// import { Http as Protocol } from 'azure-iot-device-http';
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client, Message } from 'azure-iot-device';
+import * as fs from 'fs';
 
 // String containing Hostname and Device Id in the following format:
 //  "HostName=<iothub_host_name>;DeviceId=<device_id>;x509=true"

--- a/device/samples/typescript/simple_sample_module.ts
+++ b/device/samples/typescript/simple_sample_module.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-import { ModuleClient, Message } from 'azure-iot-device';
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { ModuleClient, Message } from 'azure-iot-device';
 
 ModuleClient.fromEnvironment(
   Protocol,

--- a/device/samples/typescript/upload_to_blob.ts
+++ b/device/samples/typescript/upload_to_blob.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// ⚠️THIS EXAMPLE IS DEPRECATED⚠️
+// THIS EXAMPLE IS DEPRECATED
 // We recommend you follow the 'upload_to_blob_advanced.ts' sample.
 
 import { Client } from 'azure-iot-device';

--- a/device/samples/typescript/upload_to_blob.ts
+++ b/device/samples/typescript/upload_to_blob.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-// This example is deprecated. We recommend you follow the 'upload_to_blob_advanced.ts' sample.
+// ⚠️THIS EXAMPLE IS DEPRECATED⚠️
+// We recommend you follow the 'upload_to_blob_advanced.ts' sample.
 
 import { Client } from 'azure-iot-device';
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';

--- a/device/samples/typescript/upload_to_blob_advanced.ts
+++ b/device/samples/typescript/upload_to_blob_advanced.ts
@@ -16,8 +16,14 @@
 // More information on Uploading Files with IoT Hub can be found here:
 // https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-file-upload
 
-import { Client } from 'azure-iot-device';
+// Choose a protocol by uncommenting one of these transports.
 import { Mqtt as Protocol } from 'azure-iot-device-mqtt';
+// import { Amqp as Protocol } from 'azure-iot-device-amqp';
+// import { Http as Protocol } from 'azure-iot-device-Http';
+// import { MqttWs as Protocol } from 'azure-iot-device-mqtt';
+// import { AmqpWs as Protocol } from 'azure-iot-device-amqp';
+
+import { Client } from 'azure-iot-device';
 import { errors } from 'azure-iot-common';
 import { AnonymousCredential, BlobUploadCommonResponse, BlockBlobClient, newPipeline, Pipeline } from '@azure/storage-blob';
 


### PR DESCRIPTION
# Checklist
- [x] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-node/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
Getting customer feedback on how to use other protocols besides mqtt. Noticed that many of our samples do not have the block for customers to choose.

```
var Protocol = require('azure-iot-device-mqtt').Mqtt;
// const Protocol = require('azure-iot-device-amqp').AmqpWs;
// const Protocol = require('azure-iot-device-http').Http;
// const Protocol = require('azure-iot-device-amqp').Amqp;
// const Protocol = require('azure-iot-device-mqtt').MqttWs;
```

# Description of the solution
Added block to each sample.
