### PR TITLE
Update synctodevops.yml

### DIFF
--- a/.github/workflows/synctodevops.yml
+++ b/.github/workflows/synctodevops.yml
@@ -4,7 +4,7 @@ name: Sync issue to Azure DevOps work item
 "on":
   issues:
     types:
-      [opened, reopened, closed, deleted, assigned]
+      [opened, reopened, closed, deleted, assigned, labeled, unlabeled]
 
 jobs:
   alert:
@@ -18,6 +18,7 @@ jobs:
           ado_area_path: "${{ secrets.ADO_AREA_PATH }}"
           ado_wit: "Bug"
           ado_new_state: "New"
+          ado_active_state: "In Progress"
           ado_close_state: "Done"
           ado_bypassrules: false
           log_level: 300


### PR DESCRIPTION
added active state to env variables
added label and unlabel action


# Checklist
- [ ] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-node/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
GitHub workflow to sync Issues to work items on boards did not have an active state env value set for when an issue was re-opened.

Also added labeled and unlabeled event so we can track the label on the board as well.
