### PR TITLE
fix(azure-iot-device-mqtt): add naive D2C message size checking

### DIFF
--- a/device/transport/mqtt/src/mqtt.ts
+++ b/device/transport/mqtt/src/mqtt.ts
@@ -277,6 +277,12 @@ export class Mqtt extends EventEmitter implements DeviceTransport {
               topic += '/';
             }
 
+            // This will not catch all messages that exceed IoT Hub limits because properties contribute the size as well.
+            if ((message?.data?.length ?? 0) > 256 * 1024) {
+              sendEventCallback(new errors.MessageTooLargeError('Message size is greater than 256KiB'));
+              return;
+            }
+
             /*Codes_SRS_NODE_COMMON_MQTT_BASE_16_010: [** The `sendEvent` method shall use QoS level of 1.]*/
             this._mqtt.publish(topic, message.data, { qos: 1, retain: false }, (err, result) => {
               if (err) {

--- a/device/transport/mqtt/test/_mqtt_test.js
+++ b/device/transport/mqtt/test/_mqtt_test.js
@@ -369,6 +369,30 @@ describe('Mqtt', function () {
     });
   });
 
+  describe('#sendEvent', function () {
+    it('calls the callback without an error if the message body goes right up to 256KiB in size', function (testCallback) {
+      const mqtt = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);
+      mqtt.connect(function () {
+        const message = new Message('a'.repeat(1024 * 256));
+        mqtt.sendEvent(message, function (err) {
+          assert.isNull(err);
+          testCallback();
+        });
+      });
+    });
+
+    it('calls the callback with an error if the message body goes past 256KiB in size', function (testCallback) {
+      const mqtt = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);
+      mqtt.connect(function () {
+        const message = new Message('a'.repeat((1024 * 256) + 1));
+        mqtt.sendEvent(message, function (err) {
+          assert.instanceOf(err, errors.MessageTooLargeError);
+          testCallback();
+        });
+      });
+    });
+  });
+
   describe('#onDeviceMethod', function () {
     it('calls the registered callback when a method is received', function (testCallback) {
       const mqtt = new Mqtt(fakeAuthenticationProvider, fakeMqttBase);


### PR DESCRIPTION
This adds naive D2C message size checking. This won't catch every message that hits the size limit because properties (including system properties) count toward the limit. However, the formula for this seems a tricky to derive from simply testing against a hub.