### PR TITLE
Specify Lerna version in pipeline to address breaking change in Lerna

### DIFF
--- a/vsts/node-nightly-df.yaml
+++ b/vsts/node-nightly-df.yaml
@@ -18,7 +18,7 @@ jobs:
 
   - script: |
        npm install --global node-gyp
-       npm install --global lerna
+       npm install --global lerna@^6.6.2
        npm install
     displayName: 'Install Dependencies'
 

--- a/vsts/node-nightly-linux.yaml
+++ b/vsts/node-nightly-linux.yaml
@@ -18,7 +18,7 @@ jobs:
 
   - script: |
        npm install --global node-gyp
-       npm install --global lerna
+       npm install --global lerna@^6.6.2
        npm install
     displayName: 'Install Dependencies'
 

--- a/vsts/node-nightly-windows.yaml
+++ b/vsts/node-nightly-windows.yaml
@@ -18,7 +18,7 @@ jobs:
   - powershell: |
        runas.exe /savecred /user:administrator
        npm install --global node-gyp@6.1.0
-       npm install --global lerna
+       npm install --global lerna@^6.6.2
        npm install
     displayName: 'Install Dependencies'
 


### PR DESCRIPTION
Our pipelines are failing because Lerna made a major version bump that gets rid of the `lerna bootstrap` command. Changing the pipeline yaml files to stay on version 6.x.x to avoid this.