### PR TITLE
Have force disconnect as an option

### DIFF
--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -280,7 +280,7 @@ export class MqttBase extends EventEmitter {
             }, 30000);
 
             debug('disconnecting mqtt client');
-            this._disconnectClient(this._options.mqtt?.forceDisconnect ?? false, () => {
+            this._disconnectClient(this._options?.mqtt?.forceDisconnect ?? false, () => {
               clearTimeout(disconnectTimeout);
               if (!switched) {
                 debug('mqtt client disconnected - reconnecting');

--- a/common/transport/mqtt/src/mqtt_base.ts
+++ b/common/transport/mqtt/src/mqtt_base.ts
@@ -16,7 +16,7 @@ class OnTheWireMessage {
   enqueuedTimeSecondsSinceEpoch: number;
   callback: (err?: Error, result?: any) => void;
   constructor(callback: (err?: Error, result?: any) => void) {
-    this.enqueuedTimeSecondsSinceEpoch = Math.floor( Date.now() / 1000 );
+    this.enqueuedTimeSecondsSinceEpoch = Math.floor(Date.now() / 1000);
     this.callback = callback;
   }
 }
@@ -280,7 +280,7 @@ export class MqttBase extends EventEmitter {
             }, 30000);
 
             debug('disconnecting mqtt client');
-            this._disconnectClient(true, () => {
+            this._disconnectClient(this._options.mqtt?.forceDisconnect ?? false, () => {
               clearTimeout(disconnectTimeout);
               if (!switched) {
                 debug('mqtt client disconnected - reconnecting');
@@ -467,6 +467,7 @@ export class MqttBase extends EventEmitter {
   }
 
   private _disconnectClient(forceDisconnect: boolean, callback: () => void): void {
+    debug('forceDisconnect is valued at: ' + forceDisconnect);
     if (this._mqttClient) {
       debug('removing all listeners');
       this._mqttTrackedListeners.removeAllTrackedListeners();
@@ -514,9 +515,9 @@ export class MqttBase extends EventEmitter {
   }
 }
 
-  /**
-   * @private
-   */
+/**
+ * @private
+ */
 export interface MqttBaseTransportConfig {
   sharedAccessSignature?: string | SharedAccessSignature;
   clientId: string;

--- a/device/core/src/interfaces.ts
+++ b/device/core/src/interfaces.ts
@@ -85,6 +85,10 @@ export interface MqttTransportOptions {
    * Optional [Agent]{@link https://nodejs.org/api/https.html#https_class_https_agent} object to use with MQTT-WS connections
    */
   webSocketAgent?: Agent;
+  /**
+   * Optional boolean flag indicating whether to force disconnection in high throughput scenarios to cause messages to be properly dropped.
+   */
+  forceDisconnect?: boolean;
 
 }
 
@@ -144,12 +148,12 @@ export interface DeviceClientOptions extends X509 {
   /**
    * Optional object with options specific to the MQTT transport
    */
-   mqtt?: MqttTransportOptions;
+  mqtt?: MqttTransportOptions;
 
   /**
    * Optional object with options specific to the HTTP transport
    */
-   http?: HttpTransportOptions;
+  http?: HttpTransportOptions;
 
   /**
    * Optional object with options specific to the AMQP transport


### PR DESCRIPTION
When experiencing message loss due to high throughput, the force flag in disconnectClient can be set to true to cause messages to be properly dropped and thus re-sent.

Original ICM ID 567171345

Now default is False otherwise set to True