### PR TITLE
ci: route npm installs through CFS-protected feed

### DIFF
--- a/vsts/e2e-debug-loop.yaml
+++ b/vsts/e2e-debug-loop.yaml
@@ -1,5 +1,13 @@
 resources:
 - repo: self
+
+variables:
+  # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
+  # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
+  # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
+  # URLs already stored in package-lock.json, so the lockfiles need no changes.
+  npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+
 jobs:
 - job: Phase_1
   displayName: Ubuntu 20.04

--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
+  # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
+  # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
+  # URLs already stored in package-lock.json, so the lockfiles need no changes.
+  npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
 
 resources:
   repositories:

--- a/vsts/node-nightly-df.yaml
+++ b/vsts/node-nightly-df.yaml
@@ -3,6 +3,13 @@ resources:
   - repo: self
     clean: true
 
+variables:
+  # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
+  # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
+  # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
+  # URLs already stored in package-lock.json, so the lockfiles need no changes.
+  npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+
 jobs:
 - job: Phase_2
   displayName: Ubuntu 20.04 - Node 18.x

--- a/vsts/node-nightly-linux.yaml
+++ b/vsts/node-nightly-linux.yaml
@@ -3,6 +3,13 @@ resources:
   - repo: self
     clean: true
 
+variables:
+  # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
+  # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
+  # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
+  # URLs already stored in package-lock.json, so the lockfiles need no changes.
+  npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+
 stages:
 - stage: setup
   jobs:

--- a/vsts/node-nightly-windows.yaml
+++ b/vsts/node-nightly-windows.yaml
@@ -3,6 +3,13 @@ resources:
   - repo: self
     clean: true
 
+variables:
+  # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
+  # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
+  # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
+  # URLs already stored in package-lock.json, so the lockfiles need no changes.
+  npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+
 stages:
 - stage: setup
   jobs:


### PR DESCRIPTION
## Why

Following the CISO/MSProtect rollout, **direct access to public npm registries** (`registry.npmjs.org`, `registry.yarnpkg.com`, `registry.npmmirror.com`) is being **blocked on Microsoft-managed devices and build agents**. Every `npm install` in our Azure DevOps CI and release pipelines would start failing once the block reaches the agents we use.

## What

Set an `npm_config_registry` pipeline variable pointing at the CFS-protected feed `https://packagefeedproxy.microsoft.io/npm/` in all five pipelines under `vsts/`:

- `node-nightly-linux.yaml`
- `node-nightly-windows.yaml`
- `node-nightly-df.yaml`
- `e2e-debug-loop.yaml`
- `horton-e2e.yaml`

Azure DevOps exposes the variable as the `NPM_CONFIG_REGISTRY` environment variable, and npm reads `npm_config_*` env vars case-insensitively. A single variable therefore redirects `npm install`, `npm install -g node-gyp/lerna`, `npx lerna`, and the release `npm pack` step — and it also propagates into the `horton-e2e` job that comes from the external `jobs-gate-node.yaml@e2e_fx` template, where a step can't be injected.

## Why the lockfiles are untouched

npm's `replace-registry-host` defaults to `"npmjs"`, which automatically rewrites the `registry.npmjs.org` tarball URLs already stored in each `package-lock.json` `resolved` field to the configured registry ([npm v10 docs](https://docs.npmjs.com/cli/v10/using-npm/config#replace-registry-host)). No lockfile regeneration is required.

## Why not a repo-level `.npmrc`

This is a public repository. Committing the internal feed URL as the default registry would break external contributors' `npm install` and leak internal infrastructure. The override is scoped to the pipelines only, leaving the repo's default npm behavior intact.

## Out of scope (verified)

- No `.npmrc` / `.yarnrc`, no yarn/pnpm usage, and no Dockerfile that installs packages.
- GitHub Actions (`codeql.yml`, etc.) run on GitHub-hosted runners (not Microsoft-managed) and the JS autobuild does not fetch from npm.

## Open question

Need to confirm that `packagefeedproxy.microsoft.io` is reachable **anonymously** from the hosted agent pools these pipelines use (`ubuntu-24.04`, `windows-latest`). If those pools require feed authentication, a follow-up will add an `npmAuthenticate` step / service connection.
