### PR TITLE
fix(deps): address CVE-2026-13149 by forcing brace-expansion >=5.0.7 under nx

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
 			"minimatch": "3.1.4",
 			"lodash": ">=4.18.0"
 		},
+		"nx": {
+			"brace-expansion": "^5.0.7"
+		},
 		"tmp": ">=0.2.7",
 		"form-data": ">=4.0.6",
 		"tar": ">=7.5.16"


### PR DESCRIPTION
Fixes Component Governance alert [17960102](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_componentGovernance/1940/alert/17960102?typeId=47554738).

## The finding

**CVE-2026-13149** / [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) — High (7.7).

`brace-expansion`'s `expand()` is exponential-time, `O(2^n)`, in the number of consecutive non-expanding `{}` groups. `expand_` computes `post` unconditionally at the top of the function, before the early-return branches that discard it, so each level spawns two recursive expansions over the same remaining work. A ~90 byte all-ASCII input blocks the calling thread for minutes; slightly longer hangs it indefinitely. The `max` option does not help, since it only bounds the output-building loops.

| | |
|---|---|
| Affected | `< 1.1.16`, `>= 2.0.0 < 2.1.2`, `>= 3.0.0 < 5.0.7` |
| Patched | `1.1.16`, `2.1.2`, `5.0.7` |
| Reported location | `/s/node_modules/nx/node_modules/brace-expansion` @ `5.0.6` |

## Verification of the finding

A clean install (`node_modules` and `package-lock.json` both removed, which is what CI does since the lockfile is gitignored) resolves these copies:

```
1.1.16   node_modules/brace-expansion                                <- already patched
2.1.2    node_modules/mocha/node_modules/brace-expansion             <- already patched
5.0.6    node_modules/nx/node_modules/brace-expansion                <- AFFECTED
5.0.7    node_modules/@npmcli/arborist/node_modules/brace-expansion  <- already patched
5.0.7    node_modules/@npmcli/map-workspaces/node_modules/brace-expansion
5.0.7    node_modules/@npmcli/package-json/node_modules/brace-expansion
5.0.7    node_modules/@nx/devkit/node_modules/brace-expansion
5.0.7    node_modules/@tufjs/models/node_modules/brace-expansion
5.0.7    node_modules/glob/node_modules/brace-expansion
5.0.7    node_modules/ignore-walk/node_modules/brace-expansion
```

The alert is real and `nx` is genuinely the only unpatched copy.

## The fix

Every other consumer declares a caret range, so a fresh install already lands on a patched version:

* `minimatch` 3.x declares `^1.1.7` → `1.1.16`
* `minimatch` 5.x (via `mocha` and `filelist`) declares `^2.0.1` → `2.1.2`
* the 5.x consumers declare `^5.0.2` / `^5.0.5` → `5.0.7`

`nx` is the one exception: it pins `"brace-expansion": "5.0.6"` exactly, so npm can never move it. That is exactly why the alert points at `node_modules/nx/node_modules/brace-expansion`. A single scoped override is the whole fix:

```json
"nx": {
  "brace-expansion": "^5.0.7"
}
```

### Why the override is scoped to `nx` and not applied at the top level

This matters, so recording it here. `brace-expansion` 5.x exports a **named** `expand`:

```js
// brace-expansion@5.0.7 dist/commonjs/index.js
exports.expand = expand;
```

but `minimatch` 3.x and 5.x both consume it as a **callable default**:

```js
// minimatch@3.1.4 minimatch.js:1 and minimatch@5.1.9 minimatch.js:19
const expand = require('brace-expansion')
...
return expand(pattern)
```

A flat `"brace-expansion": "^5.0.7"` override would therefore turn `expand` into a non-callable object and break mocha's test-file globbing and everything else that goes through `minimatch`. The 1.x and 2.x backports exist precisely so those consumers can be patched in place, and this change relies on them.

## Verification of the fix

Clean install after the change — every copy is now at or above a patched version:

```
1.1.16   node_modules/brace-expansion
2.1.2    node_modules/mocha/node_modules/brace-expansion
5.0.7    node_modules/nx/node_modules/brace-expansion              <- was 5.0.6
5.0.7    node_modules/@npmcli/arborist/node_modules/brace-expansion
5.0.7    node_modules/@npmcli/map-workspaces/node_modules/brace-expansion
5.0.7    node_modules/@npmcli/package-json/node_modules/brace-expansion
5.0.7    node_modules/@nx/devkit/node_modules/brace-expansion
5.0.7    node_modules/@tufjs/models/node_modules/brace-expansion
5.0.7    node_modules/glob/node_modules/brace-expansion
5.0.7    node_modules/ignore-walk/node_modules/brace-expansion
```

The advisory PoC (30 non-expanding groups, ~2 minutes on a vulnerable version) run against each of the three distinct major lines actually installed:

```
node_modules/brace-expansion                    v1.1.16   1ms  results=1
node_modules/mocha/node_modules/brace-expansion v2.1.2    0ms  results=1
node_modules/nx/node_modules/brace-expansion    v5.0.7    1ms  results=1
```

Functional checks:

* `npx lerna list` → `lerna success found 25 packages` (lerna delegates to `nx`, so this exercises the overridden copy)
* `common/core`: `npm run ci` → lint clean, `tsc` clean, **220 passing** (this exercises mocha's `minimatch` globbing)

## Notes

* `package-lock.json` is gitignored in this repo, so the root `package.json` `overrides` block is the only mechanism that can pin a transitive dependency here.
* All three patched versions are already past the 7-day hold on the CFS-protected feed and install normally.
* This does **not** close CVE-2026-14257, a separate `brace-expansion` finding whose only patched release is `5.0.8`. That is handled separately.
