### PR TITLE
fix(deps): address CVE-2026-14257 by raising the brace-expansion floor under nx to 5.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 			"lodash": ">=4.18.0"
 		},
 		"nx": {
-			"brace-expansion": "^5.0.7"
+			"brace-expansion": "^5.0.8"
 		},
 		"tmp": ">=0.2.7",
 		"form-data": ">=4.0.6",


### PR DESCRIPTION
Fixes Component Governance alerts [18264209](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_componentGovernance/1940/alert/18264209?typeId=47554738) and [18292184](https://dev.azure.com/azure-iot-sdks/f9b79625-2860-4d92-a4ee-57b03fabfd10/_componentGovernance/1940?alertId=18292184&branchMoniker=main) (work item 923).

**No longer blocked.** `brace-expansion@5.0.8` has cleared the 7-day hold on the CFS-protected feed (`npm view brace-expansion dist-tags` → `latest: 5.0.8`), so this has now been verified with a real clean install and is ready to merge.

## The finding

**CVE-2026-14257** / [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) — High (7.5).

`expand()` bounds the *number* of results it produces (the `max` option, 100,000 by default) but not their *length*. Chaining many brace groups keeps the result count under `max` while making every result grow with the number of groups, so total output scales as `max × N`. A ~7.5 KB input (`'{a,b}'.repeat(1500)`) kills a default Node process with a fatal, uncatchable OOM — `try`/`catch` does not help.

| | |
|---|---|
| Affected | `<= 5.0.7` — i.e. every version published at the time |
| Patched | `5.0.8` |

## The fix

#1258 pinned `nx`'s exact `5.0.6` pin up to `^5.0.7` to close CVE-2026-13149. This raises that same floor to `^5.0.8`:

```diff
 "nx": {
-  "brace-expansion": "^5.0.7"
+  "brace-expansion": "^5.0.8"
 }
```

`nx` is the only consumer in the tree that pins an exact version; every other 5.x consumer declares `^5.0.2` / `^5.0.5` and moves on its own.

## Verification

Clean install (`package-lock.json` removed and `node_modules` deleted), which is what CI does since the lockfile is gitignored:

```
1.1.16   node_modules/brace-expansion                                 <- 1.x line, see below
2.1.2    node_modules/mocha/node_modules/brace-expansion              <- 2.x line, see below
5.0.8    node_modules/nx/node_modules/brace-expansion                 <- this PR (was 5.0.7)
5.0.8    node_modules/@npmcli/arborist/node_modules/brace-expansion
5.0.8    node_modules/@npmcli/map-workspaces/node_modules/brace-expansion
5.0.8    node_modules/@npmcli/package-json/node_modules/brace-expansion
5.0.8    node_modules/@nx/devkit/node_modules/brace-expansion
5.0.8    node_modules/@tufjs/models/node_modules/brace-expansion
5.0.8    node_modules/glob/node_modules/brace-expansion
5.0.8    node_modules/ignore-walk/node_modules/brace-expansion
```

All ten locations named across alerts 18292184 and 18264209 are covered.

The advisory PoC, which OOM-crashes the process on any version `<= 5.0.7`, run against the upgraded `nx` copy under a deliberately constrained heap:

```
> node --max-old-space-size=512 -e "expand('{a,b}'.repeat(1500))"
v5.0.8 | survived 512MB heap: 659ms | results=2666
```

Bounded and truncated rather than unbounded — matching the ~0.7 s / no-crash behaviour described in the advisory.

Functional checks:

* `npx lerna list` → `lerna success found 25 packages` (lerna delegates to `nx`, so this exercises the overridden copy)
* `common/core`: `npm run ci` → lint clean, `tsc` clean, **220 passing**

## Heads-up: CVE-2026-69152 supersedes this

[GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) / CVE-2026-69152 was published 2026-07-30 and reviewed into the advisory database today. It is a **bypass of the `5.0.8` mitigation** — `maxLength` was enforced in `combine()` but not on the two intermediate arrays that feed it, so a ~25 KB input still OOM-crashes and a ~400 KB input stalls the event loop for over two minutes. The advisory states plainly: *"Applications already on 5.0.8 are affected."*

| | |
|---|---|
| Affected | `< 1.1.18`, `>= 2.0.0 < 2.1.4`, `>= 3.0.0 < 3.0.6`, `>= 4.0.0 < 5.0.9` |
| Patched | `1.1.18`, `2.1.4`, `3.0.6`, `5.0.9` |

**This PR is still worth merging as-is.** `5.0.9` is tagged upstream but not yet on the CFS feed (`npm view brace-expansion@5.0.9 version` → E404, published ~2026-07-30 so expected around 2026-08-06). Pinning `^5.0.9` today would break every CI install with `ETARGET`, whereas `^5.0.8`:

* is installable right now and closes CVE-2026-14257 immediately, and
* floats to `5.0.9` automatically on the next CI install once the hold lifts, closing CVE-2026-69152 with no further change here.

So the floor lands now and self-heals; no follow-up PR is needed for the `nx` path.

## The 1.x and 2.x alerts

Alerts [18300015](https://dev.azure.com/azure-iot-sdks/f9b79625-2860-4d92-a4ee-57b03fabfd10/_componentGovernance/1940?alertId=18300015&branchMoniker=main) (`/node_modules/brace-expansion` @ 1.1.16, work item 924) and [18264213](https://dev.azure.com/azure-iot-sdks/f9b79625-2860-4d92-a4ee-57b03fabfd10/_componentGovernance/1940?alertId=18264213&branchMoniker=main) (`/node_modules/mocha/node_modules/brace-expansion` @ 2.1.2, work item 922) are **out of scope here and need no code change.**

Those copies come from `minimatch` 3.x (`^1.1.7`) and `minimatch` 5.x (`^2.0.1`). Forcing 5.x onto them is not possible — 5.x exports a named `expand`, while `minimatch` 3.x/5.x call the module as a callable default, which would break mocha's globbing.

Upstream has now released the backports on both lines: `1.1.17`/`1.1.18` (PR [#129](https://github.com/juliangruber/brace-expansion/pull/129)) and `2.1.3`/`2.1.4` (PR [#130](https://github.com/juliangruber/brace-expansion/pull/130)), covering CVE-2026-14257 *and* CVE-2026-69152. Both are still inside the CFS hold. Because this repo has no committed lockfile and both consumers use caret ranges, `1.1.18` and `2.1.4` will be picked up automatically on the next CI install once they land — nothing to merge, only to re-scan.

Watch with:

```powershell
npm view brace-expansion versions --json   # wait for 1.1.18 / 2.1.4 / 5.0.9
```
