### PR TITLE
ci: run lerna via npx in the nightly ci and e2e steps

### DIFF
--- a/vsts/node-nightly-linux.yaml
+++ b/vsts/node-nightly-linux.yaml
@@ -79,13 +79,13 @@ stages:
     - script: |
         set -e
         . $(Pipeline.Workspace)/secretsEnv/activate    # Set env vars defined in setup.
-        lerna run ci
+        npx lerna run ci
       displayName: 'Unit & Integration Tests'
 
     - script: |
         set -e
         . $(Pipeline.Workspace)/secretsEnv/activate    # Set env vars defined in setup.
-        lerna run e2e
+        npx lerna run e2e
       displayName: 'E2E Tests'
 
     - task: PublishTestResults@2

--- a/vsts/node-nightly-windows.yaml
+++ b/vsts/node-nightly-windows.yaml
@@ -82,12 +82,12 @@ stages:
 
     - script: |
         call $(Pipeline.Workspace)\secretsEnv\activate.cmd
-        call lerna run ci
+        call npx lerna run ci
       displayName: 'Unit & Integration Tests'
 
     - script: |
         call $(Pipeline.Workspace)\secretsEnv\activate.cmd
-        lerna run e2e
+        call npx lerna run e2e
       displayName: 'E2E Tests'
 
     - task: PublishTestResults@2


### PR DESCRIPTION
## What failed

Nightly [`node-eastus-windows` build 161589](https://dev.azure.com/azure-iot-sdks/azure-iot-sdks/_build/results?buildId=161589&view=results) failed in stage `build_and_tests`, job `Windows Node 18.x`, step **Unit & Integration Tests** (`Cmd.exe exited with code '1'`). No tests ran at all; `E2E Tests` and everything downstream were skipped.

```
C:\npm\prefix\node_modules\lerna\node_modules\import-local\index.js:8
        const normalizedFilename = filename.startsWith('file://') ? fileURLToPath(filename) : filename;
                                            ^
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at module.exports (C:\npm\prefix\node_modules\lerna\node_modules\import-local\index.js:8:38)
    at file:///C:/npm/prefix/node_modules/lerna/dist/cli.js:7:5
Node.js v18.20.8
```

## Root cause

The step invoked bare `call lerna run ci`. On the hosted `windows-latest` image that resolves the **globally preinstalled lerna** at `C:\npm\prefix\node_modules\lerna` rather than the repo's `lerna@9.0.7`, and that global copy crashes under Node 18.

The preceding **Build** step in the same job passed, because it already uses `npx lerna run build`:

```
call npx lerna run build
lerna notice cli v9.0.7
Lerna (powered by Nx)   Successfully ran target build for 21 projects
```

The Node 18 / lerna 9 migration converted the `build` invocation to `npx` but missed `ci` and `e2e`.

## Fix

Use `npx` for the `ci` and `e2e` steps so the repo-local lerna is always the one that runs.

- `vsts/node-nightly-windows.yaml` - `call lerna run ci` -> `call npx lerna run ci`, `lerna run e2e` -> `call npx lerna run e2e`. The e2e step would have failed identically as soon as `ci` was unblocked.
- `vsts/node-nightly-linux.yaml` - same two changes. Linux is green today only because that image's global lerna happens to be 9.0.7, so the same latent breakage is present there and invisible.

Verified locally that `npx lerna --version` resolves to `9.0.7` from the root devDependency.

## Out of scope

`vsts/node-nightly-df.yaml` and `vsts/e2e-debug-loop.yaml` contain the same bare-`lerna` pattern (and `e2e-debug-loop.yaml` still calls `lerna bootstrap --hoist`, removed in lerna 9), but those pipelines need broader work to bring back to life and are intentionally left alone here.
