### PR TITLE
Own the javascript CodeQL snapshot from the nightly Linux build

### DIFF
--- a/vsts/horton-e2e.yaml
+++ b/vsts/horton-e2e.yaml
@@ -5,6 +5,11 @@ variables:
   Horton.Repo: $(Build.Repository.Uri)
   Horton.Commit: $(Build.SourceBranch)
   Horton.ForcedImage: ''
+  # This is an e2e gate, not the SDL scanning pipeline. Auto-injected CodeQL here
+  # produces incidental databases that displace the one from the nightly Linux
+  # pipeline (vsts/node-nightly-linux.yaml), because S360 records
+  # arg_max(SnapshotDate) per (repo, language). See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
   # Direct access to public npm registries (registry.npmjs.org, etc.) is blocked on
   # Microsoft-managed devices/agents. Route npm/npx through the CFS-protected feed.
   # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball

--- a/vsts/node-nightly-linux.yaml
+++ b/vsts/node-nightly-linux.yaml
@@ -9,6 +9,14 @@ variables:
   # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
   # URLs already stored in package-lock.json, so the lockfiles need no changes.
   npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+  # CodeQL is auto-injected into every job by the 1ES policy decorator. Off by
+  # default here so the resource-provisioning and cleanup jobs stop producing
+  # incidental databases -- S360 records arg_max(SnapshotDate) per
+  # (repo, language), and the 'javascript' snapshot for this repo was being
+  # attributed to the 'create_azure_resources' job. The 'Phase_2' job below opts
+  # back in after the real npm/lerna build.
+  # See https://aka.ms/codeql3000 and https://aka.ms/sdlfaqcodeql.
+  Codeql.Enabled: false
 
 stages:
 - stage: setup
@@ -54,6 +62,12 @@ stages:
   - job: Phase_2
     displayName: Ubuntu 22.04 - Node 18.x
     condition: succeededOrFailed()
+    variables:
+      # Owns the 'javascript' CodeQL snapshot for this repo
+      # (Microsoft.Security.CodeQL.10000). Overrides the pipeline-level
+      # Codeql.Enabled: false. Only on main; PR builds need no snapshot.
+      Codeql.Enabled: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+      Codeql.Language: javascript
     pool:
       vmImage: 'ubuntu-22.04'
 
@@ -66,6 +80,9 @@ stages:
       inputs:
         versionSpec: '18.x'
 
+    - task: CodeQL3000Init@0
+      displayName: 'Initialize CodeQL'
+
     - script: |
         npm install --global node-gyp
         npm install --ignore-scripts
@@ -75,6 +92,12 @@ stages:
           npx tsc --version
           npx lerna run build
       displayName: 'Build'
+
+    # Finalize before the test steps so the snapshot is not hostage to flaky
+    # integration/E2E runs; CodeQL only needs the sources and the built output.
+    - task: CodeQL3000Finalize@0
+      displayName: 'Finalize CodeQL'
+      condition: always()
 
     - script: |
         set -e

--- a/vsts/node-nightly-linux.yaml
+++ b/vsts/node-nightly-linux.yaml
@@ -82,6 +82,7 @@ stages:
 
     - task: CodeQL3000Init@0
       displayName: 'Initialize CodeQL'
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - script: |
         npm install --global node-gyp
@@ -97,7 +98,7 @@ stages:
     # integration/E2E runs; CodeQL only needs the sources and the built output.
     - task: CodeQL3000Finalize@0
       displayName: 'Finalize CodeQL'
-      condition: always()
+      condition: and(always(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
     - script: |
         set -e

--- a/vsts/node-nightly-windows.yaml
+++ b/vsts/node-nightly-windows.yaml
@@ -9,6 +9,10 @@ variables:
   # npm's default replace-registry-host=npmjs rewrites the registry.npmjs.org tarball
   # URLs already stored in package-lock.json, so the lockfiles need no changes.
   npm_config_registry: https://packagefeedproxy.microsoft.io/npm/
+  # The 'javascript' snapshot S360 recorded for this repo was coming from this
+  # pipeline's 'create_azure_resources' job, which builds nothing. The snapshot is
+  # owned by vsts/node-nightly-linux.yaml instead. See https://aka.ms/codeql3000.
+  Codeql.Enabled: false
 
 stages:
 - stage: setup


### PR DESCRIPTION
Own the javascript CodeQL snapshot from the nightly Linux build

S360 grades this repo on 'javascript' for Microsoft.Security.CodeQL.10000, and
the database it recorded was produced by the auto-injected CodeQL in the
'create_azure_resources' job of the node-eastus-windows pipeline -- a job that
provisions an IoT Hub and builds nothing. S360 records arg_max(SnapshotDate) per
(repo, language), so whichever job happens to upload last wins.

Make it deliberate instead:

- vsts/node-nightly-linux.yaml turns CodeQL off at pipeline level and the
  'Phase_2' job opts back in with Codeql.Language: javascript, running
  CodeQL3000Init before the npm install and CodeQL3000Finalize immediately after
  'npx lerna run build'. Finalizing before the test steps keeps the snapshot from
  being held hostage by flaky integration/E2E runs.
- vsts/node-nightly-windows.yaml and vsts/horton-e2e.yaml opt out; neither needs
  to produce the snapshot.

CodeQL is enabled only on main. These pipelines also run on PRs, which do not
need to produce a snapshot.

Note: .github/workflows/codeql.yml still pins github/codeql-action@v1, which is
retired. That workflow feeds GitHub code scanning, not the internal CodeQL
Central store that S360 reads, so it is out of scope here -- but it should be
updated or removed separately.
