### PR TITLE
Add TypeScript 7 support for `azure-iot-device-amqp`

### DIFF
--- a/device/transport/amqp/src/amqp_ws.ts
+++ b/device/transport/amqp/src/amqp_ws.ts
@@ -10,7 +10,7 @@ import { AuthenticationProvider, TransportConfig } from 'azure-iot-common';
  * Constructs a transport object that can be used by the device {@link azure-iot-device.Client} to send and receive messages to and from an IoT Hub instance, using the AMQP protocol over secure websockets.
  * This class overloads the constructor of the base {@link azure-iot-device-amqp.Amqp} class from the AMQP transport, and inherits all methods from it.
  *
- * @augments module:azure-iot-device-amqp.Amqp
+ * @augments Amqp
  */
 export class AmqpWs extends Amqp {
   /**


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT Node.js SDK!

# Need Support?
- **Have a feature request for SDKs?** Please post it on [User Voice](https://feedback.azure.com/forums/321918-azure-iot) to help us prioritize
- **Have a technical question?** Ask on [Stack Overflow with tag "azure-iot-hub"](https://stackoverflow.com/questions/tagged/azure-iot-hub)
- **Need Support?** Every customer with an active Azure subscription has access to [support](https://docs.microsoft.com/en-us/azure/azure-supportability/how-to-create-azure-support-request) with guaranteed response time.  Consider submitting a ticket and get assistance from Microsoft support team
- **Found a bug?** Please help us fix it by thoroughly documenting it and filing an issue on GitHub (See below).

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that.
This being said, the more you do, the quicker it'll go through our gated build!
-->

# Checklist
- [x] I have read the [contribution guidelines](https://github.com/Azure/azure-iot-sdk-node/blob/main/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
After I updated some of my projects to TypeScript7, I got the following new error message during build:

```
node_modules/azure-iot-device-amqp/dist/amqp_ws.d.ts:7:14 - error TS8023: JSDoc '@augments module' does not match the 'extends Amqp' clause.

7  * @augments module:azure-iot-device-amqp.Amqp
               ~~~~~~


Found 1 error in node_modules/azure-iot-device-amqp/dist/amqp_ws.d.ts:7
```

# Description of the solution
To be honest I am not a TypeScript developer, but this does removes the error. But I saw in `device/transport/mqtt/src/mqtt_ws.ts` that there is no `@augments ...` statement at all, so removing it from `amqp_ws.ts` can also be a solution.

It is up to you, you can decide and also edit my PR and the code as you like :)
